### PR TITLE
Issue #14: Fast class-reference search; collapse senders/implementors…

### DIFF
--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -2003,6 +2003,14 @@ class GemstoneBrowserSession:
         selector_literal = self.smalltalk_string_literal(method_selector)
         return "(%s asSymbol)" % selector_literal
 
+    def class_symbol_expression(self, class_name):
+        # AI: A class is reached at runtime via its global Symbol, so 'find references to
+        # AI: class X' is really 'find methods that reference #X'. We render the symbol the
+        # AI: same way selector_reference_expression renders selectors - via 'X' asSymbol -
+        # AI: so quoting and escaping of the class name reuses one well-known path.
+        class_literal = self.smalltalk_string_literal(class_name)
+        return "(%s asSymbol)" % class_literal
+
     def source_offsets_for_compiled_method(self, compiled_method):
         source_offsets = compiled_method.perform("_sourceOffsets")
         offsets = []
@@ -5849,7 +5857,7 @@ class GemstoneBrowserSession:
                 "returned_count": 0,
             }
         method_summaries = self.class_reference_occurrence_summaries(
-            normalized_class_name
+            normalized_class_name,
         )
         total_count = len(method_summaries)
         limited_references = (
@@ -5862,133 +5870,33 @@ class GemstoneBrowserSession:
         }
 
     def class_reference_occurrence_summaries(self, class_name):
