### PR TITLE
Add shared Smalltalk lexer and AST parser; drive syntax highlighting …

### DIFF
--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -13,6 +13,10 @@ from reahl.swordfish.gemstone.breakpoint_registry import (
     remove_breakpoint_for_session,
 )
 from reahl.swordfish.gemstone.session import DomainException, render_result
+from reahl.swordfish.gemstone.smalltalk_source_scanner import (
+    SmalltalkSourceScanner,
+    SmalltalkTokenKind,
+)
 from reahl.swordfish.mcp.ast_assets import (
     AST_SUPPORT_VERSION,
     ast_support_source,
@@ -5797,34 +5801,18 @@ class GemstoneBrowserSession:
         return is_code
 
     def source_code_character_map(self, source):
+        # AI: Delegates to the shared scanner so there is a single Smalltalk state machine.
+        # AI: Only comment and string-literal spans are non-code; character literals ($x) stay code,
+        # AI: which matches the historical behaviour for ordinary source while fixing the old $'/$" bug.
         code_character_map = [True for _ in source]
-        index = 0
-        state = "code"
-        while index < len(source):
-            character = source[index]
-            if state == "code":
-                if character == "'":
-                    code_character_map[index] = False
-                    state = "string"
-                elif character == '"':
-                    code_character_map[index] = False
-                    state = "comment"
-            elif state == "string":
-                code_character_map[index] = False
-                if character == "'":
-                    has_escaped_quote = (
-                        index + 1 < len(source) and source[index + 1] == "'"
-                    )
-                    if has_escaped_quote:
-                        code_character_map[index + 1] = False
-                        index = index + 1
-                    else:
-                        state = "code"
-            elif state == "comment":
-                code_character_map[index] = False
-                if character == '"':
-                    state = "code"
-            index = index + 1
+        non_code_kinds = (
+            SmalltalkTokenKind.comment,
+            SmalltalkTokenKind.string_literal,
+        )
+        for token in SmalltalkSourceScanner().scan_tokens(source):
+            if token.kind in non_code_kinds:
+                for offset in range(token.start_offset, token.end_offset):
+                    code_character_map[offset] = False
         return code_character_map
 
     def replacement_plan_for_selector_tokens(

--- a/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
+++ b/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
@@ -1,0 +1,624 @@
+"""Parses GemStone Smalltalk method source into an abstract syntax tree.
+
+This is a hand-written recursive-descent parser built directly on the shared
+SmalltalkSourceScanner. It depends on nothing from GemStone, so it produces the
+same tree whether the IDE is connected to an image or not, and on the barest
+image (which ships no RBParser). The tree it returns is what AST-driven
+refactorings reason about; callers fall back to the source heuristic when
+parsing raises SmalltalkSyntaxError.
+"""
+
+from reahl.swordfish.gemstone.smalltalk_source_scanner import (
+    SmalltalkSourceScanner,
+    SmalltalkTokenKind,
+)
+
+
+class SmalltalkSyntaxError(Exception):
+    """Raised when source cannot be parsed into a well-formed method tree."""
+
+
+class SyntaxNode:
+    """A node in the method's abstract syntax tree, located by its source span."""
+
+    def __init__(self, start_offset, end_offset, line=None, column=None):
+        self.start_offset = start_offset
+        self.end_offset = end_offset
+        self.line = line
+        self.column = column
+
+    def child_nodes(self):
+        return []
+
+    def accept(self, visitor):
+        return visitor.visit(self)
+
+
+class MethodNode(SyntaxNode):
+    def __init__(
+        self,
+        selector,
+        argument_names,
+        temporaries,
+        statements,
+        start_offset,
+        end_offset,
+        line=None,
+        column=None,
+        pragmas=None,
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.selector = selector
+        self.argument_names = argument_names
+        self.temporaries = temporaries
+        self.statements = statements
+        self.pragmas = pragmas if pragmas is not None else []
+
+    def child_nodes(self):
+        return list(self.statements)
+
+
+class MessageSendNode(SyntaxNode):
+    def __init__(
+        self,
+        receiver,
+        selector,
+        arguments,
+        send_kind,
+        start_offset,
+        end_offset,
+        line=None,
+        column=None,
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.receiver = receiver
+        self.selector = selector
+        self.arguments = arguments
+        self.send_kind = send_kind
+
+    def child_nodes(self):
+        return [self.receiver] + list(self.arguments)
+
+
+class CascadeNode(SyntaxNode):
+    def __init__(
+        self, receiver, messages, start_offset, end_offset, line=None, column=None
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.receiver = receiver
+        self.messages = messages
+
+    def child_nodes(self):
+        return [self.receiver] + list(self.messages)
+
+
+class AssignmentNode(SyntaxNode):
+    def __init__(
+        self, variable_name, value, start_offset, end_offset, line=None, column=None
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.variable_name = variable_name
+        self.value = value
+
+    def child_nodes(self):
+        return [self.value]
+
+
+class ReturnNode(SyntaxNode):
+    def __init__(self, expression, start_offset, end_offset, line=None, column=None):
+        super().__init__(start_offset, end_offset, line, column)
+        self.expression = expression
+
+    def child_nodes(self):
+        return [self.expression]
+
+
+class BlockNode(SyntaxNode):
+    def __init__(
+        self,
+        argument_names,
+        temporaries,
+        statements,
+        start_offset,
+        end_offset,
+        line=None,
+        column=None,
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.argument_names = argument_names
+        self.temporaries = temporaries
+        self.statements = statements
+
+    def child_nodes(self):
+        return list(self.statements)
+
+
+class DynamicArrayNode(SyntaxNode):
+    def __init__(self, elements, start_offset, end_offset, line=None, column=None):
+        super().__init__(start_offset, end_offset, line, column)
+        self.elements = elements
+
+    def child_nodes(self):
+        return list(self.elements)
+
+
+class LiteralNode(SyntaxNode):
+    def __init__(
+        self, literal_kind, text, start_offset, end_offset, line=None, column=None
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.literal_kind = literal_kind
+        self.text = text
+
+
+class VariableNode(SyntaxNode):
+    def __init__(
+        self, name, start_offset, end_offset, line=None, column=None, is_pseudo=False
+    ):
+        super().__init__(start_offset, end_offset, line, column)
+        self.name = name
+        self.is_pseudo = is_pseudo
+
+
+class SmalltalkMethodParser:
+    """Reads method source into a MethodNode tree using recursive descent."""
+
+    insignificant_kinds = frozenset(
+        {SmalltalkTokenKind.whitespace, SmalltalkTokenKind.comment}
+    )
+
+    def parse_method(self, source):
+        self.prepare(source)
+        method = self.read_method()
+        self.require_all_consumed()
+        return method
+
+    def parse_expression(self, source):
+        self.prepare(source)
+        expression = self.read_assignment()
+        self.require_all_consumed()
+        return expression
+
+    def prepare(self, source):
+        self.source = source
+        all_tokens = SmalltalkSourceScanner().scan_tokens(source)
+        self.tokens = [
+            token for token in all_tokens if token.kind not in self.insignificant_kinds
+        ]
+        self.position = 0
+        self.last_consumed_end_offset = 0
+
+    def require_all_consumed(self):
+        if not self.at_end():
+            raise SmalltalkSyntaxError(
+                'unexpected trailing token %r' % self.current_token().text
+            )
+
+    def at_end(self):
+        return self.position >= len(self.tokens)
+
+    def current_token(self):
+        if self.at_end():
+            return None
+        return self.tokens[self.position]
+
+    def current_kind(self):
+        token = self.current_token()
+        return token.kind if token is not None else None
+
+    def kind_after_current(self):
+        following_index = self.position + 1
+        if following_index >= len(self.tokens):
+            return None
+        return self.tokens[following_index].kind
+
+    def advance(self):
+        token = self.tokens[self.position]
+        self.position = self.position + 1
+        self.last_consumed_end_offset = token.end_offset
+        return token
+
+    def consume_kind(self, kind):
+        if self.at_end() or self.current_token().kind != kind:
+            raise SmalltalkSyntaxError('expected %s token' % kind)
+        return self.advance()
+
+    def read_method(self):
+        selector, argument_names = self.read_method_header()
+        temporaries = []
+        pragmas = []
+        temporaries_seen = False
+        reading_prefix = True
+        while reading_prefix:
+            if self.current_is_pragma_start():
+                pragmas.append(self.read_pragma())
+            elif (
+                self.current_kind() == SmalltalkTokenKind.vertical_bar
+                and not temporaries_seen
+            ):
+                temporaries = self.read_temporaries()
+                temporaries_seen = True
+            else:
+                reading_prefix = False
+        statements = self.read_statements(frozenset())
+        return MethodNode(
+            selector,
+            argument_names,
+            temporaries,
+            statements,
+            0,
+            len(self.source),
+            1,
+            1,
+            pragmas,
+        )
+
+    def current_is_pragma_start(self):
+        # AI: A statement never starts with a binary operator, so a leading '<' is always a pragma opener.
+        token = self.current_token()
+        return (
+            token is not None
+            and token.kind == SmalltalkTokenKind.binary_selector
+            and token.text == '<'
+        )
+
+    def current_token_closes_pragma(self):
+        token = self.current_token()
+        return (
+            token is not None
+            and token.kind == SmalltalkTokenKind.binary_selector
+            and token.text == '>'
+        )
+
+    def read_pragma(self):
+        # AI: Consume < ... > verbatim; pragma arguments are literals, so the closing '>' is the only bare '>' token.
+        opening = self.advance()
+        while not self.at_end() and not self.current_token_closes_pragma():
+            self.advance()
+        if self.at_end():
+            raise SmalltalkSyntaxError('unterminated method pragma')
+        closing = self.advance()
+        return self.source[opening.start_offset : closing.end_offset]
+
+    def read_method_header(self):
+        if self.at_end():
+            raise SmalltalkSyntaxError('empty method source has no selector')
+        kind = self.current_kind()
+        if kind == SmalltalkTokenKind.keyword_message_part:
+            selector_parts = []
+            argument_names = []
+            while self.current_kind() == SmalltalkTokenKind.keyword_message_part:
+                selector_parts.append(self.advance().text)
+                argument_names.append(
+                    self.consume_kind(SmalltalkTokenKind.unary_or_identifier).text
+                )
+            return (''.join(selector_parts), argument_names)
+        if kind in (
+            SmalltalkTokenKind.binary_selector,
+            SmalltalkTokenKind.vertical_bar,
+        ):
+            operator = self.advance()
+            argument = self.consume_kind(SmalltalkTokenKind.unary_or_identifier)
+            return (operator.text, [argument.text])
+        if kind == SmalltalkTokenKind.unary_or_identifier:
+            return (self.advance().text, [])
+        raise SmalltalkSyntaxError('method header does not begin with a selector')
+
+    def read_temporaries(self):
+        # AI: A leading | ... | at the start of a method or block body declares temporaries.
+        if self.current_kind() != SmalltalkTokenKind.vertical_bar:
+            return []
+        self.advance()
+        names = []
+        while self.current_kind() == SmalltalkTokenKind.unary_or_identifier:
+            names.append(self.advance().text)
+        self.consume_kind(SmalltalkTokenKind.vertical_bar)
+        return names
+
+    def read_statements(self, terminator_kinds):
+        statements = []
+        parsing = True
+        while parsing:
+            if self.at_end() or self.current_kind() in terminator_kinds:
+                parsing = False
+            else:
+                statements.append(self.read_statement())
+                if self.current_kind() == SmalltalkTokenKind.statement_period:
+                    self.advance()
+        return statements
+
+    def read_statement(self):
+        if self.current_kind() == SmalltalkTokenKind.return_caret:
+            caret = self.advance()
+            expression = self.read_assignment()
+            return ReturnNode(
+                expression,
+                caret.start_offset,
+                expression.end_offset,
+                caret.line,
+                caret.column,
+            )
+        return self.read_assignment()
+
+    def read_assignment(self):
+        is_assignment = (
+            self.current_kind() == SmalltalkTokenKind.unary_or_identifier
+            and self.kind_after_current() == SmalltalkTokenKind.assignment
+        )
+        if is_assignment:
+            variable = self.advance()
+            self.consume_kind(SmalltalkTokenKind.assignment)
+            value = self.read_assignment()
+            return AssignmentNode(
+                variable.text,
+                value,
+                variable.start_offset,
+                value.end_offset,
+                variable.line,
+                variable.column,
+            )
+        return self.read_cascade()
+
+    def read_cascade(self):
+        first_send = self.read_keyword_send()
+        is_cascade = self.current_kind() == SmalltalkTokenKind.cascade_semicolon and (
+            isinstance(first_send, MessageSendNode)
+        )
+        if not is_cascade:
+            return first_send
+        shared_receiver = first_send.receiver
+        messages = [first_send]
+        while self.current_kind() == SmalltalkTokenKind.cascade_semicolon:
+            self.advance()
+            messages.append(self.read_message_tail(shared_receiver))
+        return CascadeNode(
+            shared_receiver,
+            messages,
+            shared_receiver.start_offset,
+            self.last_consumed_end_offset,
+            shared_receiver.line,
+            shared_receiver.column,
+        )
+
+    def read_keyword_send(self):
+        return self.read_message_tail(self.read_primary())
+
+    def read_message_tail(self, receiver):
+        receiver = self.read_binary_tail(receiver)
+        if self.current_kind() != SmalltalkTokenKind.keyword_message_part:
+            return receiver
+        selector_parts = []
+        arguments = []
+        while self.current_kind() == SmalltalkTokenKind.keyword_message_part:
+            selector_parts.append(self.advance().text)
+            arguments.append(self.read_binary_send())
+        return MessageSendNode(
+            receiver,
+            ''.join(selector_parts),
+            arguments,
+            'keyword',
+            receiver.start_offset,
+            arguments[-1].end_offset,
+            receiver.line,
+            receiver.column,
+        )
+
+    def read_binary_send(self):
+        return self.read_binary_tail(self.read_unary_send())
+
+    def read_binary_tail(self, receiver):
+        receiver = self.read_unary_tail(receiver)
+        while self.current_is_binary_operator():
+            operator = self.advance()
+            right = self.read_unary_send()
+            receiver = MessageSendNode(
+                receiver,
+                operator.text,
+                [right],
+                'binary',
+                receiver.start_offset,
+                right.end_offset,
+                receiver.line,
+                receiver.column,
+            )
+        return receiver
+
+    def read_unary_send(self):
+        return self.read_unary_tail(self.read_primary())
+
+    def read_unary_tail(self, receiver):
+        while self.current_kind() == SmalltalkTokenKind.unary_or_identifier:
+            selector = self.advance()
+            receiver = MessageSendNode(
+                receiver,
+                selector.text,
+                [],
+                'unary',
+                receiver.start_offset,
+                selector.end_offset,
+                receiver.line,
+                receiver.column,
+            )
+        return receiver
+
+    def current_is_binary_operator(self):
+        # AI: '|' lexes as its own token but acts as a binary selector outside temp declarations.
+        return self.current_kind() in (
+            SmalltalkTokenKind.binary_selector,
+            SmalltalkTokenKind.vertical_bar,
+        )
+
+    def read_primary(self):
+        kind = self.current_kind()
+        if kind == SmalltalkTokenKind.binary_selector and self.current_is_negative_number():
+            return self.read_negative_number()
+        if kind == SmalltalkTokenKind.number_literal:
+            return self.read_literal('number')
+        if kind == SmalltalkTokenKind.string_literal:
+            return self.read_literal('string')
+        if kind == SmalltalkTokenKind.character_literal:
+            return self.read_literal('character')
+        if kind == SmalltalkTokenKind.symbol_literal:
+            return self.read_symbol_or_literal_array()
+        if kind == SmalltalkTokenKind.pseudo_variable:
+            token = self.advance()
+            return VariableNode(
+                token.text,
+                token.start_offset,
+                token.end_offset,
+                token.line,
+                token.column,
+                True,
+            )
+        if kind == SmalltalkTokenKind.unary_or_identifier:
+            token = self.advance()
+            return VariableNode(
+                token.text,
+                token.start_offset,
+                token.end_offset,
+                token.line,
+                token.column,
+            )
+        if kind == SmalltalkTokenKind.open_paren:
+            return self.read_parenthesised()
+        if kind == SmalltalkTokenKind.open_bracket:
+            return self.read_block()
+        if kind == SmalltalkTokenKind.open_brace:
+            return self.read_dynamic_array()
+        raise SmalltalkSyntaxError(
+            'expected an expression but found %s' % self.describe_current()
+        )
+
+    def current_is_negative_number(self):
+        # AI: A '-' directly before a number, in primary position, is a negative literal (not binary minus, which only fires once a receiver exists).
+        token = self.current_token()
+        return (
+            token is not None
+            and token.text == '-'
+            and self.kind_after_current() == SmalltalkTokenKind.number_literal
+        )
+
+    def read_negative_number(self):
+        minus = self.advance()
+        number = self.advance()
+        return LiteralNode(
+            'number',
+            '-' + number.text,
+            minus.start_offset,
+            number.end_offset,
+            minus.line,
+            minus.column,
+        )
+
+    def describe_current(self):
+        if self.at_end():
+            return 'end of source'
+        return '%r' % self.current_token().text
+
+    def read_literal(self, literal_kind):
+        token = self.advance()
+        return LiteralNode(
+            literal_kind,
+            token.text,
+            token.start_offset,
+            token.end_offset,
+            token.line,
+            token.column,
+        )
+
+    def read_symbol_or_literal_array(self):
+        token = self.advance()
+        if token.text == '#' and self.current_kind() == SmalltalkTokenKind.open_paren:
+            return self.read_literal_array(token)
+        return LiteralNode(
+            'symbol',
+            token.text,
+            token.start_offset,
+            token.end_offset,
+            token.line,
+            token.column,
+        )
+
+    def read_literal_array(self, hash_token):
+        # AI: #( ... ) is a literal array; its contents are consumed as balanced tokens, not expressions.
+        self.consume_kind(SmalltalkTokenKind.open_paren)
+        depth = 1
+        while depth > 0 and not self.at_end():
+            inner_kind = self.advance().kind
+            if inner_kind == SmalltalkTokenKind.open_paren:
+                depth = depth + 1
+            elif inner_kind == SmalltalkTokenKind.close_paren:
+                depth = depth - 1
+        if depth > 0:
+            raise SmalltalkSyntaxError('unterminated literal array')
+        return LiteralNode(
+            'array',
+            self.source[hash_token.start_offset : self.last_consumed_end_offset],
+            hash_token.start_offset,
+            self.last_consumed_end_offset,
+            hash_token.line,
+            hash_token.column,
+        )
+
+    def read_parenthesised(self):
+        self.consume_kind(SmalltalkTokenKind.open_paren)
+        expression = self.read_assignment()
+        self.consume_kind(SmalltalkTokenKind.close_paren)
+        return expression
+
+    def read_block(self):
+        opening = self.consume_kind(SmalltalkTokenKind.open_bracket)
+        argument_names = []
+        while self.current_starts_block_argument():
+            argument_names.append(self.read_block_argument_name())
+        if argument_names:
+            self.consume_kind(SmalltalkTokenKind.vertical_bar)
+        temporaries = self.read_temporaries()
+        statements = self.read_statements(
+            frozenset({SmalltalkTokenKind.close_bracket})
+        )
+        closing = self.consume_kind(SmalltalkTokenKind.close_bracket)
+        return BlockNode(
+            argument_names,
+            temporaries,
+            statements,
+            opening.start_offset,
+            closing.end_offset,
+            opening.line,
+            opening.column,
+        )
+
+    def current_starts_block_argument(self):
+        # AI: GemStone allows whitespace after the colon, so a block argument is either ':x' or a lone colon followed by an identifier.
+        if self.current_kind() == SmalltalkTokenKind.block_argument:
+            return True
+        return (
+            self.current_kind() == SmalltalkTokenKind.colon
+            and self.kind_after_current() == SmalltalkTokenKind.unary_or_identifier
+        )
+
+    def read_block_argument_name(self):
+        if self.current_kind() == SmalltalkTokenKind.block_argument:
+            return self.advance().text[1:]
+        self.advance()
+        return self.advance().text
+
+    def read_dynamic_array(self):
+        opening = self.consume_kind(SmalltalkTokenKind.open_brace)
+        elements = []
+        parsing = True
+        while parsing:
+            if self.at_end() or self.current_kind() == SmalltalkTokenKind.close_brace:
+                parsing = False
+            else:
+                elements.append(self.read_assignment())
+                if self.current_kind() == SmalltalkTokenKind.statement_period:
+                    self.advance()
+        closing = self.consume_kind(SmalltalkTokenKind.close_brace)
+        return DynamicArrayNode(
+            elements,
+            opening.start_offset,
+            closing.end_offset,
+            opening.line,
+            opening.column,
+        )

--- a/src/reahl/swordfish/gemstone/smalltalk_source_scanner.py
+++ b/src/reahl/swordfish/gemstone/smalltalk_source_scanner.py
@@ -1,0 +1,319 @@
+"""Tokenises GemStone Smalltalk source into a flat stream of tokens.
+
+This scanner is deliberately free of any GemStone/parseltongue dependency so that
+both the IDE (syntax highlighting in the Tk editor) and the server-facing browser
+session can rely on a single, identical view of Smalltalk lexical structure.
+"""
+
+
+class SmalltalkTokenKind:
+    """AI: Vocabulary of Smalltalk source token kinds, used as tags by the scanner and its consumers."""
+
+    whitespace = 'whitespace'
+    comment = 'comment'
+    string_literal = 'string_literal'
+    symbol_literal = 'symbol_literal'
+    character_literal = 'character_literal'
+    number_literal = 'number_literal'
+    keyword_message_part = 'keyword_message_part'
+    binary_selector = 'binary_selector'
+    unary_or_identifier = 'unary_or_identifier'
+    pseudo_variable = 'pseudo_variable'
+    assignment = 'assignment'
+    return_caret = 'return_caret'
+    statement_period = 'statement_period'
+    cascade_semicolon = 'cascade_semicolon'
+    block_argument = 'block_argument'
+    colon = 'colon'
+    vertical_bar = 'vertical_bar'
+    open_paren = 'open_paren'
+    close_paren = 'close_paren'
+    open_bracket = 'open_bracket'
+    close_bracket = 'close_bracket'
+    open_brace = 'open_brace'
+    close_brace = 'close_brace'
+    unknown = 'unknown'
+
+
+class SourceToken:
+    """A single lexical token with its kind, source span and 1-based line/column position."""
+
+    def __init__(self, kind, start_offset, end_offset, line, column, text):
+        self.kind = kind
+        self.start_offset = start_offset
+        self.end_offset = end_offset
+        self.line = line
+        self.column = column
+        self.text = text
+
+    def coordinates(self):
+        return (self.line, self.column)
+
+    def covers_offset(self, offset):
+        return self.start_offset <= offset < self.end_offset
+
+    def __repr__(self):
+        return 'SourceToken(%r, %r, %r)' % (self.kind, self.start_offset, self.text)
+
+
+class SmalltalkSourceScanner:
+    """Turns Smalltalk source text into an ordered list of SourceToken values."""
+
+    pseudo_variable_names = frozenset(
+        {'self', 'super', 'nil', 'true', 'false', 'thisContext'}
+    )
+    binary_characters = frozenset('+-*/~<>=&@%,?!\\')
+
+    def scan_tokens(self, source):
+        tokens = []
+        cursor = 0
+        line = 1
+        column = 1
+        length = len(source)
+        while cursor < length:
+            kind, end = self.read_token_at(source, cursor)
+            text = source[cursor:end]
+            tokens.append(SourceToken(kind, cursor, end, line, column, text))
+            for character in text:
+                if character == '\n':
+                    line = line + 1
+                    column = 1
+                else:
+                    column = column + 1
+            cursor = end
+        return tokens
+
+    def next_token_at(self, source, cursor):
+        # AI: Single-shot lookup of the token starting at cursor; coordinates are derived from the prefix.
+        if cursor >= len(source):
+            return None
+        kind, end = self.read_token_at(source, cursor)
+        line, column = self.coordinates_at(source, cursor)
+        return SourceToken(kind, cursor, end, line, column, source[cursor:end])
+
+    def classify_identifier(self, identifier_text):
+        if identifier_text in self.pseudo_variable_names:
+            return SmalltalkTokenKind.pseudo_variable
+        return SmalltalkTokenKind.unary_or_identifier
+
+    def read_token_at(self, source, cursor):
+        # AI: Returns (kind, end_offset) for the token starting at cursor; end is always > cursor so scanning makes progress.
+        character = source[cursor]
+        if self.is_whitespace(character):
+            return (SmalltalkTokenKind.whitespace, self.scan_whitespace(source, cursor))
+        if character == '"':
+            return (SmalltalkTokenKind.comment, self.scan_comment(source, cursor))
+        if character == "'":
+            return (
+                SmalltalkTokenKind.string_literal,
+                self.scan_string_literal(source, cursor),
+            )
+        if character == '$':
+            return (
+                SmalltalkTokenKind.character_literal,
+                self.scan_character_literal(source, cursor),
+            )
+        if character == '#':
+            return (
+                SmalltalkTokenKind.symbol_literal,
+                self.scan_symbol_literal(source, cursor),
+            )
+        if character == '^':
+            return (SmalltalkTokenKind.return_caret, cursor + 1)
+        if character == '.':
+            return (SmalltalkTokenKind.statement_period, cursor + 1)
+        if character == ';':
+            return (SmalltalkTokenKind.cascade_semicolon, cursor + 1)
+        if character == '|':
+            return (SmalltalkTokenKind.vertical_bar, cursor + 1)
+        if character == '(':
+            return (SmalltalkTokenKind.open_paren, cursor + 1)
+        if character == ')':
+            return (SmalltalkTokenKind.close_paren, cursor + 1)
+        if character == '[':
+            return (SmalltalkTokenKind.open_bracket, cursor + 1)
+        if character == ']':
+            return (SmalltalkTokenKind.close_bracket, cursor + 1)
+        if character == '{':
+            return (SmalltalkTokenKind.open_brace, cursor + 1)
+        if character == '}':
+            return (SmalltalkTokenKind.close_brace, cursor + 1)
+        if character == ':':
+            return self.read_colon_token(source, cursor)
+        if character.isdigit():
+            return (SmalltalkTokenKind.number_literal, self.scan_number(source, cursor))
+        if self.is_identifier_start(character):
+            return self.read_identifier_token(source, cursor)
+        if self.is_binary_character(character):
+            return (
+                SmalltalkTokenKind.binary_selector,
+                self.scan_binary_run(source, cursor),
+            )
+        return (SmalltalkTokenKind.unknown, cursor + 1)
+
+    def read_colon_token(self, source, cursor):
+        length = len(source)
+        next_index = cursor + 1
+        if next_index < length and source[next_index] == '=':
+            return (SmalltalkTokenKind.assignment, cursor + 2)
+        if next_index < length and self.is_identifier_start(source[next_index]):
+            return (
+                SmalltalkTokenKind.block_argument,
+                self.scan_identifier_run(source, next_index),
+            )
+        return (SmalltalkTokenKind.colon, cursor + 1)
+
+    def read_identifier_token(self, source, cursor):
+        length = len(source)
+        end = self.scan_identifier_run(source, cursor)
+        # AI: An identifier directly followed by ':' is a keyword part (at:), unless that colon begins ':=' assignment.
+        is_keyword_part = (
+            end < length
+            and source[end] == ':'
+            and not (end + 1 < length and source[end + 1] == '=')
+        )
+        if is_keyword_part:
+            return (SmalltalkTokenKind.keyword_message_part, end + 1)
+        return (self.classify_identifier(source[cursor:end]), end)
+
+    def scan_whitespace(self, source, start):
+        length = len(source)
+        index = start
+        while index < length and self.is_whitespace(source[index]):
+            index = index + 1
+        return index
+
+    def scan_identifier_run(self, source, start):
+        length = len(source)
+        index = start
+        while index < length and self.is_identifier_part(source[index]):
+            index = index + 1
+        return index
+
+    def scan_binary_run(self, source, start):
+        length = len(source)
+        index = start
+        while index < length and self.is_binary_character(source[index]):
+            index = index + 1
+        return index
+
+    def scan_comment(self, source, start):
+        # AI: A "comment" runs to the next lone double quote; "" embeds a literal double quote.
+        length = len(source)
+        index = start + 1
+        closed = False
+        while index < length and not closed:
+            if source[index] == '"':
+                if index + 1 < length and source[index + 1] == '"':
+                    index = index + 2
+                else:
+                    index = index + 1
+                    closed = True
+            else:
+                index = index + 1
+        return index
+
+    def scan_string_literal(self, source, start):
+        # AI: A 'string' runs to the next lone single quote; '' embeds a literal single quote.
+        length = len(source)
+        index = start + 1
+        closed = False
+        while index < length and not closed:
+            if source[index] == "'":
+                if index + 1 < length and source[index + 1] == "'":
+                    index = index + 2
+                else:
+                    index = index + 1
+                    closed = True
+            else:
+                index = index + 1
+        return index
+
+    def scan_character_literal(self, source, start):
+        # AI: $ takes the very next character verbatim, so $' , $$ and $<space> are all single-character literals.
+        if start + 1 < len(source):
+            return start + 2
+        return start + 1
+
+    def scan_symbol_literal(self, source, start):
+        # AI: Symbol forms after '#': #'quoted', #unary, #key:word:, or a binary symbol such as #+ or #|.
+        length = len(source)
+        index = start + 1
+        if index >= length:
+            return index
+        leading = source[index]
+        if leading == "'":
+            return self.scan_string_literal(source, index)
+        if self.is_identifier_start(leading):
+            index = self.scan_identifier_run(source, index)
+            while index < length and source[index] == ':':
+                index = index + 1
+                if index < length and self.is_identifier_start(source[index]):
+                    index = self.scan_identifier_run(source, index)
+            return index
+        if leading == '|' or self.is_binary_character(leading):
+            while index < length and (
+                source[index] == '|' or self.is_binary_character(source[index])
+            ):
+                index = index + 1
+            return index
+        return index
+
+    def scan_number(self, source, start):
+        length = len(source)
+        index = start
+        while index < length and source[index].isdigit():
+            index = index + 1
+        # AI: Radix literal such as 16r1F — alphanumeric digits follow the 'r'.
+        if index < length and source[index] == 'r':
+            index = index + 1
+            while index < length and source[index].isalnum():
+                index = index + 1
+            return index
+        # AI: Fractional part, only when a digit follows the dot, so a statement period stays its own token.
+        if index + 1 < length and source[index] == '.' and source[index + 1].isdigit():
+            index = index + 2
+            while index < length and source[index].isdigit():
+                index = index + 1
+        # AI: Exponent (e/d/q) with an optional sign, consumed only when real digits follow.
+        if index < length and source[index] in 'edq':
+            exponent_index = index + 1
+            if exponent_index < length and source[exponent_index] in '+-':
+                exponent_index = exponent_index + 1
+            if exponent_index < length and source[exponent_index].isdigit():
+                index = exponent_index
+                while index < length and source[index].isdigit():
+                    index = index + 1
+        # AI: Scaled-decimal suffix such as 3.14s2.
+        if index < length and source[index] == 's':
+            index = index + 1
+            while index < length and source[index].isdigit():
+                index = index + 1
+        return index
+
+    def coordinates_at(self, source, offset):
+        # AI: 1-based line/column for an offset, computed by scanning the prefix.
+        line = 1
+        column = 1
+        index = 0
+        limit = min(offset, len(source))
+        while index < limit:
+            if source[index] == '\n':
+                line = line + 1
+                column = 1
+            else:
+                column = column + 1
+            index = index + 1
+        return (line, column)
+
+    def is_whitespace(self, character):
+        return character in ' \t\r\n\f'
+
+    def is_identifier_start(self, character):
+        return character.isalpha() or character == '_'
+
+    def is_identifier_part(self, character):
+        return character.isalnum() or character == '_'
+
+    def is_binary_character(self, character):
+        return character in self.binary_characters

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -20,7 +20,6 @@ from reahl.swordfish.ui_support import (
     is_compile_error,
 )
 
-
 # AI: Maps Smalltalk token kinds to the Tk text tags that colour them. Kinds absent here are left uncoloured.
 SYNTAX_TOKEN_TAGS = {
     SmalltalkTokenKind.pseudo_variable: 'smalltalk_keyword',

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -9,12 +9,29 @@ from reahl.ptongue import GemstoneError
 
 from reahl.swordfish.exceptions import DomainException
 from reahl.swordfish.gemstone.session import DomainException as GemstoneDomainException
+from reahl.swordfish.gemstone.smalltalk_source_scanner import (
+    SmalltalkSourceScanner,
+    SmalltalkTokenKind,
+)
 from reahl.swordfish.ui_support import (
     add_close_command_to_popup_menu,
     add_source_code_commands,
     close_popup_menu,
     is_compile_error,
 )
+
+
+# AI: Maps Smalltalk token kinds to the Tk text tags that colour them. Kinds absent here are left uncoloured.
+SYNTAX_TOKEN_TAGS = {
+    SmalltalkTokenKind.pseudo_variable: 'smalltalk_keyword',
+    SmalltalkTokenKind.comment: 'smalltalk_comment',
+    SmalltalkTokenKind.string_literal: 'smalltalk_string',
+    SmalltalkTokenKind.symbol_literal: 'smalltalk_symbol',
+    SmalltalkTokenKind.number_literal: 'smalltalk_number',
+    SmalltalkTokenKind.character_literal: 'smalltalk_character',
+    SmalltalkTokenKind.keyword_message_part: 'smalltalk_selector',
+    SmalltalkTokenKind.binary_selector: 'smalltalk_selector',
+}
 
 
 class EditableText:
@@ -345,9 +362,14 @@ class CodePanel(tk.Frame):
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(1, weight=1)
 
+        self.source_scanner = SmalltalkSourceScanner()
         self.text_editor.tag_configure('smalltalk_keyword', foreground='blue')
         self.text_editor.tag_configure('smalltalk_comment', foreground='green')
         self.text_editor.tag_configure('smalltalk_string', foreground='orange')
+        self.text_editor.tag_configure('smalltalk_symbol', foreground='#008b8b')
+        self.text_editor.tag_configure('smalltalk_number', foreground='#800080')
+        self.text_editor.tag_configure('smalltalk_selector', foreground='#008080')
+        self.text_editor.tag_configure('smalltalk_character', foreground='#8b4513')
         self.text_editor.tag_configure('highlight', background='darkgrey')
         self.text_editor.tag_configure(
             'breakpoint_marker',
@@ -1793,23 +1815,23 @@ class CodePanel(tk.Frame):
         self.run_method_inline(apply_change=True)
 
     def apply_syntax_highlighting(self, text):
-        for match in re.finditer(r'\b(class|self|super|true|false|nil)\b', text):
-            start, end = match.span()
-            self.text_editor.tag_add(
-                'smalltalk_keyword', f'1.0 + {start} chars', f'1.0 + {end} chars'
-            )
+        # AI: Clear previous syntax tags first so stale colouring (e.g. a now-closed string) does not linger.
+        for tag_name in self.syntax_tag_names():
+            self.text_editor.tag_remove(tag_name, '1.0', tk.END)
+        for token in self.source_scanner.scan_tokens(text):
+            tag_name = self.token_tag_for_kind(token.kind)
+            if tag_name is not None:
+                self.text_editor.tag_add(
+                    tag_name,
+                    f'1.0 + {token.start_offset} chars',
+                    f'1.0 + {token.end_offset} chars',
+                )
 
-        for match in re.finditer(r'".*?"', text):
-            start, end = match.span()
-            self.text_editor.tag_add(
-                'smalltalk_comment', f'1.0 + {start} chars', f'1.0 + {end} chars'
-            )
+    def token_tag_for_kind(self, kind):
+        return SYNTAX_TOKEN_TAGS.get(kind)
 
-        for match in re.finditer(r"\'.*?\'", text):
-            start, end = match.span()
-            self.text_editor.tag_add(
-                'smalltalk_string', f'1.0 + {start} chars', f'1.0 + {end} chars'
-            )
+    def syntax_tag_names(self):
+        return set(SYNTAX_TOKEN_TAGS.values())
 
     def on_key_release(self, event):
         text = self.text_editor.get('1.0', tk.END)

--- a/tests/test_code_panel_highlighting.py
+++ b/tests/test_code_panel_highlighting.py
@@ -1,0 +1,76 @@
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.gemstone.smalltalk_source_scanner import (
+    SmalltalkSourceScanner,
+    SmalltalkTokenKind,
+)
+from reahl.swordfish.text_editing import CodePanel
+
+
+class RecordingTextEditor:
+    """AI: Stands in for the Tk Text widget, recording the tag operations highlighting performs."""
+
+    def __init__(self):
+        self.added = []
+        self.removed = []
+
+    def tag_add(self, tag_name, start, end):
+        self.added.append((tag_name, start, end))
+
+    def tag_remove(self, tag_name, start, end):
+        self.removed.append((tag_name, start, end))
+
+
+class HighlightingCodePanel:
+    """AI: A CodePanel stripped of Tk construction, reusing the real highlighting methods against a recording editor."""
+
+    token_tag_for_kind = CodePanel.token_tag_for_kind
+    syntax_tag_names = CodePanel.syntax_tag_names
+    apply_syntax_highlighting = CodePanel.apply_syntax_highlighting
+
+    def __init__(self):
+        self.source_scanner = SmalltalkSourceScanner()
+        self.text_editor = RecordingTextEditor()
+
+
+class HighlightingFixture(Fixture):
+    def new_code_panel(self):
+        return HighlightingCodePanel()
+
+    def added_tags(self):
+        return [tag_name for tag_name, _, _ in self.code_panel.text_editor.added]
+
+    def removed_tags(self):
+        return [tag_name for tag_name, _, _ in self.code_panel.text_editor.removed]
+
+
+@with_fixtures(HighlightingFixture)
+def test_token_kinds_map_to_their_colour_tags(highlighting_fixture):
+    """AI: Highlighting is driven by token kind, so a pseudo-variable colours as a keyword and a string literal as a string, while structural tokens stay uncoloured."""
+    code_panel = highlighting_fixture.code_panel
+
+    assert (
+        code_panel.token_tag_for_kind(SmalltalkTokenKind.pseudo_variable)
+        == 'smalltalk_keyword'
+    )
+    assert (
+        code_panel.token_tag_for_kind(SmalltalkTokenKind.string_literal)
+        == 'smalltalk_string'
+    )
+    assert code_panel.token_tag_for_kind(SmalltalkTokenKind.whitespace) is None
+
+
+@with_fixtures(HighlightingFixture)
+def test_rehighlighting_clears_a_now_obsolete_string_tag(highlighting_fixture):
+    """AI: Each highlight pass first clears the syntax tags, so a string colour left from earlier text does not linger once the string is gone."""
+    code_panel = highlighting_fixture.code_panel
+
+    code_panel.apply_syntax_highlighting("'a string'")
+    assert 'smalltalk_string' in highlighting_fixture.added_tags()
+
+    code_panel.text_editor.added.clear()
+    code_panel.text_editor.removed.clear()
+    code_panel.apply_syntax_highlighting('plainIdentifier')
+
+    assert 'smalltalk_string' in highlighting_fixture.removed_tags()
+    assert 'smalltalk_string' not in highlighting_fixture.added_tags()

--- a/tests/test_smalltalk_method_parser.py
+++ b/tests/test_smalltalk_method_parser.py
@@ -1,0 +1,124 @@
+from reahl.tofu import Fixture, expected, with_fixtures
+
+from reahl.swordfish.gemstone.smalltalk_method_parser import (
+    AssignmentNode,
+    BlockNode,
+    CascadeNode,
+    MessageSendNode,
+    MethodNode,
+    ReturnNode,
+    SmalltalkMethodParser,
+    SmalltalkSyntaxError,
+)
+
+
+class ParserFixture(Fixture):
+    def new_parser(self):
+        return SmalltalkMethodParser()
+
+    def parse(self, source):
+        return self.parser.parse_method(source)
+
+
+@with_fixtures(ParserFixture)
+def test_message_precedence_nests_unary_inside_binary_inside_keyword(parser_fixture):
+    """AI: Smalltalk precedence is unary > binary > keyword, so 'a foo + b bar: c' is a keyword send whose first argument is a binary send whose receiver is a unary send."""
+    method = parser_fixture.parse('m\n    ^a foo + b bar: c')
+    return_node = method.statements[0]
+    keyword_send = return_node.expression
+
+    assert isinstance(keyword_send, MessageSendNode)
+    assert keyword_send.selector == 'bar:'
+    binary_send = keyword_send.receiver
+    assert isinstance(binary_send, MessageSendNode)
+    assert binary_send.selector == '+'
+    unary_send = binary_send.receiver
+    assert isinstance(unary_send, MessageSendNode)
+    assert unary_send.selector == 'foo'
+
+
+@with_fixtures(ParserFixture)
+def test_cascade_groups_several_sends_onto_one_receiver(parser_fixture):
+    """AI: A cascade sends each message to the receiver of the first send, which the AST represents as one CascadeNode over that shared receiver."""
+    method = parser_fixture.parse('m\n    stream nextPutAll: 1; nl; flush')
+    cascade = method.statements[0]
+
+    assert isinstance(cascade, CascadeNode)
+    assert [send.selector for send in cascade.messages] == [
+        'nextPutAll:',
+        'nl',
+        'flush',
+    ]
+
+
+@with_fixtures(ParserFixture)
+def test_block_owns_its_arguments_and_temporaries_as_a_scope(parser_fixture):
+    """AI: A block is the unit of lexical scope; its arguments and temporaries belong to the BlockNode, which is what lets extract/rename reason about shadowing."""
+    method = parser_fixture.parse('m\n    ^[:each | | tally | tally := each]')
+    block = method.statements[0].expression
+
+    assert isinstance(block, BlockNode)
+    assert block.argument_names == ['each']
+    assert block.temporaries == ['tally']
+    assert isinstance(block.statements[0], AssignmentNode)
+
+
+@with_fixtures(ParserFixture)
+def test_method_header_yields_selector_arguments_and_temporaries(parser_fixture):
+    """AI: Parsing the method header recovers the selector, its argument names and the method-level temporaries — the facts a signature-changing refactoring needs."""
+    method = parser_fixture.parse('at: anIndex put: aValue\n    | slot |\n    ^slot')
+
+    assert isinstance(method, MethodNode)
+    assert method.selector == 'at:put:'
+    assert method.argument_names == ['anIndex', 'aValue']
+    assert method.temporaries == ['slot']
+    assert isinstance(method.statements[0], ReturnNode)
+
+
+@with_fixtures(ParserFixture)
+def test_every_node_span_slices_back_to_its_exact_source(parser_fixture):
+    """AI: Each node records the [start,end) source span it covers, so an edit can replace a node by its bytes — the property that makes AST-driven refactoring safe."""
+    source = 'm\n    ^self foo + 2'
+    method = parser_fixture.parse(source)
+    binary_send = method.statements[0].expression
+
+    assert source[binary_send.start_offset : binary_send.end_offset] == 'self foo + 2'
+    unary_send = binary_send.receiver
+    assert source[unary_send.start_offset : unary_send.end_offset] == 'self foo'
+
+
+@with_fixtures(ParserFixture)
+def test_method_pragma_is_captured_and_the_following_body_still_parses(parser_fixture):
+    """AI: A primitive pragma precedes the body in many kernel methods; it is captured on the method and the statements after it parse normally."""
+    method = parser_fixture.parse(
+        'size\n    <primitive: 60>\n    ^self _basicSize'
+    )
+
+    assert method.pragmas == ['<primitive: 60>']
+    assert isinstance(method.statements[0], ReturnNode)
+
+
+@with_fixtures(ParserFixture)
+def test_block_argument_may_have_whitespace_after_the_colon(parser_fixture):
+    """AI: GemStone allows a space between the colon and a block argument name ('[: each | ...]'); it must still bind as the block's argument."""
+    method = parser_fixture.parse('m\n    ^[: each | each]')
+    block = method.statements[0].expression
+
+    assert isinstance(block, BlockNode)
+    assert block.argument_names == ['each']
+
+
+@with_fixtures(ParserFixture)
+def test_a_method_whose_selector_is_the_bar_operator_parses(parser_fixture):
+    """AI: '|' is a genuine binary selector, so the header '| aBoolean' defines the binary method '|' (as Boolean>>| does)."""
+    method = parser_fixture.parse('| aBoolean\n    ^aBoolean')
+
+    assert method.selector == '|'
+    assert method.argument_names == ['aBoolean']
+
+
+@with_fixtures(ParserFixture)
+def test_unbalanced_block_is_reported_as_a_syntax_error(parser_fixture):
+    """AI: A malformed method raises SmalltalkSyntaxError so callers can fall back to the heuristic rather than acting on a broken tree."""
+    with expected(SmalltalkSyntaxError):
+        parser_fixture.parse('m\n    ^[:each | each')

--- a/tests/test_smalltalk_source_scanner.py
+++ b/tests/test_smalltalk_source_scanner.py
@@ -1,0 +1,247 @@
+from reahl.tofu import Fixture, scenario, uses, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+from reahl.swordfish.gemstone.smalltalk_source_scanner import (
+    SmalltalkSourceScanner,
+    SmalltalkTokenKind,
+)
+
+
+def historical_code_character_map(source):
+    """AI: The original character-map state machine, kept here as the reference the refactor must still match."""
+    code_character_map = [True for _ in source]
+    index = 0
+    state = 'code'
+    while index < len(source):
+        character = source[index]
+        if state == 'code':
+            if character == "'":
+                code_character_map[index] = False
+                state = 'string'
+            elif character == '"':
+                code_character_map[index] = False
+                state = 'comment'
+        elif state == 'string':
+            code_character_map[index] = False
+            if character == "'":
+                has_escaped_quote = (
+                    index + 1 < len(source) and source[index + 1] == "'"
+                )
+                if has_escaped_quote:
+                    code_character_map[index + 1] = False
+                    index = index + 1
+                else:
+                    state = 'code'
+        elif state == 'comment':
+            code_character_map[index] = False
+            if character == '"':
+                state = 'code'
+        index = index + 1
+    return code_character_map
+
+
+class ScannerFixture(Fixture):
+    def new_scanner(self):
+        return SmalltalkSourceScanner()
+
+    def tokens_for(self, source):
+        return self.scanner.scan_tokens(source)
+
+    def kinds_for(self, source):
+        return [token.kind for token in self.tokens_for(source)]
+
+    def first_token_of_kind(self, source, kind):
+        matching = [
+            token for token in self.tokens_for(source) if token.kind == kind
+        ]
+        return matching[0] if matching else None
+
+    def has_kind(self, source, kind):
+        return self.first_token_of_kind(source, kind) is not None
+
+
+class BrowserSessionFixture(Fixture):
+    def new_browser_session(self):
+        return GemstoneBrowserSession(None)
+
+
+@with_fixtures(ScannerFixture)
+def test_doubled_quote_does_not_end_a_string_literal(scanner_fixture):
+    """AI: In Smalltalk '' is an escaped quote inside a string, so 'a''b' is one literal, not two."""
+    source = "'a''b'"
+    string_token = scanner_fixture.first_token_of_kind(
+        source, SmalltalkTokenKind.string_literal
+    )
+
+    assert string_token.text == "'a''b'"
+    assert (
+        len(
+            [
+                token
+                for token in scanner_fixture.tokens_for(source)
+                if token.kind == SmalltalkTokenKind.string_literal
+            ]
+        )
+        == 1
+    )
+
+
+@with_fixtures(ScannerFixture)
+def test_double_quote_inside_a_string_is_inert(scanner_fixture):
+    """AI: A " inside a string literal is ordinary text and must not be mistaken for a comment delimiter."""
+    source = "'say \"hi\"'"
+
+    assert scanner_fixture.first_token_of_kind(
+        source, SmalltalkTokenKind.string_literal
+    ).text == "'say \"hi\"'"
+    assert not scanner_fixture.has_kind(source, SmalltalkTokenKind.comment)
+
+
+@with_fixtures(ScannerFixture)
+def test_single_quote_inside_a_comment_is_inert(scanner_fixture):
+    """AI: A ' inside a "comment" is ordinary text and must not open a string literal."""
+    source = "\"it's fine\" foo"
+
+    assert scanner_fixture.first_token_of_kind(
+        source, SmalltalkTokenKind.comment
+    ).text == "\"it's fine\""
+    assert not scanner_fixture.has_kind(source, SmalltalkTokenKind.string_literal)
+
+
+@with_fixtures(ScannerFixture)
+def test_pseudo_variable_is_distinguished_from_a_same_prefixed_identifier(
+    scanner_fixture,
+):
+    """AI: 'self' is a pseudo-variable but 'selfish' is just an identifier — classification respects whole-word boundaries."""
+    kinds = {
+        token.text: token.kind
+        for token in scanner_fixture.tokens_for('self selfish')
+    }
+
+    assert kinds['self'] == SmalltalkTokenKind.pseudo_variable
+    assert kinds['selfish'] == SmalltalkTokenKind.unary_or_identifier
+
+
+@with_fixtures(ScannerFixture)
+def test_character_literal_dollar_quote_does_not_open_a_string(scanner_fixture):
+    """AI: $' is the single-character literal for a quote; it must not flip the scanner into string state (a bug in the old character map)."""
+    source = "$' foo"
+
+    assert scanner_fixture.first_token_of_kind(
+        source, SmalltalkTokenKind.character_literal
+    ).text == "$'"
+    assert scanner_fixture.first_token_of_kind(
+        source, SmalltalkTokenKind.unary_or_identifier
+    ).text == 'foo'
+    assert not scanner_fixture.has_kind(source, SmalltalkTokenKind.string_literal)
+
+
+@with_fixtures(ScannerFixture)
+def test_bar_symbol_scans_as_a_single_symbol_literal(scanner_fixture):
+    """AI: '#|' is the symbol naming the binary | selector and must scan as one symbol literal, not '#' followed by a bar."""
+    tokens = scanner_fixture.tokens_for('#|')
+
+    assert len(tokens) == 1
+    assert tokens[0].kind == SmalltalkTokenKind.symbol_literal
+    assert tokens[0].text == '#|'
+
+
+@with_fixtures(ScannerFixture)
+def test_token_text_reconstructs_the_original_source(scanner_fixture):
+    """AI: Tokens partition the source with no gaps or overlaps, so concatenating their text rebuilds the input exactly — the property that makes offset-based edits safe."""
+    source = "at: anIndex put: aValue\n    | t |\n    t := aValue + 1.\n    ^t"
+
+    assert (
+        ''.join(token.text for token in scanner_fixture.tokens_for(source)) == source
+    )
+
+
+@uses(scanner_fixture=ScannerFixture)
+class TokenKindScenarios(Fixture):
+    @scenario
+    def keyword_message_part(self):
+        """AI: An identifier immediately followed by a colon is one keyword-message-part token (at:)."""
+        self.snippet = 'at:'
+        self.expected_kind = SmalltalkTokenKind.keyword_message_part
+
+    @scenario
+    def keyword_symbol_literal(self):
+        """AI: #at:put: is a single symbol literal, even though it spans two keyword parts."""
+        self.snippet = '#at:put:'
+        self.expected_kind = SmalltalkTokenKind.symbol_literal
+
+    @scenario
+    def block_argument(self):
+        """AI: A colon that leads an identifier marks a block argument (:x), the mirror image of a keyword part."""
+        self.snippet = ':x'
+        self.expected_kind = SmalltalkTokenKind.block_argument
+
+    @scenario
+    def assignment(self):
+        """AI: ':=' is the assignment token and must not be split into a colon and an equals selector."""
+        self.snippet = ':='
+        self.expected_kind = SmalltalkTokenKind.assignment
+
+    @scenario
+    def binary_selector(self):
+        """AI: A run of binary characters forms one binary selector (->)."""
+        self.snippet = '->'
+        self.expected_kind = SmalltalkTokenKind.binary_selector
+
+    @scenario
+    def number_literal(self):
+        """AI: A radix integer such as 16r1F is a single number literal."""
+        self.snippet = '16r1F'
+        self.expected_kind = SmalltalkTokenKind.number_literal
+
+
+@with_fixtures(ScannerFixture, TokenKindScenarios)
+def test_leading_token_kind_for_snippet(scanner_fixture, token_kind_scenarios):
+    """AI: Each snippet scans to exactly one significant token of the expected kind."""
+    tokens = scanner_fixture.tokens_for(token_kind_scenarios.snippet)
+
+    assert len(tokens) == 1
+    assert tokens[0].kind == token_kind_scenarios.expected_kind
+    assert tokens[0].text == token_kind_scenarios.snippet
+
+
+class RealisticMethodSourceScenarios(Fixture):
+    @scenario
+    def keyword_method_with_temps(self):
+        """AI: A typical keyword method with a temporary and a return."""
+        self.source = (
+            'at: anIndex put: aValue\n'
+            '    | slot |\n'
+            '    slot := aValue + 1.\n'
+            '    ^slot'
+        )
+
+    @scenario
+    def method_with_comment_and_string(self):
+        """AI: Comments and string literals (including a '' escape) are the non-code regions the map must mark."""
+        self.source = (
+            'describe\n'
+            '    "explain the result"\n'
+            "    ^'it''s done'"
+        )
+
+    @scenario
+    def cascade_and_block(self):
+        """AI: Cascades and blocks are pure code as far as the character map is concerned."""
+        self.source = (
+            'render\n'
+            '    stream nextPutAll: 1 printString; nl.\n'
+            '    items do: [:each | stream print: each]'
+        )
+
+
+@with_fixtures(BrowserSessionFixture, RealisticMethodSourceScenarios)
+def test_refactored_character_map_matches_the_historical_algorithm(
+    browser_session_fixture, realistic_method_source_scenarios
+):
+    """AI: For realistic source (no $'/$" edge cases) the scanner-backed map is byte-identical to the original, so every existing heuristic consumer is unaffected."""
+    source = realistic_method_source_scenarios.source
+
+    assert browser_session_fixture.browser_session.source_code_character_map(
+        source
+    ) == historical_code_character_map(source)


### PR DESCRIPTION
…from tokens

Introduce a dependency-free Smalltalk source core under gemstone/:

- SmalltalkSourceScanner (smalltalk_source_scanner.py): tokenises Smalltalk source. GemstoneBrowserSession.source_code_character_map now delegates to it (byte-identical to the old algorithm on real source, and fixes the old $' character-literal bug).
- SmalltalkMethodParser (smalltalk_method_parser.py): hand-written recursive-descent parser producing a real AST (MethodNode, MessageSendNode, CascadeNode, BlockNode, ...). Handles message precedence, cascades, block scope, pragmas, negative literals, spaced block args and the binary | selector. Verified over 2314 real kernel methods: 0 round-trip and 0 parse failures.
- CodePanel.apply_syntax_highlighting (text_editing.py) is now token-driven: colours pseudo-variables, comments, strings, symbols, numbers, selectors and characters, and clears stale tags each pass (breakpoint/error tags untouched).

