### PR TITLE
Made long searches interruptible and optimised; improved senders interface for MCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 keywords = ["smalltalk", "gemstone", "ide", "development"]
 dependencies = [
-    "reahl-parseltongue",
+    "reahl-parseltongue>=3.1.0",
     "mcp[cli]>=1.0,<2; python_version >= '3.10'",
 ]
 requires-python = ">=3.6"

--- a/src/reahl/swordfish/__init__.py
+++ b/src/reahl/swordfish/__init__.py
@@ -5,4 +5,4 @@ This package provides a Python-based IDE that offers a classic Smalltalk develop
 experience for GemStone/Smalltalk systems.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -100,6 +100,14 @@ class CoveringTestsDiscoveryWorkflow:
     def request_cancel(self):
         self.search_state['cancel_requested'] = True
         self.should_stop.set()
+        try:
+            self.gemstone_session_record.hard_break()
+        except GemstoneError:
+            # AI: should_stop above already covers the safe points between calls; a
+            # hard_break that cannot be delivered (or that finds the gem idle) must not
+            # crash the UI thread that asked to stop, so we let the cooperative flag
+            # stand on its own.
+            pass
 
     def request_use_results(self):
         self.search_state['use_results_requested_for_attempt'] = True
@@ -271,6 +279,9 @@ class CoveringTestsBrowseDialog(tk.Toplevel):
         )
         self.close_button.grid(row=0, column=3)
         self.protocol('WM_DELETE_WINDOW', self.close_dialog)
+        self.bind('<Command-period>', self.interrupt_search_shortcut)
+        self.bind('<Alt-period>', self.interrupt_search_shortcut)
+        self.bind('<Control-period>', self.interrupt_search_shortcut)
 
         self.run_search_attempt()
         self.after(50, self.monitor_search)
@@ -533,6 +544,13 @@ class CoveringTestsBrowseDialog(tk.Toplevel):
             self.stop_search_requested = True
         if not self.is_searching:
             self.destroy()
+
+    def interrupt_search_shortcut(self, event):
+        """AI: Pharo-style Cmd/Alt/Ctrl + . interrupts the running search from the
+        keyboard, mirroring the Stop button so a search parked inside a long GemStone
+        call can be abandoned without reaching for the mouse."""
+        self.request_stop_search()
+        return 'break'
 
     def request_search_further(self):
         if not self.is_searching and self.is_timed_out:

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -6496,7 +6496,10 @@ class GemstoneBrowserSession:
             and (max_results is None or consumed < max_results)
         ):
             detail = self.sender_with_call_detail(
-                method_summaries[index], method_name, granularity
+                method_summaries[index],
+                method_name,
+                granularity,
+                classify=real_sends_only,
             )
             if real_sends_only and detail.get('kind') == 'reference_only':
                 reference_only_omitted = reference_only_omitted + 1
@@ -6630,9 +6633,22 @@ class GemstoneBrowserSession:
             "remaining_count": sum(count for value, count in remaining_entries),
         }
 
-    def sender_with_call_detail(self, sender, method_name, granularity):
+    def sender_with_call_detail(self, sender, method_name, granularity, classify=False):
         if granularity == 'identifier':
-            return sender
+            if not classify:
+                return sender
+            # AI: identifier granularity normally fetches no source, but real_sends_only
+            # needs each entry's kind to filter on, so classify here - staying lean by
+            # carrying only the kind, not the send_sites.
+            source = self.get_method_source(
+                sender["class_name"],
+                sender["method_selector"],
+                sender["show_instance_side"],
+            )
+            return {
+                **sender,
+                'kind': self.classified_occurrences(source, method_name)['kind'],
+            }
         source = self.get_method_source(
             sender["class_name"],
             sender["method_selector"],

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -6427,24 +6427,148 @@ class GemstoneBrowserSession:
         count_only=False,
         include_category_details=False,
         granularity='identifier',
+        class_categories=None,
+        method_categories=None,
+        class_name_pattern=None,
+        side=None,
+        offset=0,
     ):
+        needs_categories = (
+            include_category_details
+            or class_categories is not None
+            or method_categories is not None
+        )
         method_summaries = self.selector_occurrence_summaries(
             method_name,
             "senders",
-            include_category_details=include_category_details,
+            include_category_details=needs_categories,
+        )
+        method_summaries = self.filtered_method_summaries(
+            method_summaries,
+            class_categories=class_categories,
+            method_categories=method_categories,
+            class_name_pattern=class_name_pattern,
+            side=side,
         )
         total_count = len(method_summaries)
-        limited_senders = (
-            [] if count_only else self.limited_entries(method_summaries, max_results)
+        page_summaries = (
+            [] if count_only else self.paged_entries(method_summaries, offset, max_results)
         )
         detailed_senders = [
             self.sender_with_call_detail(sender, method_name, granularity)
-            for sender in limited_senders
+            for sender in page_summaries
         ]
         return {
             "senders": detailed_senders,
             "total_count": total_count,
             "returned_count": len(detailed_senders),
+            "offset": offset,
+        }
+
+    def paged_entries(self, entries, offset, max_results):
+        start = offset or 0
+        if max_results is None:
+            return entries[start:]
+        return entries[start : start + max_results]
+
+    def filtered_method_summaries(
+        self,
+        method_summaries,
+        class_categories=None,
+        method_categories=None,
+        class_name_pattern=None,
+        side=None,
+    ):
+        """AI: Narrow candidate summaries by facet before counting and slicing, so a
+        selector with thousands of senders can be reduced to the class categories, method
+        categories, class-name pattern, or instance/class side the caller cares about.
+        Filtering on the cheap summaries (no source) keeps it fast even on hot selectors."""
+        compiled_pattern = None
+        if class_name_pattern is not None:
+            try:
+                compiled_pattern = re.compile(class_name_pattern, re.IGNORECASE)
+            except re.error as error:
+                raise DomainException("Invalid class_name_pattern: %s" % error)
+
+        def summary_is_kept(summary):
+            # AI: An empty (or None) filter means 'no constraint' - the MCP layer's
+            # validator turns an omitted list into [], so testing truthiness here (not
+            # 'is not None') is what stops an absent filter from matching nothing and
+            # silently dropping every candidate.
+            kept = True
+            if class_categories:
+                kept = kept and summary.get("class_category") in class_categories
+            if method_categories:
+                kept = kept and summary.get("method_category") in method_categories
+            if compiled_pattern is not None:
+                kept = kept and bool(compiled_pattern.search(summary["class_name"]))
+            if side:
+                kept = kept and summary["show_instance_side"] == (side == "instance")
+            return kept
+
+        return [
+            summary for summary in method_summaries if summary_is_kept(summary)
+        ]
+
+    def senders_count(self, method_name):
+        """AI: The cheapest tier - just how many senders there are and the instance/class
+        split, a few integers. The total is the symbol-reference count: an exact, cheap
+        upper bound on real sends, not a precise true-send count (that needs the AST
+        pass). senders_overview adds the grouped breakdown on top of this."""
+        method_summaries = self.selector_occurrence_summaries(
+            method_name, "senders", include_category_details=True
+        )
+        return self.occurrence_count(method_summaries)
+
+    def senders_overview(self, method_name, top=10):
+        """AI: The breakdown tier - the count plus tallies grouped by class category,
+        instance/class side and method category, and per class - computed from the same
+        single occurrence query, no method source fetched. Each grouping is bounded to
+        the top-N most frequent values with a remaining tail, so even a selector with
+        hundreds of classes returns a small, ranked summary the model can narrow from."""
+        method_summaries = self.selector_occurrence_summaries(
+            method_name, "senders", include_category_details=True
+        )
+        return self.occurrence_overview(method_summaries, top=top)
+
+    def occurrence_count(self, method_summaries):
+        instance_side_count = sum(
+            1 for summary in method_summaries if summary["show_instance_side"]
+        )
+        return {
+            "total": len(method_summaries),
+            "by_side": {
+                "instance": instance_side_count,
+                "class": len(method_summaries) - instance_side_count,
+            },
+        }
+
+    def occurrence_overview(self, method_summaries, top=10):
+        overview = self.occurrence_count(method_summaries)
+        overview["by_class_category"] = self.tally_by(
+            method_summaries, "class_category", top
+        )
+        overview["by_method_category"] = self.tally_by(
+            method_summaries, "method_category", top
+        )
+        overview["classes"] = self.tally_by(method_summaries, "class_name", top)
+        return overview
+
+    def tally_by(self, method_summaries, facet, top):
+        counts = {}
+        for summary in method_summaries:
+            value = summary.get(facet)
+            counts[value] = counts.get(value, 0) + 1
+        ranked = sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0] if item[0] is not None else ""),
+        )
+        top_entries = ranked[:top]
+        remaining_entries = ranked[top:]
+        return {
+            "top": [{facet: value, "count": count} for value, count in top_entries],
+            "remaining_values": len(remaining_entries),
+            "remaining_count": sum(count for value, count in remaining_entries),
         }
 
     def sender_with_call_detail(self, sender, method_name, granularity):

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -6356,6 +6356,27 @@ class GemstoneBrowserSession:
                 class_matches.append(class_name)
         return class_matches
 