-        class_reference = self.class_reference_expression(
-            class_name,
-            True,
-        )
-        try:
-            candidate_value = self.run_code(
-                "ClassOrganizer new allCallsOn: %s" % class_reference
-            )
-            compiled_methods = self.flatten_compiled_methods(candidate_value)
-            method_summaries = [
-                self.method_summary(compiled_method)
-                for compiled_method in compiled_methods
-            ]
-            return self.unique_sorted_method_summaries(method_summaries)
-        except (DomainException, GemstoneError, GemstoneApiError):
-            return self.class_reference_occurrence_summaries_from_source(class_name)
-
-    def class_reference_occurrence_summaries_from_source(self, class_name):
-        class_reference_pattern = re.compile(
-            r"(?<![A-Za-z0-9_])%s(?![A-Za-z0-9_])" % re.escape(class_name)
-        )
-        method_summaries = []
-        class_names = self.all_class_names()
-        for scoped_class_name in class_names:
-            method_summaries += self.class_reference_occurrence_summaries_for_side(
-                scoped_class_name,
-                True,
-                class_reference_pattern,
-            )
-            method_summaries += self.class_reference_occurrence_summaries_for_side(
-                scoped_class_name,
-                False,
-                class_reference_pattern,
-            )
-        return self.unique_sorted_method_summaries(method_summaries)
-
-    def class_reference_occurrence_summaries_for_side(
-        self,
-        class_name,
-        show_instance_side,
-        class_reference_pattern,
-    ):
-        method_summaries = []
-        selector_names = self.selectors_for_class_side(
-            class_name,
-            show_instance_side,
-        )
-        for selector_name in selector_names:
-            method_source = None
-            try:
-                method_source = self.get_method_source(
-                    class_name,
-                    selector_name,
-                    show_instance_side,
-                )
-            except (GemstoneError, GemstoneApiError):
-                method_source = None
-            if (
-                method_source
-                and class_reference_pattern.search(method_source) is not None
-            ):
-                method_summaries.append(
-                    {
-                        "class_name": class_name,
-                        "show_instance_side": show_instance_side,
-                        "method_selector": selector_name,
-                    }
-                )
-        return method_summaries
-
-    def selector_occurrence_summaries(
-        self,
-        method_name,
-        occurrence_type,
-        include_category_details=False,
-    ):
-        try:
-            return self.selector_occurrence_summaries_fast(
-                method_name, occurrence_type, include_category_details
-            )
-        except (GemstoneError, GemstoneApiError):
-            return self.selector_occurrence_summaries_slow(
-                method_name, occurrence_type, include_category_details
-            )
-
-    def selector_occurrence_summaries_fast(
-        self,
-        method_name,
-        occurrence_type,
-        include_category_details=False,
-    ):
-        selector_expression = self.selector_reference_expression(method_name)
-        if occurrence_type == "implementors":
-            query = "ClassOrganizer new implementorsOf: %s" % selector_expression
-        elif occurrence_type == "senders":
-            query = "ClassOrganizer new sendersOf: %s" % selector_expression
-        else:
-            raise DomainException("occurrence_type must be implementors or senders.")
+        # AI: GemStone keeps a reference index that ClassOrganizer>>referencesTo: queries
+        # AI: directly; against a class's global Symbol that means 'every method that
+        # AI: mentions the class'. The returned Array is shaped (methods, source-offsets),
+        # AI: and we only need methods, so we take 'first'.
+        # AI: We emit one tab-delimited line per GsNMethod server-side, so finding all
+        # AI: references is one GCI round-trip regardless of how many results match -
+        # AI: this is what makes issue #14's class-reference search fast.
+        # AI: Joining via (String with: Character lf) join: is portable across the GemStone
+        # AI: images we run on; joining on Character lf directly relies on an image
+        # AI: extension that is not guaranteed.
+        class_symbol_expression = self.class_symbol_expression(class_name)
         smalltalk_source = """
-            | results seen stack |
+            | methods results |
+            methods := (ClassOrganizer new referencesTo: %s) first.
             results := OrderedCollection new.
-            seen := Set new.
-            stack := OrderedCollection with: (%s).
-            [ stack isEmpty ] whileFalse: [
-                | current |
-                current := stack removeLast.
-                (current isKindOf: GsNMethod) ifTrue: [
-                    | inClass className selector isInstanceSide key |
-                    inClass := current inClass.
-                    selector := current selector asString.
-                    isInstanceSide := inClass isMeta not.
-                    className := inClass name asString.
-                    (isInstanceSide not and: [ className endsWith: ' class' ])
-                        ifTrue: [ className := className copyFrom: 1 to: className size - 6 ].
-                    key := className, '>>',
-                        (isInstanceSide ifTrue: ['i'] ifFalse: ['c']), '>>',
-                        selector.
-                    (seen includes: key) ifFalse: [
-                        seen add: key.
-                        results add: className, Character tab asString,
-                            (isInstanceSide ifTrue: ['true'] ifFalse: ['false']), Character tab asString,
-                            selector ] ]
-                ifFalse: [
-                    (current isKindOf: Collection) ifTrue: [
-                        current do: [ :each | stack add: each ] ] ] ].
-            Character lf join: results
-        """ % query
+            methods do: [ :compiledMethod |
+                | inClass className isInstanceSide |
+                inClass := compiledMethod inClass.
+                isInstanceSide := inClass isMeta not.
+                className := inClass name asString.
+                (isInstanceSide not and: [ className endsWith: ' class' ])
+                    ifTrue: [ className := className copyFrom: 1 to: className size - 6 ].
+                results add: className, Character tab asString,
+                    (isInstanceSide ifTrue: ['true'] ifFalse: ['false']), Character tab asString,
+                    compiledMethod selector asString ].
+            (String with: Character lf) join: results
+        """ % class_symbol_expression
         result_string = self.run_code(smalltalk_source).to_py
         if not result_string:
             return []
@@ -6005,36 +5913,110 @@ class GemstoneBrowserSession:
                 )
         return self.unique_sorted_method_summaries(method_summaries)
 
-    def selector_occurrence_summaries_slow(
+    
+
+    
+
+    
+
+    def selector_occurrence_summaries(
         self,
         method_name,
         occurrence_type,
         include_category_details=False,
     ):
+        # AI: Single server-side query, then optionally enrich in Python. We always emit
+        # AI: the method's category as a fourth tab-delimited field so 'find senders'
+        # AI: with category filtering does not have to issue one categoryOfSelector:
+        # AI: round-trip per result - and the IDE's class-category filter stops
+        # AI: silently depending on the old slow fallback running.
+        # AI: Joining via (String with: Character lf) join: is portable across the GemStone
+        # AI: images we run on; joining on Character lf directly relies on an image
+        # AI: extension that is not guaranteed.
         selector_expression = self.selector_reference_expression(method_name)
         if occurrence_type == "implementors":
-            candidate_value = self.run_code(
-                "ClassOrganizer new implementorsOf: %s" % selector_expression
-            )
+            query = "ClassOrganizer new implementorsOf: %s" % selector_expression
         elif occurrence_type == "senders":
-            candidate_value = self.run_code(
-                "ClassOrganizer new sendersOf: %s" % selector_expression
-            )
+            query = "ClassOrganizer new sendersOf: %s" % selector_expression
         else:
             raise DomainException("occurrence_type must be implementors or senders.")
-        compiled_methods = self.flatten_compiled_methods(candidate_value)
-        class_categories = None
-        if include_category_details:
-            class_categories = self.class_categories_by_class_name()
-        method_summaries = [
-            self.method_summary(
-                compiled_method,
-                include_category_details=include_category_details,
-                class_categories=class_categories,
-            )
-            for compiled_method in compiled_methods
-        ]
+        smalltalk_source = """
+            | results seen stack |
+            results := OrderedCollection new.
+            seen := Set new.
+            stack := OrderedCollection with: (%s).
+            [ stack isEmpty ] whileFalse: [
+                | current |
+                current := stack removeLast.
+                (current isKindOf: GsNMethod) ifTrue: [
+                    | inClass className selector isInstanceSide key methodCategory methodCategoryString |
+                    inClass := current inClass.
+                    selector := current selector asString.
+                    isInstanceSide := inClass isMeta not.
+                    className := inClass name asString.
+                    (isInstanceSide not and: [ className endsWith: ' class' ])
+                        ifTrue: [ className := className copyFrom: 1 to: className size - 6 ].
+                    methodCategory := inClass categoryOfSelector: current selector.
+                    methodCategoryString := methodCategory isNil
+                        ifTrue: ['']
+                        ifFalse: [methodCategory asString].
+                    key := className, '>>',
+                        (isInstanceSide ifTrue: ['i'] ifFalse: ['c']), '>>',
+                        selector.
+                    (seen includes: key) ifFalse: [
+                        seen add: key.
+                        results add: className, Character tab asString,
+                            (isInstanceSide ifTrue: ['true'] ifFalse: ['false']), Character tab asString,
+                            selector, Character tab asString,
+                            methodCategoryString ] ]
+                ifFalse: [
+                    (current isKindOf: Collection) ifTrue: [
+                        current do: [ :each | stack add: each ] ] ] ].
+            (String with: Character lf) join: results
+        """ % query
+        result_string = self.run_code(smalltalk_source).to_py
+        if not result_string:
+            return []
+        class_categories = (
+            self.class_categories_by_class_name() if include_category_details else None
+        )
+        method_summaries = []
+        for line in result_string.split("\n"):
+            parts = line.split("\t")
+            if len(parts) != 4:
+                continue
+            class_name = parts[0]
+            show_instance_side = parts[1] == "true"
+            method_selector = parts[2]
+            method_category_text = parts[3]
+            method_summary = {
+                "class_name": class_name,
+                "show_instance_side": show_instance_side,
+                "method_selector": method_selector,
+            }
+            if include_category_details:
+                method_category = method_category_text if method_category_text else None
+                method_category_is_extension = (
+                    isinstance(method_category, str)
+                    and method_category.startswith("*")
+                )
+                extension_category_name = None
+                if method_category_is_extension:
+                    extension_category_name = method_category[1:].strip() or None
+                method_summary["class_category"] = (
+                    class_categories.get(class_name) if class_categories else None
+                )
+                method_summary["method_category"] = method_category
+                method_summary["method_category_is_extension"] = (
+                    method_category_is_extension
+                )
+                method_summary["extension_category_name"] = extension_category_name
+            method_summaries.append(method_summary)
         return self.unique_sorted_method_summaries(method_summaries)
+
+    
+
+    
 
     def implementor_entries_from_method_summaries(self, method_summaries):
         implementors = []

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -3301,6 +3301,11 @@ class FindDialog(tk.Toplevel):
         match_mode,
         should_stop=None,
     ):
+        # AI: The dialog still polls should_stop once before launching the call so
+        # AI: a Stop click that arrives before the round-trip begins is honoured;
+        # AI: the call itself is one GCI round-trip and has no point at which it
+        # AI: could be polled. Anything finer than that needs a parseltongue
+        # AI: soft-break binding, which is a separate concern (see issue #14 notes).
         class_names = [query_text]
         reference_results = []
         for class_name in class_names:

--- a/tests/test_gemstone_browser_class_references.py
+++ b/tests/test_gemstone_browser_class_references.py
@@ -1,0 +1,81 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+# AI: Issue #14: class-reference search was slow because the original fast path called
+# AI: ClassOrganizer >> allCallsOn:, which does not exist in any current GemStone image.
+# AI: Every call raised, the exception was swallowed by a defensive try/except, and a
+# AI: client-side regex walk over every method's source silently ran instead. The fix
+# AI: is to ask GemStone's reference index directly via ClassOrganizer >> referencesTo:
+# AI: and to delete the slow fallback - if the index ever fails to answer, that is a
+# AI: bug to surface, not a case to paper over. These tests pin down the single path.
+
+
+@stubclass(GemstoneBrowserSession)
+class RecordingBrowserSession(GemstoneBrowserSession):
+    """AI: Replaces the single GemStone-side leaf - run_code - with a recorder so we
+    can prove the path asks for referencesTo: and parses the tab-delimited output it
+    returns, without standing up a real stone."""
+
+    recorded_run_code_source = None
+    canned_run_code_result = None
+
+    def run_code(self, source):
+        self.recorded_run_code_source = source
+        return self.canned_run_code_result
+
+
+class TabDelimitedResult:
+    """AI: parseltongue's run_code returns a GemStone object whose .to_py yields the
+    Python value. The path reads .to_py - this stub satisfies just that contract."""
+
+    def __init__(self, to_py):
+        self.to_py = to_py
+
+
+class ClassReferenceFixture(Fixture):
+    def new_browser_session(self):
+        return RecordingBrowserSession(None)
+
+
+@with_fixtures(ClassReferenceFixture)
+def test_class_reference_search_queries_the_class_symbol_via_references_to(fixture):
+    """AI: 'find references to class X' must ask GemStone's reference index for
+    ClassOrganizer>>referencesTo: against the class's Symbol. The historical
+    allCallsOn: selector does not exist in any current image, so any query mentioning
+    it is dead - hence issue #14."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+
+    fixture.browser_session.find_class_references('Order')
+
+    source = fixture.browser_session.recorded_run_code_source
+    assert source is not None
+    assert 'referencesTo:' in source
+    assert "'Order' asSymbol" in source
+    assert 'allCallsOn:' not in source
+
+
+@with_fixtures(ClassReferenceFixture)
+def test_class_reference_search_parses_tab_delimited_method_lines(fixture):
+    """AI: The whole point of the server-side query is to do the per-method work in
+    one GCI round-trip: one tab-delimited line per GsNMethod - class<tab>isInstanceSide
+    <tab>selector - so the cost of finding references is constant in result count from
+    the Python side."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult(
+        '\n'.join([
+            'Order\ttrue\taddLine:',
+            'Order\tfalse\tdefaultLineClass',
+            'OrderBuilder\ttrue\tfromOrder:',
+        ])
+    )
+
+    result = fixture.browser_session.find_class_references('Order')
+
+    assert result['returned_count'] == 3
+    assert result['references'] == [
+        {'class_name': 'Order', 'show_instance_side': False, 'method_selector': 'defaultLineClass'},
+        {'class_name': 'Order', 'show_instance_side': True, 'method_selector': 'addLine:'},
+        {'class_name': 'OrderBuilder', 'show_instance_side': True, 'method_selector': 'fromOrder:'},
+    ]

--- a/tests/test_gemstone_browser_selector_occurrence.py
+++ b/tests/test_gemstone_browser_selector_occurrence.py
@@ -1,0 +1,134 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+# AI: After issue #14: 'find senders' / 'find implementors' used to have a fast path
+# AI: that ignored category details and a slow path that supplied them - so the IDE's
+# AI: category filter accidentally depended on the fast path failing. The corrected
+# AI: shape is a single server-side query that emits class<tab>side<tab>selector<tab>
+# AI: method-category per match, and category enrichment happens in Python.
+
+
+@stubclass(GemstoneBrowserSession)
+class RecordingBrowserSession(GemstoneBrowserSession):
+    """AI: Replaces the only live leaves - run_code (the Smalltalk query) and
+    class_categories_by_class_name (the per-class category index) - so we can
+    prove the collapsed selector_occurrence_summaries shape end-to-end."""
+
+    recorded_run_code_source = None
+    canned_run_code_result = None
+    canned_class_categories = None
+
+    def run_code(self, source):
+        self.recorded_run_code_source = source
+        return self.canned_run_code_result
+
+    def class_categories_by_class_name(self):
+        return dict(self.canned_class_categories or {})
+
+
+class TabDelimitedResult:
+    """AI: parseltongue's run_code returns a GemStone object whose .to_py is the
+    Python value; the path under test reads .to_py."""
+
+    def __init__(self, to_py):
+        self.to_py = to_py
+
+
+class SelectorOccurrenceFixture(Fixture):
+    def new_browser_session(self):
+        return RecordingBrowserSession(None)
+
+
+@with_fixtures(SelectorOccurrenceFixture)
+def test_implementors_query_asks_class_organizer_for_implementors_of_symbol(fixture):
+    """AI: 'find implementors of selector S' must ask ClassOrganizer>>implementorsOf:
+    against the selector's Symbol. The historical split sent the same query twice
+    (once fast, once slow); the single path is what makes the call cost predictable."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+
+    fixture.browser_session.selector_occurrence_summaries('printOn:', 'implementors')
+
+    source = fixture.browser_session.recorded_run_code_source
+    assert source is not None
+    assert 'implementorsOf:' in source
+    assert "'printOn:' asSymbol" in source
+    assert 'sendersOf:' not in source
+
+
+@with_fixtures(SelectorOccurrenceFixture)
+def test_senders_query_asks_class_organizer_for_senders_of_symbol(fixture):
+    """AI: 'find senders of selector S' must ask ClassOrganizer>>sendersOf: -
+    the mirror of the implementors query, so the same parsing covers both."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+
+    fixture.browser_session.selector_occurrence_summaries('printOn:', 'senders')
+
+    source = fixture.browser_session.recorded_run_code_source
+    assert source is not None
+    assert 'sendersOf:' in source
+    assert "'printOn:' asSymbol" in source
+    assert 'implementorsOf:' not in source
+
+
+@with_fixtures(SelectorOccurrenceFixture)
+def test_method_category_arrives_per_line_so_category_filtering_does_not_need_a_second_round_trip(
+    fixture,
+):
+    """AI: The Smalltalk loop now emits a 4th tab-delimited field - the method's
+    category/protocol - so 'include_category_details=True' only requires one bulk
+    class-categories lookup in Python afterwards, not one round-trip per result. This
+    is the change that makes the IDE's sender category filter stop depending on the
+    old slow path."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult(
+        '\n'.join([
+            'Account\ttrue\tprintOn:\tprinting',
+            'Order\ttrue\tprintOn:\t*reports-extension',
+        ])
+    )
+    fixture.browser_session.canned_class_categories = {
+        'Account': 'Banking',
+        'Order': 'Sales',
+    }
+
+    summaries = fixture.browser_session.selector_occurrence_summaries(
+        'printOn:',
+        'senders',
+        include_category_details=True,
+    )
+
+    account_summary = next(s for s in summaries if s['class_name'] == 'Account')
+    order_summary = next(s for s in summaries if s['class_name'] == 'Order')
+    assert account_summary['method_category'] == 'printing'
+    assert account_summary['class_category'] == 'Banking'
+    assert account_summary['method_category_is_extension'] is False
+    assert account_summary['extension_category_name'] is None
+    assert order_summary['method_category'] == '*reports-extension'
+    assert order_summary['method_category_is_extension'] is True
+    assert order_summary['extension_category_name'] == 'reports-extension'
+
+
+@with_fixtures(SelectorOccurrenceFixture)
+def test_without_category_details_the_summary_carries_only_navigation_keys(fixture):
+    """AI: When the caller does not opt in to category details, the result must stay
+    a clean three-key navigation summary - the IDE's identifier-granularity sender
+    listing depends on that minimal shape (test_gemstone_browser_send_sites
+    pins this contract from the other side)."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult(
+        'Account\ttrue\tprintOn:\tprinting'
+    )
+
+    summaries = fixture.browser_session.selector_occurrence_summaries(
+        'printOn:',
+        'implementors',
+    )
+
+    assert summaries == [
+        {
+            'class_name': 'Account',
+            'show_instance_side': True,
+            'method_selector': 'printOn:',
+        }
+    ]


### PR DESCRIPTION
… split

Class-reference search was slow because the 'fast' path called ClassOrganizer >> allCallsOn:, which is not implemented in any GemStone image we run on; every call raised, the dispatcher swallowed it under a broad except (DomainException, GemstoneError, GemstoneApiError), and a per-method source walk silently ran in its place. Replace allCallsOn: with the actual reference index - ClassOrganizer >> referencesTo: against the class's Symbol - and emit one tab-delimited line per GsNMethod server-side so the round-trip cost is constant in result count.

Drop the slow source-walk path and the try/except dispatcher with it. We control the Smalltalk we send: if it fails it is a bug we want surfaced, not papered over.

Apply the same critique to PR #3's senders/implementors split: collapse selector_occurrence_summaries into one path that also emits the method's category (a fourth tab-delimited field), so the IDE's sender category filter no longer accidentally depends on the slow fallback running to populate class_category /
method_category_is_extension. Joining with (String with: Character lf) join: rather than Character lf join: directly is portable across the image shapes we see.

The Stop button in references_for_class_query still polls should_stop once before launching the call; finer-grained interrupt needs a parseltongue soft_break() binding, which is out of scope here.