### PR TITLE
CI: actually run the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,17 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  GEMSTONE_VERSION: "3.7.4.3"
+
 jobs:
-  test:
+  checks:
+    name: Lint, import and wheel
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install build and lint tools
         run: |
           python -m pip install --upgrade pip
           pip install isort build
@@ -42,5 +46,45 @@ jobs:
       - name: Build wheel
         run: python -m build --wheel
 
-      - name: List built artifacts
-        run: ls -la dist/
+  gemstone:
+    name: Full test suite against a real GemStone stone
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # AI: tkinter is bound to the system python, and the GUI tests need it, so we use
+      # AI: /usr/bin/python3 (+ python3-tk) here rather than an actions/setup-python interpreter.
+      - name: Install system dependencies (Tk, Xvfb, unzip)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-venv python3-tk xvfb unzip wget gawk
+
+      # AI: GemStone may not be redistributed, so it is downloaded fresh from GemTalk on every
+      # AI: run into ephemeral RUNNER_TEMP and never cached or kept as an artifact. We reuse the
+      # AI: same install scripts the Docker image uses, run natively on the runner.
+      - name: Install GemStone (downloaded fresh; not cached or redistributed)
+        run: |
+          set -euxo pipefail
+          WORK="$RUNNER_TEMP/gs"
+          mkdir -p "$WORK/gemstone"
+          for script in answersForInstallgs.sh defineGemStoneEnvironment.sh gemShell.sh installGemStone.sh; do
+            curl -fsSL "https://raw.githubusercontent.com/reahl/parseltongue/master/gemstone/$script" \
+              -o "$WORK/gemstone/$script"
+          done
+          chmod +x "$WORK/gemstone/"*.sh
+          # AI: installGemStone.sh needs root for /opt/gemstone, /etc/services and /etc/environment.
+          # AI: With CI set it resolves the installer answers from $(pwd)/gemstone, so we cd into $WORK.
+          sudo env DEV_HOME="$WORK" DEV_USER="$(whoami)" CI=true \
+            bash -c "cd '$WORK' && ./gemstone/installGemStone.sh '${GEMSTONE_VERSION}'"
+
+      - name: Run the full test suite (including live GemStone tests)
+        run: |
+          set -euxo pipefail
+          WORK="$RUNNER_TEMP/gs"
+          python3 -m venv "$WORK/venv"
+          source "$WORK/venv/bin/activate"
+          pip install --upgrade pip
+          pip install -e '.[test]'
+          source "$WORK/gemstone/gemShell.sh" "${GEMSTONE_VERSION}"
+          pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Run the full test suite (including live GemStone tests)
         run: |
-          set -euxo pipefail
+          # AI: No 'set -u' here: GemStone's gemsetup.sh references unset vars (MANPATH, VERSION),
+          # AI: which is fatal under nounset. -e/-x/pipefail still catch real failures.
+          set -exo pipefail
           WORK="$RUNNER_TEMP/gs"
           python3 -m venv "$WORK/venv"
           source "$WORK/venv/bin/activate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ version = {attr = "reahl.swordfish.__version__"}
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+markers = [
+    "gemstone: test requires a running GemStone stone (excluded from CI)",
+]
 
 [tool.black]
 line-length = 88

--- a/tests/test_mcp_live_gemstone.py
+++ b/tests/test_mcp_live_gemstone.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 import uuid
 
+import pytest
+
 from reahl.ptongue import GemstoneError
 from reahl.ptongue.gemstonecontrol import Stone
 from reahl.tofu import (
@@ -31,6 +33,9 @@ from reahl.swordfish.mcp.session_registry import (
     has_connection,
 )
 from reahl.swordfish.mcp.tools import register_tools
+
+# AI: This whole module drives a real GemStone stone, so CI (which has none) deselects it via 'not gemstone'.
+pytestmark = pytest.mark.gemstone
 
 
 class McpToolRegistrar:

--- a/tests/test_mcp_live_gemstone.py
+++ b/tests/test_mcp_live_gemstone.py
@@ -75,13 +75,15 @@ class RunningStoneFixture(Fixture):
                 Stone().stop()
 
     def is_stone_running(self):
+        # AI: gslist exits non-zero (printing "No GemStone servers.") when nothing is running,
+        # AI: which is the very case this predicate must report as False so the stone gets started.
+        # AI: So we read its stdout listing rather than asserting on the exit code.
         command_result = subprocess.run(
             ["bash", "-lc", "gslist"],
             capture_output=True,
             text=True,
             check=False,
         )
-        assert command_result.returncode == 0, command_result.stderr
         return "Stone       gs64stone" in command_result.stdout
 
 


### PR DESCRIPTION
Previously CI only checked import sorting and built a wheel; the pytest suite never ran. Now:

- 'checks' job (py3.11/3.12): isort, package import, entry point, wheel build.
- 'gemstone' job: installs GemStone natively on the runner using the same install scripts as the dev image (downloaded fresh from GemTalk each run into RUNNER_TEMP, never cached/redistributed), then runs the FULL suite including the live tests, which start/stop their own stone.

Also mark the live module with the 'gemstone' pytest marker (registered in pyproject) so a stone-less subset can be run locally via -m 'not gemstone'.