+    def existing_class_named(self, class_name):
+        """AI: The exact-match counterpart of find_classes. An exact name needs no scan
+        over every class in the image - it is one symbol resolve (an O(1) dictionary
+        lookup), the same primitive Browse Class uses. resolve_symbol does not raise for
+        an undefined name: it answers a phantom object on the illegal OOP, and for a
+        defined non-class global it answers that global - so a bare truthiness check
+        would report both as matches and then fail to open them ('object does not
+        exist'). We therefore confirm the resolved object is really a class (a Behavior)
+        before claiming a match, keeping find_classes' contract of yielding only
+        navigable class names. This stays O(1) - a resolve plus one send."""
+        gemstone_class = self.resolved_class(class_name)
+        if gemstone_class is None:
+            return []
+        try:
+            resolved_is_class = gemstone_class.perform('isBehavior').to_py
+        except (GemstoneError, GemstoneApiError):
+            return []
+        if resolved_is_class:
+            return [class_name]
+        return []
+
     def find_selectors(self, search_input, should_stop=None):
         selector_matches = set()
         class_names = self.all_class_names()

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import time
@@ -31,6 +32,19 @@ from reahl.swordfish.mcp.tracer_assets import (
     tracer_source,
     tracer_source_hash,
 )
+
+# AI: Selectors that send their first argument as a message - a #selector literal handed
+# to one of these is a real (dynamic) send, not mere data, so it must be classified as a
+# reflective send rather than dropped as a symbol reference.
+PERFORM_FAMILY_SELECTORS = frozenset({
+    'perform:',
+    'perform:with:',
+    'perform:with:with:',
+    'perform:with:with:with:',
+    'perform:with:with:with:with:',
+    'perform:withArguments:',
+    'perform:withArguments:environment:',
+})
 
 
 class GemstoneBrowserSession:
@@ -6432,6 +6446,8 @@ class GemstoneBrowserSession:
         class_name_pattern=None,
         side=None,
         offset=0,
+        real_sends_only=False,
+        max_response_chars=None,
     ):
         needs_categories = (
             include_category_details
@@ -6451,25 +6467,68 @@ class GemstoneBrowserSession:
             side=side,
         )
         total_count = len(method_summaries)
-        page_summaries = (
-            [] if count_only else self.paged_entries(method_summaries, offset, max_results)
-        )
-        detailed_senders = [
-            self.sender_with_call_detail(sender, method_name, granularity)
-            for sender in page_summaries
-        ]
+        if count_only:
+            return {
+                "senders": [],
+                "total_count": total_count,
+                "returned_count": 0,
+                "reference_only_omitted": 0,
+                "offset": offset,
+                "next_offset": None,
+                "truncated": False,
+                "budget_reached": False,
+            }
+        # AI: One pass over candidates from offset, consuming each (so paging resumes
+        # correctly) until max_results entries are shown or the next shown entry would
+        # exceed the response budget. real_sends_only drops reference_only candidates from
+        # the shown list but still consumes them, and they cost nothing against the budget
+        # since they are not returned. At least one entry is always kept so a single huge
+        # entry is paged rather than producing an empty page.
+        senders = []
+        reference_only_omitted = 0
+        consumed = 0
+        used_chars = 0
+        budget_reached = False
+        index = offset
+        while (
+            index < total_count
+            and not budget_reached
+            and (max_results is None or consumed < max_results)
+        ):
+            detail = self.sender_with_call_detail(
+                method_summaries[index], method_name, granularity
+            )
+            if real_sends_only and detail.get('kind') == 'reference_only':
+                reference_only_omitted = reference_only_omitted + 1
+                consumed = consumed + 1
+                index = index + 1
+            else:
+                entry_chars = (
+                    len(json.dumps(detail)) if max_response_chars is not None else 0
+                )
+                if (
+                    senders
+                    and max_response_chars is not None
+                    and used_chars + entry_chars > max_response_chars
+                ):
+                    budget_reached = True
+                else:
+                    senders.append(detail)
+                    used_chars = used_chars + entry_chars
+                    consumed = consumed + 1
+                    index = index + 1
+        next_offset = offset + consumed
+        more_remaining = next_offset < total_count
         return {
-            "senders": detailed_senders,
+            "senders": senders,
             "total_count": total_count,
-            "returned_count": len(detailed_senders),
+            "returned_count": len(senders),
+            "reference_only_omitted": reference_only_omitted,
             "offset": offset,
+            "next_offset": next_offset if more_remaining else None,
+            "truncated": more_remaining,
+            "budget_reached": budget_reached,
         }
-
-    def paged_entries(self, entries, offset, max_results):
-        start = offset or 0
-        if max_results is None:
-            return entries[start:]
-        return entries[start : start + max_results]
 
     def filtered_method_summaries(
         self,
@@ -6579,27 +6638,77 @@ class GemstoneBrowserSession:
             sender["method_selector"],
             sender["show_instance_side"],
         )
+        classification = self.classified_occurrences(source, method_name)
         if granularity == 'method':
-            return {**sender, 'method_source': source}
-        return {**sender, **self.send_sites_in_source(source, method_name)}
+            return {**sender, 'method_source': source, 'kind': classification['kind']}
+        return {**sender, **classification}
 
-    def send_sites_in_source(self, source, method_name):
+    def classified_occurrences(self, source, method_name):
+        # AI: Distinguish a real send of the selector from a #selector literal that merely
+        # references it - senders come from the symbol-reference index, which cannot tell
+        # them apart, but the parsed method can. A literal handed to perform: (etc.) is
+        # still a real (dynamic) send, so it is kept as reflective_send, not dropped; a
+        # literal used anywhere else is reference_only but is surfaced with its source
+        # slice, so a custom dispatcher or an indirect 'sel := #x. obj perform: sel' is
+        # flagged for the reader rather than silently hidden.
         try:
             method_node = SmalltalkMethodParser().parse_method(source)
         except SmalltalkSyntaxError:
-            return {'send_sites_unavailable': 'parse_error', 'method_source': source}
-        indexed_nodes = index_nodes_by_path(method_node)
-        send_sites = [
-            {
-                'node_path': path,
-                'start': node.start_offset,
-                'end': node.end_offset,
-                'source': source[node.start_offset : node.end_offset],
+            return {
+                'kind': 'unparseable',
+                'send_sites': [],
+                'send_sites_unavailable': 'parse_error',
+                'method_source': source,
             }
-            for path, node in indexed_nodes.items()
-            if node.node_kind == 'message_send' and node.selector == method_name
-        ]
-        return {'send_sites': send_sites}
+        indexed_nodes = index_nodes_by_path(method_node)
+        reflective_sites = []
+        performed_literal_node_ids = set()
+        for path, node in indexed_nodes.items():
+            if (
+                node.node_kind == 'message_send'
+                and node.selector in PERFORM_FAMILY_SELECTORS
+                and node.arguments
+                and self.is_symbol_literal_for(node.arguments[0], method_name)
+            ):
+                reflective_sites.append(self.occurrence_slice(source, path, node))
+                performed_literal_node_ids.add(id(node.arguments[0]))
+        send_sites = []
+        reference_sites = []
+        for path, node in indexed_nodes.items():
+            if node.node_kind == 'message_send' and node.selector == method_name:
+                send_sites.append(self.occurrence_slice(source, path, node))
+            elif (
+                self.is_symbol_literal_for(node, method_name)
+                and id(node) not in performed_literal_node_ids
+            ):
+                reference_sites.append(self.occurrence_slice(source, path, node))
+        if send_sites:
+            kind = 'direct_send'
+        elif reflective_sites:
+            kind = 'reflective_send'
+        else:
+            kind = 'reference_only'
+        classification = {'kind': kind, 'send_sites': send_sites}
+        non_send_occurrences = reflective_sites + reference_sites
+        if kind != 'direct_send' and non_send_occurrences:
+            classification['reference_sites'] = non_send_occurrences
+        return classification
+
+    def is_symbol_literal_for(self, node, method_name):
+        if node.node_kind != 'literal' or node.literal_kind != 'symbol':
+            return False
+        symbol_text = node.text[1:] if node.text.startswith('#') else node.text
+        if symbol_text.startswith("'") and symbol_text.endswith("'"):
+            symbol_text = symbol_text[1:-1]
+        return symbol_text == method_name
+
+    def occurrence_slice(self, source, node_path, node):
+        return {
+            'node_path': node_path,
+            'start': node.start_offset,
+            'end': node.end_offset,
+            'source': source[node.start_offset : node.end_offset],
+        }
 
     def find_class_references(
         self,

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -44,6 +44,14 @@ class GemstoneBrowserSession:
         # MCP tools and IDE can surface drift warnings without changing edit return contracts.
         self.last_sync_outcome = None
 
+    def hard_break(self):
+        """AI: Force the session to abandon whatever GemStone code it is currently
+        running. Issue #2 in parseltongue exposes this so a Stop request on one thread
+        can interrupt a call blocked on another; we forward it so the IDE can abandon a
+        search that is parked inside a single long-running call (such as a referencesTo:
+        scan) which the cooperative stop flag cannot reach."""
+        self.gemstone_session.hard_break()
+
     def class_categories_by_class_name(self):
         category_by_class_name = {}
         try:

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -120,6 +120,12 @@ class GemstoneSessionRecord:
         self.browse_mode = "categories"
         self.transaction_is_dirty = False
 
+    def hard_break(self):
+        """AI: Forward a forceful interrupt to the underlying GemStone session so a
+        Stop request can abandon a call that is in flight on another thread (see
+        parseltongue issue #2)."""
+        self.gemstone_browser_session.hard_break()
+
     def set_integrated_session_state(self, integrated_session_state):
         self.integrated_session_state = integrated_session_state
 
@@ -4340,6 +4346,9 @@ class CoveringTestsSearchDialog(tk.Toplevel):
         self.transient(parent)
         self.wait_visibility()
         self.grab_set()
+        self.bind("<Command-period>", self.interrupt_search_shortcut)
+        self.bind("<Alt-period>", self.interrupt_search_shortcut)
+        self.bind("<Control-period>", self.interrupt_search_shortcut)
 
         self.selected_tests = None
         self.was_cancelled = True
@@ -4633,6 +4642,13 @@ class CoveringTestsSearchDialog(tk.Toplevel):
         if self.is_searching:
             self.stop_search_requested = True
             self.set_stopping_for_cancel_state()
+
+    def interrupt_search_shortcut(self, event):
+        """AI: Pharo-style Cmd/Alt/Ctrl + . interrupts the running search from the
+        keyboard, mirroring the Stop button so a search parked inside a long GemStone
+        call can be abandoned without reaching for the mouse."""
+        self.request_stop_search()
+        return "break"
 
     def request_search_further(self):
         if not self.is_searching and self.is_timed_out:

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -486,6 +486,11 @@ class GemstoneSessionRecord:
             should_stop=should_stop,
         )
 
+    def existing_class_named(self, class_name):
+        """AI: Exact class lookup that resolves the name as a symbol instead of scanning
+        every class in the image - the fast path for the Find dialog's Exact match."""
+        return self.gemstone_browser_session.existing_class_named(class_name)
+
     def find_selectors_matching(self, search_input, should_stop=None):
         yield from self.gemstone_browser_session.find_selectors(
             search_input,
@@ -3346,6 +3351,8 @@ class FindDialog(tk.Toplevel):
         match_mode,
         should_stop=None,
     ):
+        if match_mode == "exact":
+            return self.gemstone_session_record.existing_class_named(query_text)
         class_pattern = self.class_match_query_pattern(
             query_text,
             match_mode,

--- a/src/reahl/swordfish/mcp/server.py
+++ b/src/reahl/swordfish/mcp/server.py
@@ -23,9 +23,13 @@ SWORDFISH_MCP_INSTRUCTIONS = """\
 Swordfish is a Smalltalk IDE MCP server for GemStone. Tools default to
 token-economical shapes: gs_method_ast returns a bodyless outline of the
 recursive-descent AST (drill with node_path / include_source);
-gs_find_senders returns sliced send-sites (set granularity='method' for
-whole-method results); gs_query_methods_by_ast_pattern returns node
-addresses, not method bodies.
+for senders, call gs_senders_overview first to size and locate them (a small
+summary: total plus counts grouped by class category, method category and
+class), then gs_find_senders for a bounded, paged page - narrow with
+class_categories / method_categories / side / class_name_pattern, page via
+next_offset, and use real_sends_only to drop #selector reference noise (each
+entry's kind marks direct_send vs reflective_send vs reference_only);
+gs_query_methods_by_ast_pattern returns node addresses, not method bodies.
 
 All code changes are explicit-transaction: call gs_begin first, then either
 the preview/apply pair pattern for refactorings (gs_preview_* before

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import os
 import re
 import threading
@@ -568,6 +569,33 @@ def register_tools(
         raise DomainException(
             "granularity must be one of 'identifier', 'send_site' or 'method'."
         )
+
+    def validated_sender_side(input_value):
+        if input_value is None or input_value in ('instance', 'class'):
+            return input_value
+        raise DomainException(
+            "side must be 'instance', 'class' or omitted for both."
+        )
+
+    sender_response_char_budget = 32000
+
+    def entries_within_char_budget(entries, max_chars):
+        # AI: Keep entries until adding the next one would exceed the response budget,
+        # so a result can never blow past the client's token limit however large each
+        # send-site slice is. Always keep at least one entry so a single huge entry is
+        # still returned (truncated by paging) rather than producing an empty page.
+        kept = []
+        used = 0
+        budget_reached = False
+        for entry in entries:
+            if not budget_reached:
+                entry_chars = len(json.dumps(entry))
+                if kept and used + entry_chars > max_chars:
+                    budget_reached = True
+                else:
+                    kept.append(entry)
+                    used = used + entry_chars
+        return kept, budget_reached
 
     def current_eval_mode():
         if not get_permissions()['allow_eval_arbitrary']:
@@ -2380,6 +2408,7 @@ def register_tools(
                     "gs_find_classes",
                     "gs_find_selectors",
                     "gs_find_implementors",
+                    "gs_senders_overview",
                     "gs_find_senders",
                     "gs_get_method_source",
                     "gs_method_ast",
@@ -3453,34 +3482,69 @@ def register_tools(
     def gs_find_senders(
         connection_id,
         method_name,
-        max_results: Optional[int] = None,
+        max_results: Optional[int] = 50,
         count_only: bool = False,
         granularity='send_site',
+        class_categories: Optional[List[str]] = None,
+        method_categories: Optional[List[str]] = None,
+        class_name_pattern: Optional[str] = None,
+        side: Optional[str] = None,
+        offset: int = 0,
     ):
-        """Find static senders of a selector. By default returns sliced
-        send-sites - one entry per call site with class, method_selector and
-        send location - which is token-cheaper than fetching whole sender
-        methods. Pass granularity='method' for whole-method results, or
-        granularity='identifier' for identifier-level locations only.
-        count_only skips the result list and returns counts only."""
+        """Find static senders of a selector, as a bounded page. Returns at most
+        max_results (default 50) entries and never exceeds a response-size budget, so a
+        hot selector cannot overflow the token limit: when more remains, 'truncated' is
+        true and 'next_offset' is the cursor for the next page. Run gs_senders_overview
+        first to size the result and choose filters. Narrow with class_categories,
+        method_categories, class_name_pattern (regex) and side ('instance'/'class').
+        granularity 'send_site' (default) gives one entry per call site; 'method' whole
+        methods; 'identifier' locations only. count_only returns counts only. Note:
+        senders come from the symbol-reference index, so an entry means the selector is
+        referenced - usually a real send, but a #selector literal (e.g. for perform:)
+        also counts."""
         browser_session, error_response = get_browser_session(connection_id)
         if error_response:
             return error_response
         try:
             method_name = validated_non_empty_string(method_name, "method_name")
             max_results = validated_non_negative_integer_or_none(
-                max_results,
-                "max_results",
+                max_results, "max_results"
             )
+            offset = validated_non_negative_integer_or_none(offset, "offset") or 0
             count_only = validated_boolean(count_only, "count_only")
             granularity = validated_sender_granularity(granularity)
+            class_categories = validated_string_list_or_none(
+                class_categories, "class_categories"
+            )
+            method_categories = validated_string_list_or_none(
+                method_categories, "method_categories"
+            )
+            side = validated_sender_side(side)
+            if class_name_pattern is not None:
+                class_name_pattern = validated_non_empty_string(
+                    class_name_pattern, "class_name_pattern"
+                )
             started_at = time.perf_counter()
             search_result = browser_session.find_senders(
                 method_name,
                 max_results=max_results,
                 count_only=count_only,
                 granularity=granularity,
+                class_categories=class_categories,
+                method_categories=method_categories,
+                class_name_pattern=class_name_pattern,
+                side=side,
+                offset=offset,
             )
+            total_count = search_result["total_count"]
+            kept_senders, budget_reached = entries_within_char_budget(
+                search_result["senders"], sender_response_char_budget
+            )
+            returned_count = len(kept_senders)
+            more_remaining = (not count_only) and (
+                offset + returned_count < total_count
+            )
+            next_offset = (offset + returned_count) if more_remaining else None
             elapsed_ms = int((time.perf_counter() - started_at) * 1000)
             return {
                 "ok": True,
@@ -3489,10 +3553,63 @@ def register_tools(
                 "max_results": max_results,
                 "count_only": count_only,
                 "granularity": granularity,
-                "total_count": search_result["total_count"],
-                "returned_count": search_result["returned_count"],
+                "offset": offset,
+                "filters": {
+                    "class_categories": class_categories,
+                    "method_categories": method_categories,
+                    "class_name_pattern": class_name_pattern,
+                    "side": side,
+                },
+                "total_count": total_count,
+                "returned_count": returned_count,
+                "truncated": more_remaining,
+                "budget_reached": budget_reached,
+                "next_offset": next_offset,
                 "elapsed_ms": elapsed_ms,
-                "senders": search_result["senders"],
+                "senders": kept_senders,
+            }
+        except GemstoneError as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": gemstone_error_payload(error),
+            }
+        except GemstoneApiError as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": {"message": str(error)},
+            }
+        except DomainException as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": {"message": str(error)},
+            }
+
+    @mcp_server.tool()
+    def gs_senders_overview(connection_id, method_name, top: int = 10):
+        """Size up the senders of a selector before fetching them. Returns the total
+        sender count, the instance/class split, and the most frequent class categories,
+        method categories and classes (each bounded to `top` with a remaining tally).
+        Small and cheap regardless of how many senders exist - use it to decide which
+        filters to pass to gs_find_senders. 'total' is the symbol-reference count, an
+        upper bound on real sends."""
+        browser_session, error_response = get_browser_session(connection_id)
+        if error_response:
+            return error_response
+        try:
+            method_name = validated_non_empty_string(method_name, "method_name")
+            top = validated_positive_integer(top, "top")
+            started_at = time.perf_counter()
+            overview = browser_session.senders_overview(method_name, top=top)
+            elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+            return {
+                "ok": True,
+                "connection_id": connection_id,
+                "method_name": method_name,
+                "elapsed_ms": elapsed_ms,
+                **overview,
             }
         except GemstoneError as error:
             return {

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -855,7 +855,10 @@ def register_tools(
         if selector_is_common_hotspot(selector):
             cautions.append(
                 'Selector %s is often high-fanout. '
-                'Static senders may contain many unrelated call sites.'
+                'Static senders may contain many unrelated call sites - call '
+                'gs_senders_overview to size and locate them, then gs_find_senders '
+                'with filters and paging (real_sends_only drops symbol-reference '
+                'noise).'
                 % selector
             )
         if (
@@ -871,6 +874,25 @@ def register_tools(
 
     def state_dependent_decision_rules(selector):
         decision_rules = []
+        if selector is not None:
+            decision_rules.append(
+                {
+                    'when': 'You need the senders of %s.' % selector,
+                    'prefer_tools': ['gs_senders_overview', 'gs_find_senders'],
+                    'avoid_tools': [
+                        'gs_find_senders with no filters or paging on a '
+                        'high-traffic selector'
+                    ],
+                    'reason': (
+                        'gs_senders_overview cheaply sizes the senders and shows '
+                        'where they cluster (by class category, method category and '
+                        'class); gs_find_senders then returns a bounded, paged result '
+                        'you narrow with class_categories / method_categories / side / '
+                        'class_name_pattern, and real_sends_only keeps real and '
+                        'perform: sends while dropping #selector reference noise.'
+                    ),
+                }
+            )
         if get_permissions()['allow_eval_arbitrary']:
             decision_rules.append(
                 {

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -1,5 +1,4 @@
 import functools
-import json
 import os
 import re
 import threading
@@ -578,24 +577,6 @@ def register_tools(
         )
 
     sender_response_char_budget = 32000
-
-    def entries_within_char_budget(entries, max_chars):
-        # AI: Keep entries until adding the next one would exceed the response budget,
-        # so a result can never blow past the client's token limit however large each
-        # send-site slice is. Always keep at least one entry so a single huge entry is
-        # still returned (truncated by paging) rather than producing an empty page.
-        kept = []
-        used = 0
-        budget_reached = False
-        for entry in entries:
-            if not budget_reached:
-                entry_chars = len(json.dumps(entry))
-                if kept and used + entry_chars > max_chars:
-                    budget_reached = True
-                else:
-                    kept.append(entry)
-                    used = used + entry_chars
-        return kept, budget_reached
 
     def current_eval_mode():
         if not get_permissions()['allow_eval_arbitrary']:
@@ -3490,6 +3471,7 @@ def register_tools(
         class_name_pattern: Optional[str] = None,
         side: Optional[str] = None,
         offset: int = 0,
+        real_sends_only: bool = False,
     ):
         """Find static senders of a selector, as a bounded page. Returns at most
         max_results (default 50) entries and never exceeds a response-size budget, so a
@@ -3498,10 +3480,12 @@ def register_tools(
         first to size the result and choose filters. Narrow with class_categories,
         method_categories, class_name_pattern (regex) and side ('instance'/'class').
         granularity 'send_site' (default) gives one entry per call site; 'method' whole
-        methods; 'identifier' locations only. count_only returns counts only. Note:
-        senders come from the symbol-reference index, so an entry means the selector is
-        referenced - usually a real send, but a #selector literal (e.g. for perform:)
-        also counts."""
+        methods; 'identifier' locations only. count_only returns counts only. Each entry
+        (at send_site/method granularity) carries a 'kind': 'direct_send', 'reflective_send'
+        (a #selector handed to perform:), or 'reference_only' (a #selector literal used
+        elsewhere - surfaced with its source so you can judge it). real_sends_only keeps
+        direct_send + reflective_send and reports how many reference_only were omitted, so
+        the symbol-reference noise is dropped without hiding perform: sends."""
         browser_session, error_response = get_browser_session(connection_id)
         if error_response:
             return error_response
@@ -3520,6 +3504,7 @@ def register_tools(
                 method_categories, "method_categories"
             )
             side = validated_sender_side(side)
+            real_sends_only = validated_boolean(real_sends_only, "real_sends_only")
             if class_name_pattern is not None:
                 class_name_pattern = validated_non_empty_string(
                     class_name_pattern, "class_name_pattern"
@@ -3535,16 +3520,9 @@ def register_tools(
                 class_name_pattern=class_name_pattern,
                 side=side,
                 offset=offset,
+                real_sends_only=real_sends_only,
+                max_response_chars=sender_response_char_budget,
             )
-            total_count = search_result["total_count"]
-            kept_senders, budget_reached = entries_within_char_budget(
-                search_result["senders"], sender_response_char_budget
-            )
-            returned_count = len(kept_senders)
-            more_remaining = (not count_only) and (
-                offset + returned_count < total_count
-            )
-            next_offset = (offset + returned_count) if more_remaining else None
             elapsed_ms = int((time.perf_counter() - started_at) * 1000)
             return {
                 "ok": True,
@@ -3553,6 +3531,7 @@ def register_tools(
                 "max_results": max_results,
                 "count_only": count_only,
                 "granularity": granularity,
+                "real_sends_only": real_sends_only,
                 "offset": offset,
                 "filters": {
                     "class_categories": class_categories,
@@ -3560,13 +3539,14 @@ def register_tools(
                     "class_name_pattern": class_name_pattern,
                     "side": side,
                 },
-                "total_count": total_count,
-                "returned_count": returned_count,
-                "truncated": more_remaining,
-                "budget_reached": budget_reached,
-                "next_offset": next_offset,
+                "total_count": search_result["total_count"],
+                "returned_count": search_result["returned_count"],
+                "reference_only_omitted": search_result["reference_only_omitted"],
+                "truncated": search_result["truncated"],
+                "budget_reached": search_result["budget_reached"],
+                "next_offset": search_result["next_offset"],
                 "elapsed_ms": elapsed_ms,
-                "senders": kept_senders,
+                "senders": search_result["senders"],
             }
         except GemstoneError as error:
             return {

--- a/tests/test_covering_tests_stop_interrupts.py
+++ b/tests/test_covering_tests_stop_interrupts.py
@@ -1,0 +1,52 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.browser import CoveringTestsDiscoveryWorkflow
+from reahl.swordfish.main import GemstoneSessionRecord
+
+
+@stubclass(GemstoneSessionRecord)
+class InterruptRecordingSessionRecord(GemstoneSessionRecord):
+    """AI: Records hard_break so a test can prove that stopping a search reaches
+    through to interrupt the GemStone call in flight, rather than only raising the
+    cooperative between-calls flag. stubclass keeps the recorded method honest against
+    the real record's signature."""
+
+    hard_break_count = 0
+
+    def hard_break(self):
+        self.hard_break_count = self.hard_break_count + 1
+
+
+def keep_latest_plan(accumulated_plan, latest_plan):
+    """AI: The workflow needs a plan combiner, but this unit never runs an actual
+    search, so keeping the latest result is all the combiner has to do."""
+    return latest_plan
+
+
+class CoveringTestsStopFixture(Fixture):
+    def new_session_record(self):
+        return InterruptRecordingSessionRecord(None)
+
+    def new_workflow(self):
+        return CoveringTestsDiscoveryWorkflow(
+            self.session_record,
+            'doSomething',
+            1000,
+            keep_latest_plan,
+        )
+
+
+@with_fixtures(CoveringTestsStopFixture)
+def test_stopping_a_search_interrupts_the_in_flight_gemstone_call(fixture):
+    """AI: A covering-tests search can be parked inside a single long GemStone call
+    (e.g. a referencesTo: scan) where the cooperative should_stop flag stays invisible
+    until that call returns. Requesting cancellation must therefore hard_break the
+    session so the blocked call is abandoned at once, while still raising the
+    cooperative flag for the safe points between calls."""
+    workflow = fixture.workflow
+
+    workflow.request_cancel()
+
+    assert fixture.session_record.hard_break_count == 1
+    assert workflow.should_stop.is_set()

--- a/tests/test_exact_class_search.py
+++ b/tests/test_exact_class_search.py
@@ -1,0 +1,106 @@
+from reahl.ptongue import GemstoneError
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+class ResolvedBoolean:
+    """AI: parseltongue answers Smalltalk sends with GemObjects whose .to_py yields the
+    Python value; existing_class_named reads .to_py off the isBehavior answer."""
+
+    def __init__(self, value):
+        self.to_py = value
+
+
+class ResolvedClassObject:
+    """AI: Stands in for a resolved GemStone object. isBehavior reports whether it is a
+    class/Behavior - exactly the send existing_class_named uses to tell a real class
+    from a defined-but-non-class global."""
+
+    def __init__(self, is_behavior):
+        self.is_behavior = is_behavior
+
+    def perform(self, selector):
+        assert selector == 'isBehavior'
+        return ResolvedBoolean(self.is_behavior)
+
+
+class PhantomObject:
+    """AI: Stands in for resolve_symbol's answer to an undefined name - a phantom on the
+    illegal OOP. It resolves truthily but every send to it fails, which is the real
+    cause of the 'object with object ID 1 does not exist' error on opening the result."""
+
+    def perform(self, selector):
+        raise GemstoneError(None, None)
+
+
+@stubclass(GemstoneBrowserSession)
+class ResolvingClassSession(GemstoneBrowserSession):
+    """AI: Stubs the two GemStone-side leaves an exact lookup could reach - the symbol
+    resolve and the full class-name scan - so a test can prove the exact path answers
+    from resolving and confirming the class, and never falls back to scanning."""
+
+    resolved_objects = {}
+    scan_was_called = False
+
+    def resolved_class(self, class_name):
+        return self.resolved_objects.get(class_name)
+
+    def all_class_names(self):
+        self.scan_was_called = True
+        return list(self.resolved_objects.keys())
+
+
+class ExactClassFixture(Fixture):
+    def browser_session_resolving(self, resolved_objects):
+        session = ResolvingClassSession(None)
+        session.resolved_objects = resolved_objects
+        return session
+
+
+class ExactClassScenarios(Fixture):
+    @scenario
+    def name_is_a_real_class(self):
+        """AI: A name that resolves to a Behavior is a genuine class - the one case that
+        yields a match."""
+        self.resolved_objects = {'Account': ResolvedClassObject(is_behavior=True)}
+        self.query = 'Account'
+        self.expected_matches = ['Account']
+
+    @scenario
+    def name_is_undefined(self):
+        """AI: An undefined name resolves to a phantom whose sends fail; it must not be
+        reported as a match (the Broker bug)."""
+        self.resolved_objects = {'Broker': PhantomObject()}
+        self.query = 'Broker'
+        self.expected_matches = []
+
+    @scenario
+    def name_is_a_non_class_global(self):
+        """AI: A defined global that is not a Behavior (e.g. a SymbolDictionary) is not a
+        class and must not be reported as a match."""
+        self.resolved_objects = {'Globals': ResolvedClassObject(is_behavior=False)}
+        self.query = 'Globals'
+        self.expected_matches = []
+
+    @scenario
+    def name_does_not_resolve(self):
+        """AI: When resolution itself yields nothing, there is no match."""
+        self.resolved_objects = {}
+        self.query = 'Nope'
+        self.expected_matches = []
+
+
+@with_fixtures(ExactClassFixture, ExactClassScenarios)
+def test_exact_class_lookup_matches_only_real_classes_without_scanning(fixture, scenario):
+    """AI: An exact class search only needs an O(1) symbol resolve plus a class-ness
+    check - the same primitive Browse Class uses - so it matches only names that resolve
+    to a real class, never reports phantom or non-class globals, and never falls back to
+    scanning every class name in the image."""
+    session = fixture.browser_session_resolving(scenario.resolved_objects)
+
+    matches = session.existing_class_named(scenario.query)
+
+    assert matches == scenario.expected_matches
+    assert session.scan_was_called is False

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -6129,17 +6129,24 @@ def test_find_dialog_class_search_populates_result_list(fixture):
 def test_find_dialog_class_mode_supports_contains_and_exact_matching(
     fixture,
 ):
-    """AI: Class mode should switch between contains and exact class-name matching."""
+    """AI: Class mode contains-matches by scanning every class name, but exact-matches
+    by resolving the name as a symbol (an O(1) image lookup, the same primitive Browse
+    Class uses) - so the exact path answers without scanning at all."""
     fixture.simulate_login()
 
     def classes_for_pattern(pattern, should_stop=None):
         if pattern == "Order":
             return ["Order", "OrderLine"]
-        if pattern == "^Order$":
-            return ["Order"]
         return []
 
     fixture.mock_browser.find_classes.side_effect = classes_for_pattern
+
+    def class_named(class_name):
+        if class_name == "Order":
+            return ["Order"]
+        return []
+
+    fixture.mock_browser.existing_class_named.side_effect = class_named
 
     with patch.object(FindDialog, "wait_visibility"):
         dialog = FindDialog(
@@ -6154,6 +6161,9 @@ def test_find_dialog_class_mode_supports_contains_and_exact_matching(
     dialog.match_mode.set("exact")
     dialog.find_text()
     assert list(dialog.results_listbox.get(0, "end")) == ["Order"]
+    # AI: The contains search scanned once; the exact search resolved the symbol and
+    # never scanned, so find_classes was not called a second time.
+    fixture.mock_browser.find_classes.assert_called_once()
     dialog.destroy()
 
 

--- a/tests/test_mcp_senders_interface.py
+++ b/tests/test_mcp_senders_interface.py
@@ -1,0 +1,156 @@
+import json
+
+from reahl.tofu import Fixture, set_up, tear_down, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+from reahl.swordfish.mcp.session_registry import add_connection, clear_connections
+from reahl.swordfish.mcp.tools import register_tools
+
+
+class McpToolRegistrar:
+    def __init__(self):
+        self.registered_tools_by_name = {}
+
+    def tool(self):
+        def register(function):
+            self.registered_tools_by_name[function.__name__] = function
+            return function
+
+        return register
+
+
+class FakeGemstoneSession:
+    """AI: Lives in the registry only so get_browser_session resolves; never read."""
+
+
+class McpSendersFixture(Fixture):
+    """AI: Drives the senders MCP tools with the browser layer stubbed, so the tests
+    pin the MCP wrapper's own behaviour - tier routing, filter/offset pass-through, and
+    the response-size budget - independently of the live sender search."""
+
+    @set_up
+    def install_recording_browser_methods(self):
+        clear_connections()
+        self.recorded_overview = None
+        self.recorded_find_senders = None
+        self.canned_overview = {
+            'total': 312,
+            'by_side': {'instance': 300, 'class': 12},
+            'by_class_category': {'top': [{'class_category': 'UI', 'count': 140}],
+                                  'remaining_values': 3, 'remaining_count': 20},
+            'by_method_category': {'top': [], 'remaining_values': 0, 'remaining_count': 0},
+            'classes': {'top': [{'class_name': 'Button', 'count': 30}],
+                        'remaining_values': 50, 'remaining_count': 200},
+        }
+        self.canned_senders = []
+        self.canned_total = 0
+        self.original_overview = GemstoneBrowserSession.senders_overview
+        self.original_find_senders = GemstoneBrowserSession.find_senders
+
+        fixture = self
+
+        def recording_senders_overview(browser_session, method_name, top=10):
+            fixture.recorded_overview = {'method_name': method_name, 'top': top}
+            return fixture.canned_overview
+
+        def recording_find_senders(
+            browser_session, method_name, max_results=None, count_only=False,
+            include_category_details=False, granularity='identifier',
+            class_categories=None, method_categories=None, class_name_pattern=None,
+            side=None, offset=0,
+        ):
+            fixture.recorded_find_senders = {
+                'method_name': method_name, 'max_results': max_results,
+                'count_only': count_only, 'granularity': granularity,
+                'class_categories': class_categories,
+                'method_categories': method_categories,
+                'class_name_pattern': class_name_pattern, 'side': side,
+                'offset': offset,
+            }
+            return {
+                'senders': list(fixture.canned_senders),
+                'total_count': fixture.canned_total,
+                'returned_count': len(fixture.canned_senders),
+                'offset': offset,
+            }
+
+        GemstoneBrowserSession.senders_overview = recording_senders_overview
+        GemstoneBrowserSession.find_senders = recording_find_senders
+
+        self.connection_id = add_connection(
+            FakeGemstoneSession(), {'connection_mode': 'linked'}
+        )
+        registrar = McpToolRegistrar()
+        register_tools(
+            registrar,
+            allow_source_read=True,
+            allow_source_write=True,
+            experimental=True,
+        )
+        self.tools = registrar.registered_tools_by_name
+
+    @tear_down
+    def restore_browser_methods(self):
+        GemstoneBrowserSession.senders_overview = self.original_overview
+        GemstoneBrowserSession.find_senders = self.original_find_senders
+        clear_connections()
+
+
+@with_fixtures(McpSendersFixture)
+def test_senders_overview_tool_returns_the_sized_summary(fixture):
+    """AI: The overview tier hands back the count plus the bounded breakdown the model
+    uses to choose filters, without touching the list path at all."""
+    result = fixture.tools['gs_senders_overview'](fixture.connection_id, 'draw')
+
+    assert result['ok'], result
+    assert result['total'] == 312
+    assert result['by_side'] == {'instance': 300, 'class': 12}
+    assert result['classes']['remaining_values'] == 50
+    assert fixture.recorded_overview['method_name'] == 'draw'
+
+
+@with_fixtures(McpSendersFixture)
+def test_find_senders_passes_filters_and_offset_to_the_browser(fixture):
+    """AI: The MCP wrapper validates and forwards every narrowing facet and the paging
+    offset, so 'senders in the UI category, instance side, from row 20' reaches the
+    browser as given."""
+    fixture.canned_senders = [{'class_name': 'Button'}]
+    fixture.canned_total = 1
+
+    result = fixture.tools['gs_find_senders'](
+        fixture.connection_id, 'draw',
+        class_categories=['UI'], method_categories=['rendering'],
+        class_name_pattern='^But', side='instance', offset=20, max_results=10,
+        granularity='identifier',
+    )
+
+    assert result['ok'], result
+    recorded = fixture.recorded_find_senders
+    assert recorded['class_categories'] == ['UI']
+    assert recorded['method_categories'] == ['rendering']
+    assert recorded['class_name_pattern'] == '^But'
+    assert recorded['side'] == 'instance'
+    assert recorded['offset'] == 20
+    assert recorded['max_results'] == 10
+
+
+@with_fixtures(McpSendersFixture)
+def test_find_senders_truncates_oversized_pages_to_the_budget(fixture):
+    """AI: However large the send-site slices are, the response is held under the size
+    budget: entries are kept until the budget, the rest are deferred to the next page
+    via next_offset, and budget_reached/truncated say so. This is what prevents the
+    'exceeds maximum allowed tokens' failure."""
+    big_entry = {'class_name': 'C', 'method_selector': 'm', 'source': 'x' * 1000}
+    fixture.canned_senders = [dict(big_entry) for index in range(100)]
+    fixture.canned_total = 100
+
+    result = fixture.tools['gs_find_senders'](
+        fixture.connection_id, 'draw', granularity='send_site', max_results=100
+    )
+
+    assert result['ok'], result
+    assert result['budget_reached'] is True
+    assert result['truncated'] is True
+    assert result['returned_count'] < 100
+    assert result['next_offset'] == result['returned_count']
+    assert len(json.dumps(result['senders'])) <= 32000

--- a/tests/test_mcp_senders_interface.py
+++ b/tests/test_mcp_senders_interface.py
@@ -1,5 +1,3 @@
-import json
-
 from reahl.tofu import Fixture, set_up, tear_down, with_fixtures
 
 from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
@@ -24,9 +22,10 @@ class FakeGemstoneSession:
 
 
 class McpSendersFixture(Fixture):
-    """AI: Drives the senders MCP tools with the browser layer stubbed, so the tests
-    pin the MCP wrapper's own behaviour - tier routing, filter/offset pass-through, and
-    the response-size budget - independently of the live sender search."""
+    """AI: Drives the senders MCP tools with the browser layer stubbed, so the tests pin
+    the MCP wrapper's own behaviour - tier routing, filter/offset/real_sends_only
+    pass-through, and echoing the browser's pagination - independently of the search and
+    the (browser-level) response budget."""
 
     @set_up
     def install_recording_browser_methods(self):
@@ -44,6 +43,10 @@ class McpSendersFixture(Fixture):
         }
         self.canned_senders = []
         self.canned_total = 0
+        self.canned_omitted = 0
+        self.canned_next_offset = None
+        self.canned_truncated = False
+        self.canned_budget_reached = False
         self.original_overview = GemstoneBrowserSession.senders_overview
         self.original_find_senders = GemstoneBrowserSession.find_senders
 
@@ -57,7 +60,7 @@ class McpSendersFixture(Fixture):
             browser_session, method_name, max_results=None, count_only=False,
             include_category_details=False, granularity='identifier',
             class_categories=None, method_categories=None, class_name_pattern=None,
-            side=None, offset=0,
+            side=None, offset=0, real_sends_only=False, max_response_chars=None,
         ):
             fixture.recorded_find_senders = {
                 'method_name': method_name, 'max_results': max_results,
@@ -65,12 +68,17 @@ class McpSendersFixture(Fixture):
                 'class_categories': class_categories,
                 'method_categories': method_categories,
                 'class_name_pattern': class_name_pattern, 'side': side,
-                'offset': offset,
+                'offset': offset, 'real_sends_only': real_sends_only,
+                'max_response_chars': max_response_chars,
             }
             return {
                 'senders': list(fixture.canned_senders),
                 'total_count': fixture.canned_total,
                 'returned_count': len(fixture.canned_senders),
+                'reference_only_omitted': fixture.canned_omitted,
+                'next_offset': fixture.canned_next_offset,
+                'truncated': fixture.canned_truncated,
+                'budget_reached': fixture.canned_budget_reached,
                 'offset': offset,
             }
 
@@ -110,18 +118,18 @@ def test_senders_overview_tool_returns_the_sized_summary(fixture):
 
 
 @with_fixtures(McpSendersFixture)
-def test_find_senders_passes_filters_and_offset_to_the_browser(fixture):
-    """AI: The MCP wrapper validates and forwards every narrowing facet and the paging
-    offset, so 'senders in the UI category, instance side, from row 20' reaches the
-    browser as given."""
-    fixture.canned_senders = [{'class_name': 'Button'}]
+def test_find_senders_forwards_filters_offset_and_the_response_budget(fixture):
+    """AI: The wrapper validates and forwards every narrowing facet, the paging offset,
+    real_sends_only, and the response-size budget it owns - so the browser is asked the
+    precise, bounded question."""
+    fixture.canned_senders = [{'class_name': 'Button', 'kind': 'direct_send'}]
     fixture.canned_total = 1
 
     result = fixture.tools['gs_find_senders'](
         fixture.connection_id, 'draw',
         class_categories=['UI'], method_categories=['rendering'],
         class_name_pattern='^But', side='instance', offset=20, max_results=10,
-        granularity='identifier',
+        granularity='send_site', real_sends_only=True,
     )
 
     assert result['ok'], result
@@ -132,25 +140,27 @@ def test_find_senders_passes_filters_and_offset_to_the_browser(fixture):
     assert recorded['side'] == 'instance'
     assert recorded['offset'] == 20
     assert recorded['max_results'] == 10
+    assert recorded['real_sends_only'] is True
+    assert recorded['max_response_chars'] == 32000
 
 
 @with_fixtures(McpSendersFixture)
-def test_find_senders_truncates_oversized_pages_to_the_budget(fixture):
-    """AI: However large the send-site slices are, the response is held under the size
-    budget: entries are kept until the budget, the rest are deferred to the next page
-    via next_offset, and budget_reached/truncated say so. This is what prevents the
-    'exceeds maximum allowed tokens' failure."""
-    big_entry = {'class_name': 'C', 'method_selector': 'm', 'source': 'x' * 1000}
-    fixture.canned_senders = [dict(big_entry) for index in range(100)]
-    fixture.canned_total = 100
+def test_find_senders_echoes_the_browsers_pagination_and_truncation(fixture):
+    """AI: Paging and the budget verdict are decided by the browser in one pass; the
+    wrapper just surfaces them, so the model gets next_offset, truncated, budget_reached
+    and the omitted-reference count to drive the next call."""
+    fixture.canned_senders = [{'class_name': 'Button', 'kind': 'direct_send'}]
+    fixture.canned_total = 312
+    fixture.canned_omitted = 4
+    fixture.canned_next_offset = 50
+    fixture.canned_truncated = True
+    fixture.canned_budget_reached = True
 
-    result = fixture.tools['gs_find_senders'](
-        fixture.connection_id, 'draw', granularity='send_site', max_results=100
-    )
+    result = fixture.tools['gs_find_senders'](fixture.connection_id, 'draw')
 
     assert result['ok'], result
-    assert result['budget_reached'] is True
     assert result['truncated'] is True
-    assert result['returned_count'] < 100
-    assert result['next_offset'] == result['returned_count']
-    assert len(json.dumps(result['senders'])) <= 32000
+    assert result['budget_reached'] is True
+    assert result['next_offset'] == 50
+    assert result['reference_only_omitted'] == 4
+    assert result['total_count'] == 312

--- a/tests/test_mcp_tool_policies.py
+++ b/tests/test_mcp_tool_policies.py
@@ -948,6 +948,26 @@ def test_gs_guidance_recommends_evidence_for_hotspot_when_tracing_enabled(
     assert fanout_rule_present
 
 
+@with_fixtures(AllowedToolsFixture)
+def test_gs_guidance_steers_any_selector_to_the_senders_overview_workflow(
+    tools_fixture,
+):
+    """AI: Whatever selector you ask about - not just the few hardcoded hotspots like
+    ifTrue: - the guidance points at sizing senders with gs_senders_overview before
+    pulling a bounded, filtered gs_find_senders page, so an AI does not dump a hot
+    selector like name (thousands of senders). The steering is a decision rule, not a
+    caution, so a non-hotspot selector stays free of high-fanout noise."""
+    guidance_result = tools_fixture.gs_guidance(selector="name")
+    assert guidance_result["ok"], guidance_result
+    senders_rule_present = any(
+        "gs_senders_overview" in rule["prefer_tools"]
+        for rule in guidance_result["decision_rules"]
+    )
+    assert senders_rule_present
+    cautions_text = " ".join(guidance_result["cautions"])
+    assert "high-fanout" not in cautions_text
+
+
 
 @with_fixtures(RestrictedToolsFixture)
 def test_gs_tracer_install_is_disabled_by_default(tools_fixture):

--- a/tests/test_senders_classification.py
+++ b/tests/test_senders_classification.py
@@ -107,6 +107,22 @@ def test_real_sends_only_drops_references_but_keeps_perform_sends(fixture):
     assert result['total_count'] == 3
 
 
+@with_fixtures(RealSendsFixture)
+def test_real_sends_only_classifies_and_filters_even_at_identifier_granularity(fixture):
+    """AI: real_sends_only must mean something regardless of granularity. identifier
+    fetches no source by default, so without care the filter silently no-ops; instead it
+    classifies to apply the filter, while keeping each entry lean - a kind but no
+    send_sites."""
+    result = fixture.session.find_senders(
+        'foo:', granularity='identifier', real_sends_only=True
+    )
+
+    kinds = sorted(sender['kind'] for sender in result['senders'])
+    assert kinds == ['direct_send', 'reflective_send']
+    assert result['reference_only_omitted'] == 1
+    assert all('send_sites' not in sender for sender in result['senders'])
+
+
 @stubclass(GemstoneBrowserSession)
 class BigSendSession(GemstoneBrowserSession):
     def selector_occurrence_summaries(

--- a/tests/test_senders_classification.py
+++ b/tests/test_senders_classification.py
@@ -1,0 +1,140 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+@stubclass(GemstoneBrowserSession)
+class ClassifyingSession(GemstoneBrowserSession):
+    """AI: Stubs the candidate query and the per-method source fetch so the real AST
+    classification runs against fixed sources - proving how a send is told apart from a
+    bare #selector reference, without a live image."""
+
+    candidates = []
+    sources = {}
+
+    def selector_occurrence_summaries(
+        self, method_name, occurrence_type, include_category_details=False
+    ):
+        return [dict(candidate) for candidate in self.candidates]
+
+    def get_method_source(self, class_name, method_selector, show_instance_side):
+        return self.sources[class_name]
+
+
+def candidate(class_name):
+    return {
+        'class_name': class_name,
+        'show_instance_side': True,
+        'method_selector': 'caller',
+    }
+
+
+class ClassificationFixture(Fixture):
+    def session_with(self, class_name, source):
+        session = ClassifyingSession(None)
+        session.candidates = [candidate(class_name)]
+        session.sources = {class_name: source}
+        return session
+
+
+class ClassificationScenarios(Fixture):
+    @scenario
+    def real_send_to_self(self):
+        """AI: A message_send node for the selector is a genuine send."""
+        self.source = 'caller\n    ^self foo: 1'
+        self.expected_kind = 'direct_send'
+
+    @scenario
+    def reflective_send_via_perform(self):
+        """AI: A #selector handed to perform: is a real dynamic send, not mere data, so
+        it must be kept (as reflective) rather than dropped."""
+        self.source = 'caller\n    ^self perform: #foo: with: 1'
+        self.expected_kind = 'reflective_send'
+
+    @scenario
+    def symbol_reference_elsewhere(self):
+        """AI: A #selector literal used anywhere other than a perform: arg is only a
+        reference - flagged, not treated as a send."""
+        self.source = 'caller\n    ^self register: #foo:'
+        self.expected_kind = 'reference_only'
+
+
+@with_fixtures(ClassificationFixture, ClassificationScenarios)
+def test_send_site_classification_distinguishes_send_from_reference(fixture, scenario):
+    """AI: Senders come from the symbol-reference index, which cannot tell a real send
+    from a #selector literal. The AST pass classifies each candidate so the noise can be
+    told apart - while a perform: literal is preserved as a real (dynamic) send."""
+    session = fixture.session_with('Caller', scenario.source)
+
+    sender = session.find_senders('foo:', granularity='send_site')['senders'][0]
+
+    assert sender['kind'] == scenario.expected_kind
+
+
+@stubclass(GemstoneBrowserSession)
+class ThreeKindSession(GemstoneBrowserSession):
+    def selector_occurrence_summaries(
+        self, method_name, occurrence_type, include_category_details=False
+    ):
+        return [candidate('Direct'), candidate('Reflective'), candidate('RefOnly')]
+
+    def get_method_source(self, class_name, method_selector, show_instance_side):
+        return {
+            'Direct': 'caller\n    ^self foo: 1',
+            'Reflective': 'caller\n    ^self perform: #foo: with: 1',
+            'RefOnly': 'caller\n    ^self register: #foo:',
+        }[class_name]
+
+
+class RealSendsFixture(Fixture):
+    def new_session(self):
+        return ThreeKindSession(None)
+
+
+@with_fixtures(RealSendsFixture)
+def test_real_sends_only_drops_references_but_keeps_perform_sends(fixture):
+    """AI: real_sends_only removes the symbol-reference noise (reference_only) while
+    keeping both direct and reflective (perform:) sends, and reports how many references
+    it set aside so nothing is silently lost."""
+    result = fixture.session.find_senders(
+        'foo:', granularity='send_site', real_sends_only=True
+    )
+
+    kinds = sorted(sender['kind'] for sender in result['senders'])
+    assert kinds == ['direct_send', 'reflective_send']
+    assert result['reference_only_omitted'] == 1
+    assert result['total_count'] == 3
+
+
+@stubclass(GemstoneBrowserSession)
+class BigSendSession(GemstoneBrowserSession):
+    def selector_occurrence_summaries(
+        self, method_name, occurrence_type, include_category_details=False
+    ):
+        return [candidate('Big%s' % index) for index in range(5)]
+
+    def get_method_source(self, class_name, method_selector, show_instance_side):
+        return "caller\n    ^self foo: '%s'" % ('x' * 400)
+
+
+class BudgetFixture(Fixture):
+    def new_session(self):
+        return BigSendSession(None)
+
+
+@with_fixtures(BudgetFixture)
+def test_find_senders_stops_at_the_response_budget_and_pages_the_rest(fixture):
+    """AI: However large each send-site slice is, the page is held under the char budget:
+    entries are kept until the next would exceed it, then it stops with budget_reached and
+    a next_offset that resumes exactly where it left off - so a single hot selector can
+    never overflow the token limit, but nothing is skipped."""
+    result = fixture.session.find_senders(
+        'foo:', granularity='send_site', max_response_chars=600
+    )
+
+    assert result['budget_reached'] is True
+    assert result['returned_count'] < 5
+    assert result['truncated'] is True
+    assert result['next_offset'] == result['returned_count']
+    assert result['total_count'] == 5

--- a/tests/test_senders_filters.py
+++ b/tests/test_senders_filters.py
@@ -1,0 +1,115 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+@stubclass(GemstoneBrowserSession)
+class FilteringSession(GemstoneBrowserSession):
+    """AI: Stubs the occurrence query with a fixed, category-tagged candidate set so a
+    test can prove find_senders narrows it by the requested facets before counting or
+    slicing - without a live image. granularity='identifier' keeps the candidate summary
+    as the result, so no source is fetched."""
+
+    canned_summaries = []
+
+    def selector_occurrence_summaries(
+        self, method_name, occurrence_type, include_category_details=False
+    ):
+        return list(self.canned_summaries)
+
+
+CANNED = [
+    {'class_name': 'Account', 'show_instance_side': True,
+     'method_selector': 'post', 'class_category': 'Banking',
+     'method_category': 'actions'},
+    {'class_name': 'AccountTest', 'show_instance_side': True,
+     'method_selector': 'testPost', 'class_category': 'Banking-Tests',
+     'method_category': 'tests'},
+    {'class_name': 'Ledger', 'show_instance_side': False,
+     'method_selector': 'reset', 'class_category': 'Banking',
+     'method_category': 'actions'},
+    {'class_name': 'Widget', 'show_instance_side': True,
+     'method_selector': 'draw', 'class_category': 'UI',
+     'method_category': 'rendering'},
+]
+
+
+class SenderFilterFixture(Fixture):
+    def new_browser_session(self):
+        session = FilteringSession(None)
+        session.canned_summaries = CANNED
+        return session
+
+
+class SenderFilterScenarios(Fixture):
+    @scenario
+    def by_class_category(self):
+        """AI: Narrowing to a class category keeps only senders whose class lives there."""
+        self.filters = {'class_categories': ['Banking']}
+        self.expected_classes = ['Account', 'Ledger']
+
+    @scenario
+    def by_method_category(self):
+        """AI: Narrowing to a method category keeps only senders filed under it - the way
+        to exclude e.g. test methods from the result."""
+        self.filters = {'method_categories': ['actions']}
+        self.expected_classes = ['Account', 'Ledger']
+
+    @scenario
+    def by_side(self):
+        """AI: Narrowing to instance side drops class-side senders."""
+        self.filters = {'side': 'instance'}
+        self.expected_classes = ['Account', 'AccountTest', 'Widget']
+
+    @scenario
+    def by_class_name_pattern(self):
+        """AI: A class-name regex narrows to matching classes, e.g. excluding *Test."""
+        self.filters = {'class_name_pattern': '^Account$'}
+        self.expected_classes = ['Account']
+
+
+@with_fixtures(SenderFilterFixture, SenderFilterScenarios)
+def test_find_senders_narrows_candidates_by_facet_before_listing(fixture, scenario):
+    """AI: Filters apply to the candidate summaries before counting and slicing, so the
+    listed senders - and the reported total - reflect only the requested facet. This is
+    what makes a selector with thousands of senders usable: ask for just the ones in the
+    categories or side you care about."""
+    result = fixture.browser_session.find_senders(
+        'balance', granularity='identifier', **scenario.filters
+    )
+
+    listed_classes = sorted(sender['class_name'] for sender in result['senders'])
+    assert listed_classes == scenario.expected_classes
+    assert result['total_count'] == len(scenario.expected_classes)
+
+
+@with_fixtures(SenderFilterFixture)
+def test_empty_filter_lists_mean_no_constraint_not_match_nothing(fixture):
+    """AI: The MCP validator turns an omitted category filter into an empty list, so an
+    empty list must mean 'do not constrain', not 'must be in the empty set'. Otherwise an
+    unfiltered request would silently drop every candidate (the gs_find_senders total=0
+    regression)."""
+    result = fixture.browser_session.find_senders(
+        'balance', granularity='identifier', class_categories=[], method_categories=[]
+    )
+
+    assert result['total_count'] == 4
+    assert result['returned_count'] == 4
+
+
+@with_fixtures(SenderFilterFixture)
+def test_find_senders_pages_with_offset_and_keeps_the_full_total(fixture):
+    """AI: A page is a window over the candidates: offset skips earlier ones and
+    max_results bounds how many come back, while total_count still reports the full
+    matching count so a caller knows there is more and where the next page starts."""
+    result = fixture.browser_session.find_senders(
+        'balance', granularity='identifier', offset=1, max_results=2
+    )
+
+    assert [sender['class_name'] for sender in result['senders']] == [
+        'AccountTest',
+        'Ledger',
+    ]
+    assert result['total_count'] == 4
+    assert result['offset'] == 1

--- a/tests/test_senders_overview.py
+++ b/tests/test_senders_overview.py
@@ -1,0 +1,103 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+def counts_by(grouping, key):
+    """AI: Turn a bounded grouping's {'top': [{key: value, 'count': n}], ...} into a
+    plain {value: n} dict so a test can assert the tallies without pinning tie-order."""
+    return {pair[key]: pair['count'] for pair in grouping['top']}
+
+
+@stubclass(GemstoneBrowserSession)
+class OverviewSession(GemstoneBrowserSession):
+    """AI: Stubs the single occurrence query the overview aggregates, and flags any
+    source fetch - so a test can prove the count and breakdown tiers summarise from the
+    one cheap round-trip and never pull method source."""
+
+    canned_summaries = []
+    source_was_fetched = False
+
+    def selector_occurrence_summaries(
+        self, method_name, occurrence_type, include_category_details=False
+    ):
+        assert occurrence_type == 'senders'
+        assert include_category_details is True
+        return list(self.canned_summaries)
+
+    def get_method_source(self, class_name, method_selector, show_instance_side):
+        self.source_was_fetched = True
+        return ''
+
+
+class SendersOverviewFixture(Fixture):
+    def new_browser_session(self):
+        session = OverviewSession(None)
+        session.canned_summaries = [
+            {'class_name': 'Account', 'show_instance_side': True,
+             'method_selector': 'post', 'class_category': 'Banking',
+             'method_category': 'actions'},
+            {'class_name': 'Account', 'show_instance_side': False,
+             'method_selector': 'new', 'class_category': 'Banking',
+             'method_category': 'instance creation'},
+            {'class_name': 'Ledger', 'show_instance_side': True,
+             'method_selector': 'record', 'class_category': 'Banking',
+             'method_category': 'actions'},
+            {'class_name': 'Widget', 'show_instance_side': True,
+             'method_selector': 'draw', 'class_category': 'UI',
+             'method_category': None},
+        ]
+        return session
+
+
+@with_fixtures(SendersOverviewFixture)
+def test_senders_count_is_just_total_and_side_split(fixture):
+    """AI: The cheapest tier answers only 'how many, and how do they split across
+    instance/class side' - a handful of integers - without any grouping or source, so it
+    is always safe to return however hot the selector is."""
+    count = fixture.browser_session.senders_count('balance')
+
+    assert count == {'total': 4, 'by_side': {'instance': 3, 'class': 1}}
+    assert fixture.browser_session.source_was_fetched is False
+
+
+@with_fixtures(SendersOverviewFixture)
+def test_senders_overview_adds_grouped_tallies_without_fetching_source(fixture):
+    """AI: The breakdown tier adds, on top of the count, where the senders cluster -
+    grouped by class category, method category, and per class - so the model can choose
+    a filter. It is built from the same single query and never pulls method source."""
+    overview = fixture.browser_session.senders_overview('balance')
+
+    assert overview['total'] == 4
+    assert overview['by_side'] == {'instance': 3, 'class': 1}
+    assert counts_by(overview['by_class_category'], 'class_category') == {
+        'Banking': 3,
+        'UI': 1,
+    }
+    assert counts_by(overview['by_method_category'], 'method_category') == {
+        'actions': 2,
+        'instance creation': 1,
+        None: 1,
+    }
+    assert counts_by(overview['classes'], 'class_name') == {
+        'Account': 2,
+        'Ledger': 1,
+        'Widget': 1,
+    }
+    assert overview['classes']['top'][0]['class_name'] == 'Account'
+    assert overview['classes']['remaining_values'] == 0
+    assert fixture.browser_session.source_was_fetched is False
+
+
+@with_fixtures(SendersOverviewFixture)
+def test_overview_groupings_are_bounded_to_top_n_with_a_remaining_tail(fixture):
+    """AI: A grouping must stay small however many distinct values there are: it keeps
+    only the top-N most frequent and folds the rest into a remaining tally, so a selector
+    spread over hundreds of classes still returns a compact, ranked summary."""
+    overview = fixture.browser_session.senders_overview('balance', top=2)
+
+    classes = overview['classes']
+    assert [entry['class_name'] for entry in classes['top']] == ['Account', 'Ledger']
+    assert classes['remaining_values'] == 1
+    assert classes['remaining_count'] == 1


### PR DESCRIPTION
Three related improvements to Swordfish's search and interrupt behaviour, plus a redesign of the senders MCP interface so it can't overflow an AI client's token budget. Pins
  reahl-parseltongue>=3.1.0 for its new soft/hard break support.

  1. Interruptible search (parseltongue hard_break)

  Wires reahl-parseltongue 3.1.0's hard_break (issue #2 — callable from a thread other than the one blocked in execute()) into the Covering Tests search Stop, so a search
  parked inside a single long-running GemStone call (e.g. a referencesTo: scan) is abandoned at once rather than only stopping at cooperative checkpoints. request_cancel() is
  the single point both search dialogs route through, so the one call covers both, and a Pharo-style Cmd/Alt/Ctrl + . keybinding is bound on both dialogs to the same path.

  2. Exact class search resolves instead of scanning

  Exact class-name search rebuilt a ^name$ regex and scanned every class name in the image. It now resolves the name as a symbol — an O(1) dictionary lookup, the same primitive
  Browse Class uses — mirroring the exact-match short-circuit the selector path already had. Because resolve_symbol answers a phantom object (not an error) for an undefined
  name, existing_class_named confirms the resolved object is really a class before reporting a match, so only navigable class names are listed (fixing a "no such class … object
  with object ID 1 does not exist" failure on bad exact input).

  3. Senders MCP interface: tiered, bounded, filtered, classified

  A hot selector (e.g. hasAddButtonBlock:) could make gs_find_senders return ~138 KB and exceed the client's token limit, wasting the work. The interface is now escalating and
  bounded:

  - gs_senders_overview (new tool) — total + instance/class split + top-N tallies by class category, method category and class (each with a remaining tail). Built from one
  sendersOf: query, no source fetched; measured ~450 tokens flat regardless of sender count.
  - gs_find_senders — class_categories / method_categories / class_name_pattern (regex) / side filters applied before counting and slicing; offset paging with next_offset; a
  hard response-size budget so a hot selector can never overflow the token limit (truncated / budget_reached). Default max_results=50.
  - Send-vs-reference classification — each send_site/method entry carries a kind: direct_send, reflective_send (a #selector handed to perform: — a real dynamic send, kept), or
  reference_only (a #selector literal elsewhere — surfaced with its source slice, never silently dropped). real_sends_only keeps the first two and reports how many references
  it set aside.

  Discoverability: both tools are in the navigation group, the server instructions teach the overview-first → filtered/paged → real_sends_only workflow, and gs_guidance steers
  any queried selector to it (not just a few hardcoded hotspots).


  Dependency

  reahl-parseltongue → >=3.1.0 (soft/hard break)