### PR TITLE
Performance improvements

### DIFF
--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -1742,7 +1742,6 @@ class MethodSelection(FramedWidget):
             '<<TreeviewSelect>>',
             self.method_hierarchy_selected,
         )
-        self.syncing_method_hierarchy_selection = False
 
         self.rowconfigure(0, weight=1)
         self.rowconfigure(1, weight=0)
@@ -2035,11 +2034,12 @@ class MethodSelection(FramedWidget):
         if selected_item_id is None and parent_item_id:
             selected_item_id = parent_item_id
         if selected_item_id:
-            self.syncing_method_hierarchy_selection = True
+            # AI: This programmatic selection makes ttk queue a <<TreeviewSelect>> for
+            # later delivery; method_hierarchy_selected recognises it as already in sync
+            # with the session state and ignores it.
             self.method_hierarchy_tree.selection_set(selected_item_id)
             self.method_hierarchy_tree.focus(selected_item_id)
             self.method_hierarchy_tree.see(selected_item_id)
-            self.syncing_method_hierarchy_selection = False
 
     def method_inheritance_entries(self):
         selected_class = self.gemstone_session_record.selected_class
@@ -2082,8 +2082,6 @@ class MethodSelection(FramedWidget):
         return superclass_chain
 
     def method_hierarchy_selected(self, event):
-        if self.syncing_method_hierarchy_selection:
-            return
         try:
             selected_item_id = event.widget.selection()[0]
         except IndexError:
@@ -2091,6 +2089,13 @@ class MethodSelection(FramedWidget):
         selected_class = event.widget.item(selected_item_id, 'text')
         selected_method = self.gemstone_session_record.selected_method_symbol
         if not selected_class or not selected_method:
+            return
+        if selected_class == self.gemstone_session_record.selected_class:
+            # AI: The selection already matches the session state. This happens when
+            # refresh_method_hierarchy syncs the tree programmatically: ttk delivers the
+            # resulting <<TreeviewSelect>> asynchronously, so it cannot be suppressed at
+            # the point of syncing. Jumping here would redundantly repopulate the whole
+            # browser and clobber the category selection.
             return
         show_instance_side = self.gemstone_session_record.show_instance_side
         if self.gemstone_session_record.gemstone_session is not None:

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -2279,6 +2279,22 @@ class GemstoneBrowserSession:
             'error': error,
         }
 
+    def compile_planned_changes(self, planned_changes):
+        '''AI: Compile every method a refactoring plan rewrites in one batched round-trip rather
+        than one per sender - the difference between a smooth rename and the compile storm that can
+        crash a linked gem. Each planned change already carries the class, side, rewritten source
+        and category, so it maps straight onto a batch spec with no dictionary scoping.'''
+        return self.compile_methods([
+            (
+                planned_change['class_name'],
+                planned_change['show_instance_side'],
+                planned_change['updated_source'],
+                planned_change['method_category'],
+                None,
+            )
+            for planned_change in planned_changes
+        ])
+
     def create_class(
         self,
         class_name,
@@ -3907,32 +3923,33 @@ class GemstoneBrowserSession:
         moved_selector,
         helper_receiver_source,
     ):
-        """AI: Rewrite every static call site of moved_selector in
-        same-class senders so its receiver becomes helper_receiver_source.
-        Walks each sender's parser AST, slices the receiver range, and
-        recompiles. Returns the count of senders that were rewritten."""
+        """AI: Rewrite every static call site of moved_selector in same-class senders so its
+        receiver becomes helper_receiver_source. Walks each sender's parser AST, slices the
+        receiver range, and recompiles every rewritten sender in one batched round-trip rather than
+        one per sender. The category is left to the batch's server-side preserve-or-default, which
+        keeps each recompiled sender's protocol without a per-sender category lookup. Returns the
+        count of senders that were rewritten."""
         sender_summaries = self.selector_occurrence_summaries(
             moved_selector,
             "senders",
         )
-        same_class_sender_summaries = [
-            sender_summary
-            for sender_summary in sender_summaries
-            if (
-                sender_summary["class_name"] == source_class_name
-                and sender_summary["show_instance_side"]
-                == source_show_instance_side
-            )
-        ]
-        rewritten_count = 0
+        candidate_selectors = []
         seen_sender_selectors = set()
-        for sender_summary in same_class_sender_summaries:
+        for sender_summary in sender_summaries:
             sender_selector = sender_summary["method_selector"]
-            if sender_selector == moved_selector:
-                continue
-            if sender_selector in seen_sender_selectors:
-                continue
-            seen_sender_selectors.add(sender_selector)
+            is_same_class = (
+                sender_summary["class_name"] == source_class_name
+                and sender_summary["show_instance_side"] == source_show_instance_side
+            )
+            is_unseen_other_selector = (
+                sender_selector != moved_selector
+                and sender_selector not in seen_sender_selectors
+            )
+            if is_same_class and is_unseen_other_selector:
+                seen_sender_selectors.add(sender_selector)
+                candidate_selectors.append(sender_selector)
+        rewrite_specs = []
+        for sender_selector in candidate_selectors:
             rewritten_source = self.sender_source_with_receiver_replaced(
                 source_class_name,
                 source_show_instance_side,
@@ -3940,21 +3957,12 @@ class GemstoneBrowserSession:
                 moved_selector,
                 helper_receiver_source,
             )
-            if rewritten_source is None:
-                continue
-            sender_category = self.get_method_category(
-                source_class_name,
-                sender_selector,
-                source_show_instance_side,
-            )
-            self.compile_method(
-                class_name=source_class_name,
-                show_instance_side=source_show_instance_side,
-                source=rewritten_source,
-                method_category=sender_category,
-            )
-            rewritten_count = rewritten_count + 1
-        return rewritten_count
+            if rewritten_source is not None:
+                rewrite_specs.append(
+                    (source_class_name, source_show_instance_side, rewritten_source, None, None)
+                )
+        self.compile_methods(rewrite_specs)
+        return len(rewrite_specs)
 
     def sender_source_with_receiver_replaced(
         self,
@@ -4193,18 +4201,14 @@ class GemstoneBrowserSession:
             parameter_name,
             default_argument_source,
         )
-        self.compile_method(
-            class_name=class_name,
-            show_instance_side=show_instance_side,
-            source=add_parameter_plan["new_method_source"],
-            method_category=add_parameter_plan["method_category"],
-        )
-        self.compile_method(
-            class_name=class_name,
-            show_instance_side=show_instance_side,
-            source=add_parameter_plan["compatibility_wrapper_source"],
-            method_category=add_parameter_plan["method_category"],
-        )
+        # AI: The widened method and its compatibility wrapper install into the same class with no
+        # compile-order dependency, so both go in one batched round-trip.
+        self.compile_methods([
+            (class_name, show_instance_side, add_parameter_plan["new_method_source"],
+             add_parameter_plan["method_category"], None),
+            (class_name, show_instance_side, add_parameter_plan["compatibility_wrapper_source"],
+             add_parameter_plan["method_category"], None),
+        ])
         summary = self.method_add_parameter_summary(add_parameter_plan)
         summary["applied"] = True
         return summary
@@ -4411,28 +4415,21 @@ class GemstoneBrowserSession:
                     "instance" if show_instance_side else "class",
                 )
             )
-        self.compile_method(
-            class_name=class_name,
-            show_instance_side=show_instance_side,
-            source=remove_parameter_plan["new_method_source"],
-            method_category=remove_parameter_plan["method_category"],
-        )
-        self.compile_method(
-            class_name=class_name,
-            show_instance_side=show_instance_side,
-            source=remove_parameter_plan["compatibility_wrapper_source"],
-            method_category=remove_parameter_plan["method_category"],
-        )
+        # AI: The new method, its compatibility wrapper and any source-sender rewrites all install
+        # into the same class with no compile-order dependency, so they go in one batched round-trip.
+        compile_specs = [
+            (class_name, show_instance_side, remove_parameter_plan["new_method_source"],
+             remove_parameter_plan["method_category"], None),
+            (class_name, show_instance_side, remove_parameter_plan["compatibility_wrapper_source"],
+             remove_parameter_plan["method_category"], None),
+        ]
         if rewrite_source_senders:
-            for caller_rewrite_plan in remove_parameter_plan[
-                "source_sender_rewrite_plans"
-            ]:
-                self.compile_method(
-                    class_name=class_name,
-                    show_instance_side=show_instance_side,
-                    source=caller_rewrite_plan["updated_source"],
-                    method_category=caller_rewrite_plan["method_category"],
-                )
+            compile_specs += [
+                (class_name, show_instance_side, caller_rewrite_plan["updated_source"],
+                 caller_rewrite_plan["method_category"], None)
+                for caller_rewrite_plan in remove_parameter_plan["source_sender_rewrite_plans"]
+            ]
+        self.compile_methods(compile_specs)
         summary = self.method_remove_parameter_summary(remove_parameter_plan)
         summary["applied"] = True
         summary["overwrite_new_method"] = overwrite_new_method
@@ -5908,13 +5905,7 @@ class GemstoneBrowserSession:
             old_selector,
             new_selector,
         )
-        for planned_change in planned_changes:
-            self.compile_method(
-                class_name=planned_change["class_name"],
-                show_instance_side=planned_change["show_instance_side"],
-                source=planned_change["updated_source"],
-                method_category=planned_change["method_category"],
-            )
+        self.compile_planned_changes(planned_changes)
         if old_selector != new_selector:
             deleted_implementors = set()
             for planned_change in planned_changes:
@@ -5974,13 +5965,7 @@ class GemstoneBrowserSession:
             old_selector,
             new_selector,
         )
-        for planned_change in planned_changes:
-            self.compile_method(
-                class_name=planned_change["class_name"],
-                show_instance_side=planned_change["show_instance_side"],
-                source=planned_change["updated_source"],
-                method_category=planned_change["method_category"],
-            )
+        self.compile_planned_changes(planned_changes)
         has_implementor_change = any(
             planned_change["change_type"] == "implementor"
             for planned_change in planned_changes

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -128,13 +128,34 @@ class GemstoneBrowserSession:
                 return False
         return True
 
+    def fetch_joined_names(self, smalltalk_source):
+        # AI: One GCI round-trip per listing: the server joins the names with lf and we
+        # split here, so the cost of a listing no longer scales with the number of
+        # elements (iterating a collection proxy costs ~2 round trips per element).
+        result_string = self.run_code(smalltalk_source).to_py
+        if not result_string:
+            return []
+        return result_string.split('\n')
+
+    def class_side_expression(self, class_name, show_instance_side):
+        # AI: Server-side twin of class_to_query: resolves the class via the symbol list
+        # and addresses the metaclass when the class side is asked for. A missing class
+        # yields nil, so the subsequent send raises GemstoneError just as sends to the
+        # phantom proxy returned by resolve_symbol do.
+        show_instance_side = self.validated_show_instance_side(show_instance_side)
+        class_expression = self.target_class_expression(class_name, None)
+        if show_instance_side:
+            return class_expression
+        return '%s class' % class_expression
+
     def list_categories(self):
-        category_names = []
+        smalltalk_source = (
+            '| names |\n'
+            'names := ClassOrganizer new categories keys asArray collect: [:each | each asString].\n'
+            '(String with: Character lf) join: names'
+        )
         try:
-            category_names = [
-                gemstone_package.to_py
-                for gemstone_package in self.class_organizer.categories().keys()
-            ]
+            category_names = self.fetch_joined_names(smalltalk_source)
         except GemstoneError:
             category_names = []
         except GemstoneApiError:
@@ -142,17 +163,16 @@ class GemstoneBrowserSession:
         return sorted(category_names)
 
     def list_dictionaries(self):
-        dictionary_names = self.run_code(
+        return self.fetch_joined_names(
             (
                 "| names |\n"
                 "names := OrderedCollection new.\n"
                 "System myUserProfile symbolList do: [:each |\n"
                 "    names add: each name asString\n"
                 "].\n"
-                "(names asSortedCollection) asArray"
+                "(String with: Character lf) join: (names asSortedCollection) asArray"
             )
         )
-        return [dictionary_name.to_py for dictionary_name in dictionary_names]
 
     def create_package(self, package_name):
         package_name_literal = self.smalltalk_string_literal(package_name)
@@ -251,16 +271,18 @@ class GemstoneBrowserSession:
     def list_classes_in_category(self, category_name):
         if not category_name:
             return []
+        category_literal = self.smalltalk_string_literal(category_name)
+        smalltalk_source = (
+            '| classes |\n'
+            'classes := ClassOrganizer new categories at: %s ifAbsent: [#()].\n'
+            '(String with: Character lf) join: '
+            '(classes asArray collect: [:each | each name asString])'
+        ) % category_literal
         try:
-            gemstone_classes = self.class_organizer.categories().at(category_name)
-            class_names = [
-                gemstone_class.name().to_py for gemstone_class in gemstone_classes
-            ]
+            class_names = self.fetch_joined_names(smalltalk_source)
         except GemstoneError:
             class_names = []
         except GemstoneApiError:
-            class_names = []
-        except KeyError:
             class_names = []
         return sorted(class_names)
 
@@ -268,7 +290,7 @@ class GemstoneBrowserSession:
         if not dictionary_name:
             return []
         dictionary_name_literal = self.smalltalk_string_literal(dictionary_name)
-        class_names = self.run_code(
+        return self.fetch_joined_names(
             (
                 "| dictionaryName dictionary classNames |\n"
                 "dictionaryName := %s.\n"
@@ -285,11 +307,10 @@ class GemstoneBrowserSession:
                 "    ].\n"
                 "    classNames := (classNames asSortedCollection) asArray\n"
                 "].\n"
-                "classNames"
+                "(String with: Character lf) join: classNames"
             )
             % dictionary_name_literal
         )
-        return [class_name.to_py for class_name in class_names]
 
     def dictionary_name_for_class(self, class_name):
         class_name_literal = self.smalltalk_string_literal(class_name)
@@ -383,12 +404,12 @@ class GemstoneBrowserSession:
     def list_method_categories(self, class_name, show_instance_side):
         if not class_name:
             return []
-        class_to_query = self.class_to_query(class_name, show_instance_side)
-        categories = [
-            gemstone_category.to_py
-            for gemstone_category in class_to_query.categoryNames().asSortedCollection()
-        ]
-        return ["all"] + categories
+        class_expression = self.class_side_expression(class_name, show_instance_side)
+        smalltalk_source = (
+            '(String with: Character lf) join: '
+            '(%s categoryNames asSortedCollection asArray collect: [:each | each asString])'
+        ) % class_expression
+        return ['all'] + self.fetch_joined_names(smalltalk_source)
 
     def list_methods(
         self,
@@ -398,19 +419,31 @@ class GemstoneBrowserSession:
     ):
         if not class_name or not method_category:
             return []
-        class_to_query = self.class_to_query(class_name, show_instance_side)
-        if method_category == "all":
-            selectors = class_to_query.selectors().asSortedCollection()
-        else:
-            try:
-                selectors = class_to_query.selectorsIn(
-                    method_category
-                ).asSortedCollection()
-            except GemstoneError:
-                return (
-                    []
-                )  # AI: category exists in categoryNames() but selectorsIn: cannot query it (e.g. *bootstrap-caching)
-        return [gemstone_selector.to_py for gemstone_selector in selectors]
+        class_expression = self.class_side_expression(class_name, show_instance_side)
+        if method_category == 'all':
+            selectors_expression = '%s selectors' % class_expression
+            return self.fetch_joined_names(
+                self.joined_selector_names_source(selectors_expression)
+            )
+        category_literal = self.smalltalk_string_literal(method_category)
+        selectors_expression = '%s selectorsIn: %s' % (
+            class_expression,
+            category_literal,
+        )
+        try:
+            return self.fetch_joined_names(
+                self.joined_selector_names_source(selectors_expression)
+            )
+        except GemstoneError:
+            return (
+                []
+            )  # AI: category exists in categoryNames() but selectorsIn: cannot query it (e.g. *bootstrap-caching)
+
+    def joined_selector_names_source(self, selectors_expression):
+        return (
+            '(String with: Character lf) join: '
+            '((%s) asSortedCollection asArray collect: [:each | each asString])'
+        ) % selectors_expression
 
     def get_compiled_method(self, class_name, method_selector, show_instance_side):
         class_to_query = self.class_to_query(class_name, show_instance_side)

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -2104,32 +2104,180 @@ class GemstoneBrowserSession:
         in_dictionary,
         show_instance_side,
         source,
-        method_category="as yet unclassified",
+        method_category=None,
     ):
-        class_literal = self.smalltalk_string_literal(class_name)
-        source_literal = self.smalltalk_string_literal(source)
-        method_category_literal = self.smalltalk_string_literal(method_category)
-        dictionary_expression = self.dictionary_reference_expression(in_dictionary)
-        class_side_suffix = "" if show_instance_side else " class"
-        return self.run_code(
-            (
-                "| classToQuery symbolList |\n"
-                "classToQuery := (%s at: (%s asSymbol)).\n"
-                "symbolList := System myUserProfile symbolList.\n"
-                "classToQuery%s\n"
-                "    compileMethod: %s\n"
-                "    dictionaries: symbolList\n"
-                "    category: %s\n"
-                "    environmentId: 0"
-            )
-            % (
-                dictionary_expression,
-                class_literal,
-                class_side_suffix,
-                source_literal,
-                method_category_literal,
-            )
+        '''AI: A dictionary-scoped compile is just a one-element batch whose class is resolved via
+        the named dictionary rather than the whole symbol list. Routing it through compile_methods
+        removes the duplicate compile implementation and, unlike the old standalone version which
+        always filed an omitted category under "as yet unclassified", now preserves an existing
+        method's protocol when no category is named.'''
+        rows = self.compile_methods(
+            [(class_name, show_instance_side, source, method_category, in_dictionary)]
         )
+        return rows[0]
+
+    def compile_methods(self, method_specs, chunk_size=50):
+        '''AI: Compile many methods in as few GCI round-trips as possible - one per chunk of
+        chunk_size, instead of three per method (category lookup, symbol-list fetch, compile).
+        Each spec is (class_name, show_instance_side, source, method_category-or-None,
+        in_dictionary-or-None). The selector is parsed here in pure Python so the gem can keep an
+        existing method's protocol when no category is named, and so a source that does not parse
+        becomes an error row rather than reaching the gem. Chunking bounds both the size of each
+        Smalltalk program and the per-round-trip allocation that pressures the gem's garbage
+        collector. A compile error or a missing class becomes that row's error and leaves the rest
+        of the batch installed. Returns one result row per input spec, in input order:
+        {class_name, selector, show_instance_side, method_category, ok, error}.'''
+        mirroring = current_working_copy().active
+        results = [None] * len(method_specs)
+        sendable = []
+        for index, spec in enumerate(method_specs):
+            class_name, show_instance_side, source, method_category, in_dictionary = spec
+            selector = self.mirrored_selector(source)
+            if selector is None:
+                results[index] = self.compile_result_row(
+                    class_name, '', show_instance_side, '', False,
+                    'Source does not define a parseable method.',
+                )
+            else:
+                previous_source = (
+                    self.existing_method_source(class_name, selector, show_instance_side)
+                    if mirroring
+                    else None
+                )
+                sendable.append(
+                    (index, class_name, show_instance_side, selector, source,
+                     method_category, in_dictionary, previous_source)
+                )
+        for chunk in self.chunked(sendable, chunk_size):
+            for entry, row in zip(chunk, self.run_compile_chunk(chunk)):
+                index = entry[0]
+                results[index] = row
+                if mirroring and row['ok']:
+                    self.mirror_compiled_method(
+                        entry[1], entry[2], entry[4], row['method_category'],
+                        entry[3], entry[7],
+                    )
+        return results
+
+    def chunked(self, items, chunk_size):
+        '''AI: Split items into successive lists of at most chunk_size, preserving order, so a
+        large batch is sent as several bounded programs rather than one unbounded one.'''
+        return [items[start:start + chunk_size] for start in range(0, len(items), chunk_size)]
+
+    def run_compile_chunk(self, chunk):
+        '''AI: Compile one chunk of specs in a single GCI call and return its result rows in the
+        same order the specs were sent.'''
+        elements = [
+            self.compile_spec_element(
+                class_name, show_instance_side, selector, source, method_category, in_dictionary
+            )
+            for (index, class_name, show_instance_side, selector, source,
+                 method_category, in_dictionary, previous_source) in chunk
+        ]
+        raw = self.run_code(self.batch_compile_program('.\n'.join(elements)))
+        return self.parsed_compile_chunk_results(raw)
+
+    def compile_spec_element(
+        self, class_name, show_instance_side, selector, source, method_category, in_dictionary
+    ):
+        '''AI: One element of the dynamic array sent to the gem:
+        { classNameStr. targetClassOrNil. selectorStr. sideBool. sourceStr. categoryOrNil }.
+        A dynamic array (curly braces) is used rather than a literal array so each element is a
+        real evaluated object - the booleans and nils are genuine, and the second slot is the
+        resolved class itself, looked up at array-build time via the same expression
+        dictionary_reference_expression builds for the dictionary-scoped path.'''
+        return '{ %s. %s. %s. %s. %s. %s }' % (
+            self.smalltalk_string_literal(class_name),
+            self.target_class_expression(class_name, in_dictionary),
+            self.smalltalk_string_literal(selector),
+            'true' if show_instance_side else 'false',
+            self.smalltalk_string_literal(source),
+            self.smalltalk_string_literal(method_category) if method_category is not None else 'nil',
+        )
+
+    def target_class_expression(self, class_name, in_dictionary):
+        '''AI: A Smalltalk expression that resolves the class to compile into - via the whole
+        symbol list when no dictionary is named, or via the named dictionary (reusing
+        dictionary_reference_expression) when one is. Both yield nil rather than raising when the
+        class is absent, so a missing class becomes a per-row error, not a chunk-wide failure.'''
+        class_literal = self.smalltalk_string_literal(class_name)
+        if in_dictionary is None:
+            return '(System myUserProfile symbolList objectNamed: %s asSymbol)' % class_literal
+        dictionary_expression = self.dictionary_reference_expression(in_dictionary)
+        return '(%s at: %s asSymbol otherwise: nil)' % (dictionary_expression, class_literal)
+
+    def batch_compile_program(self, elements_source):
+        '''AI: A program that fetches the symbol list once, then compiles every spec, resolving an
+        omitted category to the method's current protocol (or "as yet unclassified" for a new
+        method) inside the loop so the whole chunk stays one round-trip. compileMethod:... returns
+        a GsNMethod on success or an Array of compiler errors on failure - it does not raise - so a
+        bad spec is recorded and the loop continues.'''
+        return (
+            "| symbolList results |\n"
+            "symbolList := System myUserProfile symbolList.\n"
+            "results := OrderedCollection new.\n"
+            "{\n"
+            "%s\n"
+            "} do: [:spec | | className target selector onInstanceSide source category "
+            "catToUse compiled okFlag errorText |\n"
+            "    className := spec at: 1.\n"
+            "    target := spec at: 2.\n"
+            "    selector := (spec at: 3) asSymbol.\n"
+            "    onInstanceSide := spec at: 4.\n"
+            "    source := spec at: 5.\n"
+            "    category := spec at: 6.\n"
+            "    target isNil\n"
+            "        ifTrue: [results add: { className. selector asString. onInstanceSide. "
+            "''. false. 'Class not found.' }]\n"
+            "        ifFalse: [\n"
+            "            onInstanceSide ifFalse: [target := target class].\n"
+            "            catToUse := category ifNil: [\n"
+            "                (target includesSelector: selector)\n"
+            "                    ifTrue: [(target categoryOfSelector: selector) ifNil: ['as yet unclassified']]\n"
+            "                    ifFalse: ['as yet unclassified']].\n"
+            "            compiled := target\n"
+            "                compileMethod: source\n"
+            "                dictionaries: symbolList\n"
+            "                category: catToUse\n"
+            "                environmentId: 0.\n"
+            "            okFlag := compiled isKindOf: GsNMethod.\n"
+            "            errorText := okFlag ifTrue: [''] ifFalse: [compiled printString].\n"
+            "            results add: { className. selector asString. onInstanceSide. "
+            "catToUse asString. okFlag. errorText }]].\n"
+            "results"
+        ) % elements_source
+
+    def parsed_compile_chunk_results(self, raw):
+        '''AI: Turn the gem's OrderedCollection of six-element Arrays into result rows, traversing
+        with size/at: rather than a bulk to_py so each leaf converts predictably.'''
+        rows = []
+        for position in range(1, raw.size().to_py + 1):
+            entry = raw.at(position)
+            rows.append(
+                self.compile_result_row(
+                    entry.at(1).to_py,
+                    entry.at(2).to_py,
+                    entry.at(3).to_py,
+                    entry.at(4).to_py,
+                    entry.at(5).to_py,
+                    entry.at(6).to_py,
+                )
+            )
+        return rows
+
+    def compile_result_row(
+        self, class_name, selector, show_instance_side, method_category, ok, error
+    ):
+        '''AI: One per-method outcome of a batch compile, shaped the same whether it came back from
+        the gem or was decided here (an unparseable source never sent).'''
+        return {
+            'class_name': class_name,
+            'selector': selector,
+            'show_instance_side': show_instance_side,
+            'method_category': method_category,
+            'ok': ok,
+            'error': error,
+        }
 
     def create_class(
         self,

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -16,6 +16,7 @@ import tkinter.messagebox as messagebox
 import tkinter.simpledialog as simpledialog
 import time
 import traceback
+import uuid
 import weakref
 from collections import deque
 from datetime import datetime
@@ -57,6 +58,12 @@ from reahl.swordfish.gemstone.working_copy import (
 from reahl.swordfish.inspector import Explorer, InspectorTab, ObjectInspector
 from reahl.swordfish.mcp.integration_state import current_integrated_session_state
 from reahl.swordfish.mcp.server import McpDependencyNotInstalled, create_server
+from reahl.swordfish.mcp.session_serialization import (
+    current_operation_token,
+    leave_session_operation,
+    session_operation,
+    try_enter_session_operation,
+)
 from reahl.swordfish.navigation import (
     GlobalNavigationEntry,
     GlobalNavigationHistory,
@@ -1200,6 +1207,26 @@ class ActivityLog:
                 f.write(json.dumps(entry) + '\n')
 
 
+class SessionOperationAdmission:
+    """AI: Lets the IDE event drain take the shared GemStone session as a whole operation, without
+    blocking. The Tk thread must never block on the session lock - it also services MCP-driven
+    navigation, so blocking would deadlock an MCP operation that is waiting on Tk. Instead it asks
+    non-blockingly: a token means the drain may run its GCI now; None means an MCP operation holds
+    the session, so the drain defers onto the event loop and retries rather than colliding."""
+
+    def __init__(self, connection_id):
+        self.connection_id = connection_id
+
+    def try_admit(self):
+        operation_token = ('ide', uuid.uuid4().hex)
+        if try_enter_session_operation(self.connection_id, operation_token):
+            return operation_token
+        return None
+
+    def release(self, operation_token):
+        leave_session_operation(self.connection_id, operation_token)
+
+
 class EventQueue:
     def __init__(self, root, activity_log=None):
         self.root = root
@@ -1211,6 +1238,8 @@ class EventQueue:
         self.wakeup_read_descriptor = None
         self.wakeup_write_descriptor = None
         self.processing_events = False
+        self.session_admission = None
+        self.deferred_processing_scheduled = False
         self.ui_dispatcher = UiDispatcher(self.root)
         self.root.bind('<<CustomEventsPublished>>', self.schedule_event_processing)
         self.configure_cross_thread_wakeup()
@@ -1333,6 +1362,14 @@ class EventQueue:
     def process_events(self):
         if self.processing_events:
             return
+        admission_token = None
+        if self.session_admission is not None:
+            admission_token = self.session_admission.try_admit()
+            if admission_token is None:
+                # AI: An MCP operation holds the session; defer this whole drain onto the event
+                # loop rather than blocking Tk or running IDE GCI that would collide with it.
+                self.schedule_deferred_processing()
+                return
         self.processing_events = True
         try:
             while True:
@@ -1369,6 +1406,21 @@ class EventQueue:
                     self.events[event_name] = retained_callbacks
         finally:
             self.processing_events = False
+            if admission_token is not None:
+                self.session_admission.release(admission_token)
+
+    def schedule_deferred_processing(self):
+        if self.deferred_processing_scheduled:
+            return
+        self.deferred_processing_scheduled = True
+        try:
+            self.root.after(20, self.run_deferred_processing)
+        except tk.TclError:
+            self.deferred_processing_scheduled = False
+
+    def run_deferred_processing(self):
+        self.deferred_processing_scheduled = False
+        self.process_events()
 
     def clear_subscribers(self, owner):
         for event_name, registered_callbacks in self.events.copy().items():
@@ -5541,6 +5593,7 @@ class Swordfish(tk.Tk):
         self.gemstone_session_record.log_out()
         self.gemstone_session_record = None
         self.integrated_session_state.detach_ide_session()
+        self.event_queue.session_admission = None
         self.event_queue.publish(
             "LoggedOut",
             log_context={
@@ -5596,6 +5649,9 @@ class Swordfish(tk.Tk):
         )
         self.integrated_session_state.attach_ide_session(
             self.gemstone_session_record.gemstone_session
+        )
+        self.event_queue.session_admission = SessionOperationAdmission(
+            self.integrated_session_state.ide_connection_id()
         )
 
         self.clear_widgets()
@@ -7350,15 +7406,27 @@ class Swordfish(tk.Tk):
                 action_name,
                 action_parameters,
             )
+        # AI: This runs on the MCP worker thread while its operation holds the session under
+        # operation_token. The navigation must run on the Tk thread, so we dispatch it there
+        # OUTSIDE the gated event drain and re-enter the gate under the same token - the Tk side is
+        # part of this operation, not a competing one, so it must not defer or block against the
+        # operation's own hold (which would time out here).
+        operation_token = current_operation_token() or ("mcp-ide-nav", uuid.uuid4().hex)
+        ide_connection_id = self.integrated_session_state.ide_connection_id()
         response_holder = {}
         completion_event = threading.Event()
-        self.event_queue.publish(
-            "McpIdeNavigationRequested",
-            action_name=action_name,
-            action_parameters=action_parameters,
-            response_holder=response_holder,
-            completion_event=completion_event,
-        )
+
+        def run_navigation_under_operation():
+            try:
+                with session_operation(ide_connection_id, operation_token):
+                    response_holder["response"] = self.execute_mcp_ide_navigation_action(
+                        action_name,
+                        action_parameters,
+                    )
+            finally:
+                completion_event.set()
+
+        self.event_queue.ui_dispatcher.dispatch(run_navigation_under_operation)
         completed = completion_event.wait(timeout=5.0)
         if not completed:
             return {

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -14,6 +14,7 @@ import tkinter as tk
 import tkinter.filedialog as filedialog
 import tkinter.messagebox as messagebox
 import tkinter.simpledialog as simpledialog
+import time
 import traceback
 import weakref
 from collections import deque
@@ -1099,6 +1100,26 @@ class BusyCoordinator:
             if self.busy:
                 return lease_token == self.active_lease_token
             return lease_token == 0
+
+
+class ActivityLinger:
+    '''AI: Holds the MCP activity indicator visible for a minimum time after each busy signal.
+    A fast MCP operation begins and ends before the Tk thread renders its busy state, so an
+    indicator driven by raw busy-state edges shows nothing at all for exactly the workloads -
+    bursts of small, quick tool calls - a user most wants reassurance about. Every busy signal
+    extends the hold, so a burst reads as one steady period of activity ending a minimum time
+    after the last call.'''
+
+    def __init__(self, minimum_visible_seconds=0.5, clock=time.monotonic):
+        self.minimum_visible_seconds = minimum_visible_seconds
+        self.clock = clock
+        self.visible_until = 0.0
+
+    def note_activity(self):
+        self.visible_until = self.clock() + self.minimum_visible_seconds
+
+    def is_lingering(self):
+        return self.clock() < self.visible_until
 
 
 class ActionGate:
@@ -5054,6 +5075,10 @@ class Swordfish(tk.Tk):
 
         self.gemstone_session_record = None
         self.last_mcp_busy_state = None
+        self.activity_linger = ActivityLinger()
+        self.last_seen_mcp_operation_name = ''
+        self.last_mcp_activity_text = ''
+        self.linger_refresh_after_id = None
         self.last_mcp_server_running_state = None
         self.last_mcp_server_starting_state = None
         self.last_mcp_server_stopping_state = None
@@ -6276,6 +6301,9 @@ class Swordfish(tk.Tk):
             'Uncommitted changes' if session_is_dirty else ''
         )
         mcp_busy = self.integrated_session_state.is_mcp_busy()
+        # AI: The linger only stretches what the indicator *shows*; action gating below uses the
+        # real busy state so the IDE unlocks the moment the MCP is actually idle.
+        mcp_activity_visible = mcp_busy or self.activity_linger.is_lingering()
         mcp_server_status = self.mcp_server_controller.status()
         mcp_server_running = mcp_server_status["running"]
         mcp_server_starting = mcp_server_status["starting"]
@@ -6285,7 +6313,7 @@ class Swordfish(tk.Tk):
         )
         self.set_mcp_activity_indicator_visibility(
             bool(self.foreground_activity_message)
-            or mcp_busy
+            or mcp_activity_visible
             or mcp_server_starting
             or mcp_server_stopping
         )
@@ -6293,12 +6321,18 @@ class Swordfish(tk.Tk):
             self.collaboration_status_text.set(self.foreground_activity_message)
         elif mcp_busy:
             operation_name = (
-                self.integrated_session_state.current_mcp_operation_name() or "unknown"
+                self.integrated_session_state.current_mcp_operation_name()
+                or self.last_seen_mcp_operation_name
+                or "unknown"
             )
             self.collaboration_status_text.set(
                 "MCP busy: %s. IDE write/run/debug actions are read-only."
                 % operation_name
             )
+        elif mcp_activity_visible:
+            # AI: The operation already finished; during the linger the status bar reports what
+            # just ran rather than claiming the IDE is still locked.
+            self.collaboration_status_text.set(self.last_mcp_activity_text)
         elif mcp_server_stopping:
             self.collaboration_status_text.set("Stopping MCP server...")
         elif mcp_server_starting:
@@ -6312,6 +6346,8 @@ class Swordfish(tk.Tk):
                     runtime_message
                     + " Network settings changed; they will take effect at next MCP start."
                 )
+            if self.last_mcp_activity_text:
+                runtime_message = runtime_message + " " + self.last_mcp_activity_text
             self.collaboration_status_text.set(runtime_message)
         elif self.is_logged_in:
             self.collaboration_status_text.set("IDE ready. Embedded MCP is stopped.")
@@ -6324,10 +6360,44 @@ class Swordfish(tk.Tk):
         operation_name="",
         busy_lease_token=None,
     ):
+        if is_busy:
+            # AI: A fast operation is usually finished - its lease already stale - by the time
+            # the Tk thread runs this handler. Record it anyway: the indicator owes every
+            # operation a minimum visible time and the status bar a durable trace, otherwise
+            # sub-second MCP activity is invisible exactly when it is most frequent.
+            self.note_mcp_activity(operation_name)
         if not self.busy_coordinator.is_current_lease(busy_lease_token):
+            if is_busy:
+                self.refresh_collaboration_status()
             return
         self.last_mcp_busy_state = is_busy
         self.refresh_collaboration_status()
+
+    def note_mcp_activity(self, operation_name):
+        self.activity_linger.note_activity()
+        self.last_seen_mcp_operation_name = operation_name or "unknown"
+        self.last_mcp_activity_text = "Last MCP: %s %s." % (
+            self.last_seen_mcp_operation_name,
+            datetime.now().strftime("%H:%M:%S"),
+        )
+        self.schedule_linger_expiry_refresh()
+
+    def schedule_linger_expiry_refresh(self):
+        '''AI: The linger expires silently - nothing else is guaranteed to refresh the status
+        bar afterwards - so schedule one refresh just past the hold to take the indicator
+        down. A newer activity replaces the pending refresh rather than stacking one per call.'''
+        if self.linger_refresh_after_id is not None:
+            try:
+                self.after_cancel(self.linger_refresh_after_id)
+            except tk.TclError:
+                pass
+        delay_milliseconds = (
+            int(self.activity_linger.minimum_visible_seconds * 1000) + 50
+        )
+        self.linger_refresh_after_id = self.after(
+            delay_milliseconds,
+            self.refresh_collaboration_status,
+        )
 
     def handle_mcp_server_state_changed(
         self,

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -5171,10 +5171,6 @@ class Swordfish(tk.Tk):
             self.handle_model_refresh_requested,
         )
         self.event_queue.subscribe(
-            'McpIdeNavigationRequested',
-            self.handle_mcp_ide_navigation_requested,
-        )
-        self.event_queue.subscribe(
             'OpenRunWindow',
             self.handle_open_run_window,
         )
@@ -7380,22 +7376,6 @@ class Swordfish(tk.Tk):
             "ok": False,
             "error": {"message": f"Unknown IDE navigation action: {action_name}."},
         }
-
-    def handle_mcp_ide_navigation_requested(
-        self,
-        action_name="",
-        action_parameters=None,
-        response_holder=None,
-        completion_event=None,
-    ):
-        response = self.execute_mcp_ide_navigation_action(
-            action_name,
-            action_parameters,
-        )
-        if response_holder is not None:
-            response_holder["response"] = response
-        if completion_event is not None:
-            completion_event.set()
 
     def perform_mcp_ide_navigation_action(self, action_name, action_parameters=None):
         if action_parameters is None:

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -10,11 +10,11 @@ import queue
 import re
 import sys
 import threading
+import time
 import tkinter as tk
 import tkinter.filedialog as filedialog
 import tkinter.messagebox as messagebox
 import tkinter.simpledialog as simpledialog
-import time
 import traceback
 import uuid
 import weakref

--- a/src/reahl/swordfish/mcp/server.py
+++ b/src/reahl/swordfish/mcp/server.py
@@ -34,8 +34,11 @@ gs_query_methods_by_ast_pattern returns node addresses, not method bodies.
 All code changes are explicit-transaction: call gs_begin first, then either
 the preview/apply pair pattern for refactorings (gs_preview_* before
 gs_apply_*) or direct gs_compile_method, then gs_commit (requires
-approval) or gs_abort. gs_eval is powerful and should be exceptional -
-prefer structured tools for routine work.
+approval) or gs_abort. To install several methods at once use
+gs_compile_methods, which batches them into one round-trip and reports a
+per-method outcome - prefer it over a loop of gs_compile_method calls.
+gs_eval is powerful and should be exceptional - prefer structured tools for
+routine work.
 
 The Smalltalk parser is always available - no install step is required for
 AST tools. Call gs_capabilities for the stable list of policy switches and

--- a/src/reahl/swordfish/mcp/session_serialization.py
+++ b/src/reahl/swordfish/mcp/session_serialization.py
@@ -1,0 +1,34 @@
+import contextlib
+import threading
+
+# AI: GCI is single-threaded per GemStone session: starting a second call before
+# the first returns raises error 2203 and the IDE surfaces it as a fatal GemStone
+# error. We give each connection a gate so that calls sharing one session pass
+# through one at a time, while calls on different sessions stay independent.
+
+gates_by_connection_id = {}
+registry_lock = threading.Lock()
+
+
+def gate_for_connection(connection_id):
+    with registry_lock:
+        existing_gate = gates_by_connection_id.get(connection_id)
+        if existing_gate is None:
+            existing_gate = threading.RLock()
+            gates_by_connection_id[connection_id] = existing_gate
+        return existing_gate
+
+
+@contextlib.contextmanager
+def exclusive_session_access(connection_id):
+    gate = gate_for_connection(connection_id)
+    gate.acquire()
+    try:
+        yield
+    finally:
+        gate.release()
+
+
+def clear_gates():
+    with registry_lock:
+        gates_by_connection_id.clear()

--- a/src/reahl/swordfish/mcp/session_serialization.py
+++ b/src/reahl/swordfish/mcp/session_serialization.py
@@ -1,32 +1,95 @@
 import contextlib
 import threading
 
-# AI: GCI is single-threaded per GemStone session: starting a second call before
-# the first returns raises error 2203 and the IDE surfaces it as a fatal GemStone
-# error. We give each connection a gate so that calls sharing one session pass
-# through one at a time, while calls on different sessions stay independent.
+# AI: GCI is single-threaded per GemStone session: starting a second call before the first
+# returns raises error 2203 and the IDE surfaces it as a fatal GemStone error. We serialize at the
+# granularity of whole *operations* (an MCP tool call, an IDE action) rather than individual GCI
+# calls, because an operation is several GCI calls that must not interleave with another operation.
+# An operation can span two threads - an MCP operation holds the session on its worker thread and
+# then drives IDE work on the Tk thread - so the gate is keyed by an operation token, not a thread,
+# and the same token re-enters instead of deadlocking against its own hold.
+
+
+class OperationGate:
+    """AI: Mutual exclusion keyed by an operation token rather than by a thread. A whole
+    operation holds the session under one token. A different token must wait (enter) or is refused
+    (try_enter); the same token re-enters without blocking, so an operation that spans two threads
+    never deadlocks on its own hold. Contention policy is to wait, matching the choice that the
+    loser blocks until free."""
+
+    def __init__(self):
+        self.condition = threading.Condition()
+        self.holder_token = None
+        self.hold_count = 0
+
+    def enter(self, operation_token):
+        with self.condition:
+            while self.hold_count > 0 and self.holder_token != operation_token:
+                self.condition.wait()
+            self.holder_token = operation_token
+            self.hold_count = self.hold_count + 1
+
+    def try_enter(self, operation_token):
+        with self.condition:
+            held_by_other = self.hold_count > 0 and self.holder_token != operation_token
+            admitted = not held_by_other
+            if admitted:
+                self.holder_token = operation_token
+                self.hold_count = self.hold_count + 1
+            return admitted
+
+    def leave(self, operation_token):
+        with self.condition:
+            self.hold_count = self.hold_count - 1
+            if self.hold_count == 0:
+                self.holder_token = None
+                self.condition.notify_all()
+
 
 gates_by_connection_id = {}
 registry_lock = threading.Lock()
+operation_context = threading.local()
 
 
-def gate_for_connection(connection_id):
+def operation_gate_for(connection_id):
     with registry_lock:
-        existing_gate = gates_by_connection_id.get(connection_id)
-        if existing_gate is None:
-            existing_gate = threading.RLock()
-            gates_by_connection_id[connection_id] = existing_gate
-        return existing_gate
+        gate = gates_by_connection_id.get(connection_id)
+        if gate is None:
+            gate = OperationGate()
+            gates_by_connection_id[connection_id] = gate
+        return gate
+
+
+def current_operation_token():
+    # AI: The operation token in force on the current thread, or None. The MCP worker thread sets
+    # it while a tool runs, so code it calls - notably driving IDE navigation - can carry the token
+    # to the Tk thread and re-enter the gate under the same operation rather than deadlocking.
+    return getattr(operation_context, 'token', None)
 
 
 @contextlib.contextmanager
-def exclusive_session_access(connection_id):
-    gate = gate_for_connection(connection_id)
-    gate.acquire()
+def session_operation(connection_id, operation_token):
+    # AI: Hold the session for the whole duration of one operation (blocking acquire). Safe to
+    # block here on the MCP worker thread; the Tk thread must use try_enter_session_operation.
+    gate = operation_gate_for(connection_id)
+    previous_token = getattr(operation_context, 'token', None)
+    gate.enter(operation_token)
+    operation_context.token = operation_token
     try:
         yield
     finally:
-        gate.release()
+        operation_context.token = previous_token
+        gate.leave(operation_token)
+
+
+def try_enter_session_operation(connection_id, operation_token):
+    # AI: Non-blocking acquire for the Tk thread, which also services MCP-driven navigation and so
+    # must never block. A False answer means another operation holds the session; defer the work.
+    return operation_gate_for(connection_id).try_enter(operation_token)
+
+
+def leave_session_operation(connection_id, operation_token):
+    operation_gate_for(connection_id).leave(operation_token)
 
 
 def clear_gates():

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -43,6 +43,7 @@ from reahl.swordfish.mcp.session_registry import (
     has_connection,
     remove_connection,
 )
+from reahl.swordfish.mcp.session_serialization import exclusive_session_access
 from reahl.swordfish.mcp.tracer_assets import (
     TRACER_VERSION,
     tracer_source,
@@ -138,17 +139,25 @@ def register_tools(
         def coordinated_tool_decorator(function):
             @functools.wraps(function)
             def coordinated_tool(*function_arguments, **function_keywords):
-                integrated_session_state.begin_mcp_operation(function.__name__)
-                try:
-                    tool_result = function(*function_arguments, **function_keywords)
-                    if should_refresh_model(function.__name__, tool_result):
-                        integrated_session_state.request_model_refresh("transaction")
-                    notices = integrated_session_state.consume_config_change_notices()
-                    if notices and isinstance(tool_result, dict):
-                        tool_result = dict(tool_result, config_change_notices=notices)
-                    return tool_result
-                finally:
-                    integrated_session_state.end_mcp_operation()
+                connection_id = function_keywords.get("connection_id")
+                with exclusive_session_access(connection_id):
+                    integrated_session_state.begin_mcp_operation(function.__name__)
+                    try:
+                        tool_result = function(
+                            *function_arguments, **function_keywords
+                        )
+                        if should_refresh_model(function.__name__, tool_result):
+                            integrated_session_state.request_model_refresh("transaction")
+                        notices = (
+                            integrated_session_state.consume_config_change_notices()
+                        )
+                        if notices and isinstance(tool_result, dict):
+                            tool_result = dict(
+                                tool_result, config_change_notices=notices
+                            )
+                        return tool_result
+                    finally:
+                        integrated_session_state.end_mcp_operation()
 
             return tool_decorator(coordinated_tool)
 

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -43,7 +43,7 @@ from reahl.swordfish.mcp.session_registry import (
     has_connection,
     remove_connection,
 )
-from reahl.swordfish.mcp.session_serialization import exclusive_session_access
+from reahl.swordfish.mcp.session_serialization import session_operation
 from reahl.swordfish.mcp.tracer_assets import (
     TRACER_VERSION,
     tracer_source,
@@ -140,7 +140,8 @@ def register_tools(
             @functools.wraps(function)
             def coordinated_tool(*function_arguments, **function_keywords):
                 connection_id = function_keywords.get("connection_id")
-                with exclusive_session_access(connection_id):
+                operation_token = ("mcp", function.__name__, uuid.uuid4().hex)
+                with session_operation(connection_id, operation_token):
                     integrated_session_state.begin_mcp_operation(function.__name__)
                     try:
                         tool_result = function(

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -562,6 +562,40 @@ def register_tools(
                 return False
         raise DomainException("%s must be a boolean." % argument_name)
 
+    def validated_compile_method_specs(methods):
+        if not isinstance(methods, list):
+            raise DomainException("methods must be a list.")
+        if not methods:
+            raise DomainException("methods cannot be empty.")
+        method_specs = []
+        for index, entry in enumerate(methods):
+            if not isinstance(entry, dict):
+                raise DomainException("methods[%s] must be an object." % index)
+            class_name = validated_identifier(
+                entry.get("class_name"), "methods[%s].class_name" % index
+            )
+            source = validated_non_empty_string(
+                entry.get("source"), "methods[%s].source" % index
+            )
+            show_instance_side = validated_boolean_like(
+                entry.get("show_instance_side", True),
+                "methods[%s].show_instance_side" % index,
+            )
+            method_category = entry.get("method_category")
+            if method_category is not None:
+                method_category = validated_non_empty_string(
+                    method_category, "methods[%s].method_category" % index
+                )
+            in_dictionary = entry.get("in_dictionary")
+            if in_dictionary is not None:
+                in_dictionary = validated_non_empty_string_stripped(
+                    in_dictionary, "methods[%s].in_dictionary" % index
+                )
+            method_specs.append(
+                (class_name, show_instance_side, source, method_category, in_dictionary)
+            )
+        return method_specs
+
     def validated_sender_granularity(input_value):
         if input_value in ('identifier', 'send_site', 'method'):
             return input_value
@@ -4433,6 +4467,64 @@ def register_tools(
                 "show_instance_side": show_instance_side,
                 "method_category": method_category,
                 "in_dictionary": in_dictionary,
+            }
+        except GemstoneError as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": gemstone_error_payload(error),
+            }
+        except GemstoneApiError as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": {"message": str(error)},
+            }
+        except DomainException as error:
+            return {
+                "ok": False,
+                "connection_id": connection_id,
+                "error": {"message": str(error)},
+            }
+
+    @mcp_server.tool()
+    def gs_compile_methods(
+        connection_id,
+        methods,
+    ):
+        """Compile many methods into classes in a single batched round-trip
+        instead of one call per method. `methods` is a non-empty list of entries,
+        each {class_name, source, show_instance_side?, method_category?,
+        in_dictionary?}. The class hierarchy is rebuilt once after the whole
+        batch. When method_category is omitted an existing method keeps its
+        current protocol and a brand-new method is filed under 'as yet
+        unclassified'. A compile error or missing class in one entry leaves the
+        others installed and is reported in that entry's result row rather than
+        aborting the batch. Prefer this over repeated gs_compile_method calls when
+        editing several methods at once. Requires --allow-source-write and an
+        active transaction."""
+        if not get_permissions()['allow_source_write']:
+            return disabled_tool_response(
+                connection_id,
+                (
+                    "gs_compile_methods is disabled. "
+                    "Start swordfish --headless-mcp with --allow-source-write to enable."
+                ),
+            )
+        gemstone_session, error_response = get_active_session(connection_id)
+        if error_response:
+            return error_response
+        transaction_error_response = require_active_transaction(connection_id)
+        if transaction_error_response:
+            return transaction_error_response
+        browser_session = browser_session_for_policy(gemstone_session)
+        try:
+            method_specs = validated_compile_method_specs(methods)
+            results = browser_session.compile_methods(method_specs)
+            return {
+                "ok": all(row["ok"] for row in results),
+                "connection_id": connection_id,
+                "results": results,
             }
         except GemstoneError as error:
             return {

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -4,7 +4,7 @@ import re
 import threading
 import time
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from reahl.ptongue import GemstoneApiError, GemstoneError
 
@@ -2477,6 +2477,7 @@ def register_tools(
                     "gs_create_dictionary",
                     "gs_install_package",
                     "gs_compile_method",
+                    "gs_compile_methods",
                     "gs_create_class",
                     "gs_create_class_in_package",
                     "gs_create_test_case_class",
@@ -4490,7 +4491,7 @@ def register_tools(
     @mcp_server.tool()
     def gs_compile_methods(
         connection_id,
-        methods,
+        methods: List[Dict[str, Any]],
     ):
         """Compile many methods into classes in a single batched round-trip
         instead of one call per method. `methods` is a non-empty list of entries,

--- a/tests/test_event_drain_serialization.py
+++ b/tests/test_event_drain_serialization.py
@@ -1,0 +1,71 @@
+import tkinter as tk
+
+from reahl.tofu import Fixture, set_up, tear_down, with_fixtures
+
+from reahl.swordfish.main import EventQueue
+
+
+class Recorder:
+    """AI: Records how many times the drain actually invoked the handler."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def note(self):
+        self.calls = self.calls + 1
+
+
+class GatedAdmission:
+    """AI: Stand-in for SessionOperationAdmission whose admit/deny we flip by hand, so the test
+    pins the drain's decision rather than racing a real MCP operation. A token means admitted; None
+    means an operation holds the session."""
+
+    def __init__(self):
+        self.admits = True
+
+    def try_admit(self):
+        if self.admits:
+            return ('ide-token',)
+        return None
+
+    def release(self, operation_token):
+        pass
+
+
+class DrainFixture(Fixture):
+    @set_up
+    def set_up_event_queue(self):
+        self.root = tk.Tk()
+        self.event_queue = EventQueue(self.root)
+        self.admission = GatedAdmission()
+        self.event_queue.session_admission = self.admission
+        self.recorder = Recorder()
+        self.event_queue.subscribe('ProbeEvent', self.recorder.note)
+
+    @tear_down
+    def tear_down_event_queue(self):
+        self.root.destroy()
+
+
+@with_fixtures(DrainFixture)
+def test_drain_runs_handlers_when_the_session_is_free(fixture):
+    """AI: With nothing holding the session the drain admits immediately and runs its handlers in
+    line, so ordinary IDE work is not slowed when no MCP operation competes for the session."""
+    fixture.event_queue.publish('ProbeEvent')
+
+    assert fixture.recorder.calls == 1
+
+
+@with_fixtures(DrainFixture)
+def test_drain_defers_handlers_while_an_operation_holds_the_session(fixture):
+    """AI: The IDE event drain must not run its GCI-bearing handlers while an MCP operation holds
+    the session - their GCI would collide with the operation's (error 2203, the crash). While the
+    session is busy the drain defers and the event is not lost; once the session is free the same
+    handlers run."""
+    fixture.admission.admits = False
+    fixture.event_queue.publish('ProbeEvent')
+    assert fixture.recorder.calls == 0
+
+    fixture.admission.admits = True
+    fixture.event_queue.process_events()
+    assert fixture.recorder.calls == 1

--- a/tests/test_gemstone_browser_compile_methods.py
+++ b/tests/test_gemstone_browser_compile_methods.py
@@ -1,0 +1,278 @@
+'''AI: Tests for the batched compile primitive GemstoneBrowserSession.compile_methods - the single
+compile path that gs_compile_methods (bulk authoring) and compile_method_in_dictionary both route
+through. The GemStone-side leaves (run_compile_chunk, existing_method_source, mirror_compiled_method)
+are stubbed; the orchestration - selector parsing, chunking, input-order preservation, server-side
+program text and the mirroring decision - is real. Each test isolates one insight about how a batch
+behaves so the round-trip-collapsing rewrite stays honest.'''
+
+import os
+
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+from reahl.swordfish.gemstone.working_copy import point_working_copy_at
+
+
+class FakeGemValue:
+    '''AI: Stands in for a parseltongue leaf proxy whose to_py yields the Python value, so
+    parsed_compile_chunk_results can be exercised without a live gem.'''
+
+    def __init__(self, value):
+        self.value = value
+
+    @property
+    def to_py(self):
+        return self.value
+
+
+class FakeGemArray:
+    '''AI: Stands in for a gem-side Array/OrderedCollection proxy, answering size/at: the way the
+    real result is traversed - nested lists become FakeGemArrays, scalars become FakeGemValues.'''
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def size(self):
+        return FakeGemValue(len(self.rows))
+
+    def at(self, index):
+        element = self.rows[index - 1]
+        if isinstance(element, list):
+            return FakeGemArray(element)
+        return FakeGemValue(element)
+
+
+class StringBuildingFixture(Fixture):
+    def new_browser_session(self):
+        return GemstoneBrowserSession(None)
+
+
+class TargetClassExpressionScenarios(Fixture):
+    @scenario
+    def no_dictionary_resolves_via_symbol_list(self):
+        '''AI: With no dictionary named, the class is resolved across the whole symbol list, the
+        same reach an ordinary recompile has.'''
+        self.in_dictionary = None
+        self.expected_fragment = "System myUserProfile symbolList objectNamed: 'Account' asSymbol"
+
+    @scenario
+    def identifier_dictionary_resolves_via_that_dictionary(self):
+        '''AI: A named dictionary scopes the lookup to that dictionary, reusing
+        dictionary_reference_expression, and tolerates an absent class with otherwise: nil so a
+        missing class is one row's error, not a chunk-wide failure.'''
+        self.in_dictionary = 'UserGlobals'
+        self.expected_fragment = "(UserGlobals at: 'Account' asSymbol otherwise: nil)"
+
+    @scenario
+    def non_identifier_dictionary_resolves_via_object_named(self):
+        '''AI: A dictionary name that is not a bare identifier still resolves, because
+        dictionary_reference_expression falls back to objectNamed: for it.'''
+        self.in_dictionary = 'Weird Dict'
+        self.expected_fragment = "objectNamed: 'Weird Dict' asSymbol"
+
+
+@with_fixtures(StringBuildingFixture, TargetClassExpressionScenarios)
+def test_target_class_expression_resolution(fixture, scenario):
+    '''AI: The expression that finds the class to compile into depends only on whether a dictionary
+    is named and what shape its name has - this is the seam that consolidated the dictionary-scoped
+    compile onto the batch.'''
+    expression = fixture.browser_session.target_class_expression('Account', scenario.in_dictionary)
+
+    assert scenario.expected_fragment in expression
+
+
+@with_fixtures(StringBuildingFixture)
+def test_compile_spec_element_emits_dynamic_array_with_escaped_source(fixture):
+    '''AI: Each spec becomes a dynamic array element so its booleans and nils are real objects, the
+    class-side flag rides along, and a source containing a quote survives by quote-doubling rather
+    than corrupting the program.'''
+    element = fixture.browser_session.compile_spec_element(
+        'Account', False, 'name:', "name: aName\n\t^x isn't y", None, None
+    )
+
+    assert element.startswith('{') and element.endswith('}')
+    assert "'Account'" in element
+    assert "'name:'" in element
+    assert ' false.' in element
+    assert "isn''t" in element
+    assert element.rstrip().endswith('nil }')
+
+
+@with_fixtures(StringBuildingFixture)
+def test_batch_program_fetches_symbol_list_once_and_preserves_protocol(fixture):
+    '''AI: The chunk program is what makes a batch one round-trip and protocol-safe: it fetches the
+    symbol list a single time and, when a category is omitted, keeps an existing method's protocol
+    server-side rather than reclassifying it.'''
+    program = fixture.browser_session.batch_compile_program("{ 'A'. nil. 'm'. true. 's'. nil }")
+
+    assert program.count('System myUserProfile symbolList') == 1
+    assert 'includesSelector:' in program
+    assert 'categoryOfSelector:' in program
+    assert 'as yet unclassified' in program
+    assert 'compileMethod:' in program
+
+
+@with_fixtures(StringBuildingFixture)
+def test_parsed_compile_chunk_results_maps_arrays_to_rows(fixture):
+    '''AI: The gem returns one six-element array per method; parsing turns each into a result row,
+    carrying a success and a not-found outcome back unchanged.'''
+    raw = FakeGemArray([
+        ['Account', 'name', True, 'accessing', True, ''],
+        ['Bank', 'foo', False, '', False, 'Class not found.'],
+    ])
+
+    rows = fixture.browser_session.parsed_compile_chunk_results(raw)
+
+    assert rows[0] == {
+        'class_name': 'Account', 'selector': 'name', 'show_instance_side': True,
+        'method_category': 'accessing', 'ok': True, 'error': '',
+    }
+    assert rows[1]['ok'] is False
+    assert rows[1]['error'] == 'Class not found.'
+
+
+@stubclass(GemstoneBrowserSession)
+class ChunkRecordingBrowserSession(GemstoneBrowserSession):
+    '''AI: Replaces only the gem round-trip: records each chunk it is handed and reports every spec
+    in it as a successful compile, so orchestration - parse filtering, chunk boundaries and input
+    order - can be observed without an image. stubclass keeps run_compile_chunk's signature honest.'''
+
+    recorded_chunks = None
+
+    def run_compile_chunk(self, chunk):
+        self.recorded_chunks.append(list(chunk))
+        return [
+            self.compile_result_row(
+                entry[1], entry[3], entry[2],
+                entry[5] if entry[5] is not None else 'as yet unclassified',
+                True, '',
+            )
+            for entry in chunk
+        ]
+
+
+def chunk_recording_session(tmp_path, monkeypatch):
+    '''AI: A recording session with FileTree sync pointed at an absent config, so mirroring is
+    inert and these tests observe only the compile orchestration.'''
+    monkeypatch.setenv('SWORDFISH_FILETREE_SYNC_CONFIG', os.path.join(str(tmp_path), 'config.json'))
+    session = ChunkRecordingBrowserSession(None)
+    session.recorded_chunks = []
+    return session
+
+
+def test_unparseable_source_becomes_error_row_without_reaching_gem(tmp_path, monkeypatch):
+    '''AI: A source whose method cannot be parsed never reaches the gem - it becomes that row's
+    error here, while its well-formed siblings still compile, so one bad paste cannot block a batch
+    or be blamed on the image.'''
+    session = chunk_recording_session(tmp_path, monkeypatch)
+
+    results = session.compile_methods([
+        ('Account', True, '123 not a method', None, None),
+        ('Account', True, 'name\n\t^x', None, None),
+    ])
+
+    assert results[0]['ok'] is False
+    assert 'parseable' in results[0]['error']
+    assert results[1]['ok'] is True
+    assert len(session.recorded_chunks) == 1
+    assert len(session.recorded_chunks[0]) == 1
+    assert session.recorded_chunks[0][0][3] == 'name'
+
+
+def test_results_preserve_input_order_across_chunks_and_parse_failures(tmp_path, monkeypatch):
+    '''AI: Results come back in input order regardless of chunk boundaries or rows that never left
+    Python, so a caller can zip results to its own list without tracking which specs were sent.'''
+    session = chunk_recording_session(tmp_path, monkeypatch)
+
+    results = session.compile_methods(
+        [
+            ('Account', True, 'a\n\t^1', None, None),
+            ('Account', True, '123 not a method', None, None),
+            ('Account', True, 'b\n\t^2', None, None),
+            ('Account', True, 'c\n\t^3', None, None),
+        ],
+        chunk_size=2,
+    )
+
+    assert [row['selector'] for row in results] == ['a', '', 'b', 'c']
+    assert [row['ok'] for row in results] == [True, False, True, True]
+    assert len(session.recorded_chunks) == 2
+
+
+def test_large_batch_is_split_into_bounded_chunks(tmp_path, monkeypatch):
+    '''AI: A batch larger than the chunk size is sent as several bounded programs, not one
+    unbounded one - the bound that keeps each round-trip's allocation from pressuring the gem's
+    garbage collector.'''
+    session = chunk_recording_session(tmp_path, monkeypatch)
+    specs = [('Account', True, 'm%s\n\t^%s' % (index, index), None, None) for index in range(120)]
+
+    results = session.compile_methods(specs, chunk_size=50)
+
+    assert len(results) == 120
+    assert [len(chunk) for chunk in session.recorded_chunks] == [50, 50, 20]
+
+
+@stubclass(GemstoneBrowserSession)
+class MirroringRecordingBrowserSession(GemstoneBrowserSession):
+    '''AI: Replaces the gem compile and the mirror's own gem queries, recording which methods the
+    batch asks the on-disk mirror to update so we can prove the batch funnels through the same
+    mirroring everything else uses.'''
+
+    recorded_mirror_calls = None
+
+    def run_compile_chunk(self, chunk):
+        return [
+            self.compile_result_row(entry[1], entry[3], entry[2], 'accessing', True, '')
+            for entry in chunk
+        ]
+
+    def existing_method_source(self, class_name, selector, show_instance_side):
+        return None
+
+    def mirror_compiled_method(
+        self, class_name, show_instance_side, source, method_category, selector, previous_source
+    ):
+        self.recorded_mirror_calls.append((class_name, selector, method_category))
+        return None
+
+
+def test_successful_rows_are_mirrored_when_sync_is_active(tmp_path, monkeypatch):
+    '''AI: When FileTree sync is on, each method a batch successfully compiles is mirrored to disk -
+    the batch must not be a back door that edits the image without updating the working copy.'''
+    monkeypatch.setenv('SWORDFISH_FILETREE_SYNC_CONFIG', os.path.join(str(tmp_path), 'config.json'))
+    root = os.path.join(str(tmp_path), 'monticello')
+    os.makedirs(root)
+    point_working_copy_at(root)
+    session = MirroringRecordingBrowserSession(None)
+    session.recorded_mirror_calls = []
+
+    session.compile_methods([('Account', True, 'name\n\t^x', None, None)])
+
+    assert session.recorded_mirror_calls == [('Account', 'name', 'accessing')]
+
+
+@stubclass(GemstoneBrowserSession)
+class SpecCapturingBrowserSession(GemstoneBrowserSession):
+    '''AI: Captures the spec list compile_method_in_dictionary builds, so its delegation to the
+    batch primitive can be pinned exactly.'''
+
+    captured_specs = None
+
+    def compile_methods(self, method_specs, chunk_size=50):
+        self.captured_specs = method_specs
+        return [self.compile_result_row('Account', 'name', True, 'accessing', True, '')]
+
+
+@with_fixtures(StringBuildingFixture)
+def test_compile_method_in_dictionary_delegates_with_protocol_preserving_category(fixture):
+    '''AI: A dictionary-scoped compile is now a one-element batch. Crucially this is a deliberate
+    behaviour change: the old standalone version always filed an omitted category under "as yet
+    unclassified", whereas delegating with method_category=None routes it through the batch's
+    server-side preserve-or-default, so an existing method keeps its protocol.'''
+    session = SpecCapturingBrowserSession(None)
+
+    row = session.compile_method_in_dictionary('Account', 'UserGlobals', True, 'name\n\t^x')
+
+    assert session.captured_specs == [('Account', True, 'name\n\t^x', None, 'UserGlobals')]
+    assert row['ok'] is True

--- a/tests/test_gemstone_browser_extract.py
+++ b/tests/test_gemstone_browser_extract.py
@@ -275,9 +275,7 @@ def test_get_class_definition_treats_class_as_root_when_superclass_proxy_unavail
 def test_list_methods_returns_empty_for_categories_that_cannot_be_queried():
     """AI: When selectorsIn: raises a GemstoneError (e.g. *bootstrap-caching internal category), list_methods should return [] rather than crashing the method listing."""
     browser_session = GemstoneBrowserSession(None)
-    mock_class = Mock()
-    mock_class.selectorsIn.side_effect = FakeGemstoneError()
-    browser_session.class_to_query = Mock(return_value=mock_class)
+    browser_session.run_code = Mock(side_effect=FakeGemstoneError())
 
     with expected(NoException):
         result = browser_session.list_methods('Object', '*bootstrap-caching', False)

--- a/tests/test_gemstone_browser_move_and_param_preview.py
+++ b/tests/test_gemstone_browser_move_and_param_preview.py
@@ -34,6 +34,21 @@ class MoveAndParamPreviewFixture(Fixture):
             def fake_compile_method(**kwargs):
                 self.recompiled_methods.append(kwargs)
 
+            def fake_compile_methods(method_specs, chunk_size=50):
+                # AI: The batched compile seam records each spec in the same shape as a single
+                # compile, so assertions that read recompiled_methods stay valid whether a
+                # refactoring installs one method or a whole batch.
+                for class_name, show_instance_side, source, method_category, in_dictionary in method_specs:
+                    self.recompiled_methods.append(
+                        {
+                            'class_name': class_name,
+                            'show_instance_side': show_instance_side,
+                            'source': source,
+                            'method_category': method_category,
+                        }
+                    )
+                return []
+
             def fake_delete_method(class_name, method_selector, show_instance_side):
                 self.deleted_methods.append(
                     (class_name, method_selector, show_instance_side)
@@ -73,6 +88,7 @@ class MoveAndParamPreviewFixture(Fixture):
             self.browser_session.get_method_source = fake_get_method_source
             self.browser_session.get_method_category = fake_get_method_category
             self.browser_session.compile_method = fake_compile_method
+            self.browser_session.compile_methods = fake_compile_methods
             self.browser_session.delete_method = fake_delete_method
             self.browser_session.selector_occurrence_summaries = (
                 fake_selector_occurrence_summaries

--- a/tests/test_gemstone_browser_packages.py
+++ b/tests/test_gemstone_browser_packages.py
@@ -1,4 +1,4 @@
-from reahl.tofu import Fixture, with_fixtures
+from reahl.tofu import Fixture, scenario, with_fixtures
 
 from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
 
@@ -8,98 +8,19 @@ class NameProxy:
         self.to_py = value
 
 
-class BooleanProxy:
-    def __init__(self, value):
-        self.to_py = value
+class RecordingListingBrowserSession(GemstoneBrowserSession):
+    """AI: Stubs run_code at the GCI boundary with a canned lf-joined reply (the shape the
+    server-side join produces) and records every executed source, so tests can assert both
+    the parsed result and that a listing costs exactly one server round trip."""
 
-
-class SymbolDictionaryStub:
-    def __init__(self, dictionary_name):
-        self.dictionary_name = dictionary_name
-
-    def name(self):
-        return NameProxy(self.dictionary_name)
-
-    def isBehavior(self):
-        return BooleanProxy(False)
-
-
-class GemstoneClassStub:
-    def __init__(self, class_name):
-        self.class_name = class_name
-
-    def name(self):
-        return NameProxy(self.class_name)
-
-    def isBehavior(self):
-        return BooleanProxy(True)
-
-
-class NonClassEntryStub:
-    def __init__(self, name):
-        self.name_value = name
-
-    def name(self):
-        return NameProxy(self.name_value)
-
-    def isBehavior(self):
-        return BooleanProxy(False)
-
-
-class CategoriesStub:
-    def __init__(self, classes_by_category):
-        self.classes_by_category = classes_by_category
-
-    def keys(self):
-        return [NameProxy(category_name) for category_name in self.classes_by_category]
-
-    def at(self, category_name):
-        return self.classes_by_category[category_name]
-
-
-class ClassOrganizerStub:
-    def __init__(self, classes_by_category):
-        self.classes_by_category = classes_by_category
-
-    def categories(self):
-        return CategoriesStub(self.classes_by_category)
-
-
-class PackageLibraryStub:
-    def __init__(self, package_entries, classes_by_package):
-        self.package_entries = [
-            SymbolDictionaryStub(package_name) for package_name in package_entries
-        ]
-        self.classes_by_package = classes_by_package
-
-    def __iter__(self):
-        return iter(self.package_entries)
-
-    def objectNamed(self, package_name):
-        return self.classes_by_package[package_name]
-
-
-class StubbedClassOrganizerBrowserSession(GemstoneBrowserSession):
-    def __init__(
-        self,
-        classes_by_package,
-        package_library_names,
-        package_dictionary_entries_by_package,
-    ):
+    def __init__(self, joined_reply=""):
         super().__init__(None)
-        self.organizer = ClassOrganizerStub(classes_by_package)
-        self.library_entries = PackageLibraryStub(
-            package_library_names,
-            package_dictionary_entries_by_package,
-        )
+        self.joined_reply = joined_reply
+        self.executed_sources = []
 
-    @property
-    def class_organizer(self):
-        return self.organizer
-
-    @property
-    def package_library(self):
-        return self.library_entries
+    def run_code(self, source):
+        self.executed_sources.append(source)
+        return NameProxy(self.joined_reply)
 
 
 class StubbedDictionaryBrowserSession(GemstoneBrowserSession):
@@ -115,11 +36,11 @@ class StubbedDictionaryBrowserSession(GemstoneBrowserSession):
     def run_code(self, source):
         self.executed_sources.append(source)
         if "System myUserProfile symbolList do:" in source:
-            return [NameProxy(name) for name in self.dictionary_names]
+            return NameProxy("\n".join(self.dictionary_names))
         dictionary_literal = source.split("dictionaryName := ")[1].split(".\n", 1)[0]
         dictionary_name = self.smalltalk_string_value(dictionary_literal)
         class_names = self.class_names_by_dictionary.get(dictionary_name, [])
-        return [NameProxy(class_name) for class_name in class_names]
+        return NameProxy("\n".join(class_names))
 
 
 class SourceCapturingBrowserSession(GemstoneBrowserSession):
@@ -132,27 +53,9 @@ class SourceCapturingBrowserSession(GemstoneBrowserSession):
         return source
 
 
-class BrowserPackagesFixture(Fixture):
+class BrowserListingFixture(Fixture):
     def new_browser_session(self):
-        return StubbedClassOrganizerBrowserSession(
-            {
-                "Kernel": [
-                    GemstoneClassStub("Object"),
-                    GemstoneClassStub("Behavior"),
-                ]
-            },
-            [
-                "Stuff",
-                "Wonka-thing",
-            ],
-            {
-                "Stuff": [NonClassEntryStub("Stuff")],
-                "Wonka-thing": [
-                    GemstoneClassStub("WonkaThingTest"),
-                    NonClassEntryStub("Wonka-thing"),
-                ],
-            },
-        )
+        return RecordingListingBrowserSession()
 
 
 class BrowserDictionariesFixture(Fixture):
@@ -176,46 +79,160 @@ class BrowserSourceCaptureFixture(Fixture):
         return SourceCapturingBrowserSession()
 
 
-@with_fixtures(BrowserPackagesFixture)
+@with_fixtures(BrowserListingFixture)
 def test_list_classes_in_category_returns_empty_for_unknown_category(
-    browser_packages_fixture,
+    browser_listing_fixture,
 ):
-    """AI: Listing classes for a missing category should return an empty list."""
-    assert (
-        browser_packages_fixture.browser_session.list_classes_in_category("Nope") == []
-    )
+    """AI: Listing classes for a missing category should return an empty list: the server
+    program answers an empty string via at:ifAbsent: rather than raising."""
+    browser_session = browser_listing_fixture.browser_session
+    assert browser_session.list_classes_in_category("Nope") == []
+    assert "ifAbsent:" in browser_session.executed_sources[0]
 
 
-@with_fixtures(BrowserPackagesFixture)
-def test_list_classes_in_category_returns_class_names_for_known_category(
-    browser_packages_fixture,
+@with_fixtures(BrowserListingFixture)
+def test_list_classes_in_category_returns_sorted_class_names_for_known_category(
+    browser_listing_fixture,
 ):
-    """AI: Listing classes for a known category should return that category's class names."""
-    assert browser_packages_fixture.browser_session.list_classes_in_category(
-        "Kernel"
-    ) == [
+    """AI: Listing classes for a known category should return that category's class names,
+    sorted, regardless of the order the server emits them in."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.joined_reply = "Object\nBehavior"
+    assert browser_session.list_classes_in_category("Kernel") == [
         "Behavior",
         "Object",
     ]
 
 
-@with_fixtures(BrowserPackagesFixture)
-def test_list_classes_in_category_ignores_package_library_entries(
-    browser_packages_fixture,
+@with_fixtures(BrowserListingFixture)
+def test_class_listings_consult_class_organizer_not_package_library(
+    browser_listing_fixture,
 ):
-    """AI: Category class listing should not include classes discovered only from package dictionaries."""
-    assert (
-        browser_packages_fixture.browser_session.list_classes_in_category("Wonka-thing")
-        == []
-    )
+    """AI: Category class listing must come from ClassOrganizer's categories only; classes
+    discovered via package dictionaries (GsPackageLibrary) do not belong in it."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.list_classes_in_category("Wonka-thing")
+    executed_source = browser_session.executed_sources[0]
+    assert "ClassOrganizer new categories" in executed_source
+    assert "GsPackageLibrary" not in executed_source
 
 
-@with_fixtures(BrowserPackagesFixture)
+@with_fixtures(BrowserListingFixture)
 def test_list_categories_only_returns_class_organizer_categories(
-    browser_packages_fixture,
+    browser_listing_fixture,
 ):
     """AI: Category listing should only return categories from ClassOrganizer."""
-    assert browser_packages_fixture.browser_session.list_categories() == ["Kernel"]
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.joined_reply = "Kernel"
+    assert browser_session.list_categories() == ["Kernel"]
+    executed_source = browser_session.executed_sources[0]
+    assert "ClassOrganizer new categories" in executed_source
+    assert "GsPackageLibrary" not in executed_source
+
+
+@with_fixtures(BrowserListingFixture)
+def test_list_method_categories_prepends_the_all_pseudo_category(
+    browser_listing_fixture,
+):
+    """AI: The 'all' pseudo-category is an IDE concept, prepended client-side; the server
+    only reports the class's real protocol names."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.joined_reply = "accessing\ntesting"
+    assert browser_session.list_method_categories("Order", True) == [
+        "all",
+        "accessing",
+        "testing",
+    ]
+
+
+@with_fixtures(BrowserListingFixture)
+def test_method_listings_address_the_class_side_when_asked(browser_listing_fixture):
+    """AI: Listing for the class side must query the metaclass: the server expression
+    addresses '<class> class', not the class itself."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.list_method_categories("Order", False)
+    assert " class " in browser_session.executed_sources[0]
+    browser_session.list_methods("Order", "all", False)
+    assert " class " in browser_session.executed_sources[1]
+
+
+@with_fixtures(BrowserListingFixture)
+def test_list_methods_for_all_lists_every_selector(browser_listing_fixture):
+    """AI: The 'all' pseudo-category lists the selectors of every protocol of the class."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.joined_reply = "total\ndescription"
+    assert browser_session.list_methods("Order", "all", True) == [
+        "total",
+        "description",
+    ]
+    assert "selectors" in browser_session.executed_sources[0]
+    assert "selectorsIn:" not in browser_session.executed_sources[0]
+
+
+@with_fixtures(BrowserListingFixture)
+def test_list_methods_for_a_real_category_queries_that_category(
+    browser_listing_fixture,
+):
+    """AI: A real protocol name restricts the listing to that protocol's selectors."""
+    browser_session = browser_listing_fixture.browser_session
+    browser_session.joined_reply = "total"
+    assert browser_session.list_methods("Order", "accessing", True) == ["total"]
+    executed_source = browser_session.executed_sources[0]
+    assert "selectorsIn:" in executed_source
+    assert "'accessing'" in executed_source
+
+
+class ListingCallScenarios(Fixture):
+    @scenario
+    def categories(self):
+        """AI: Listing all class categories of the image."""
+        self.make_listing_call = lambda browser_session: browser_session.list_categories()
+
+    @scenario
+    def classes_in_category(self):
+        """AI: Listing the classes of one category."""
+        self.make_listing_call = lambda browser_session: (
+            browser_session.list_classes_in_category("Kernel")
+        )
+
+    @scenario
+    def dictionaries(self):
+        """AI: Listing the symbol dictionaries of the user."""
+        self.make_listing_call = lambda browser_session: (
+            browser_session.list_dictionaries()
+        )
+
+    @scenario
+    def classes_in_dictionary(self):
+        """AI: Listing the classes of one symbol dictionary."""
+        self.make_listing_call = lambda browser_session: (
+            browser_session.list_classes_in_dictionary("UserGlobals")
+        )
+
+    @scenario
+    def method_categories(self):
+        """AI: Listing the protocols of a class."""
+        self.make_listing_call = lambda browser_session: (
+            browser_session.list_method_categories("Order", True)
+        )
+
+    @scenario
+    def methods(self):
+        """AI: Listing the selectors of a protocol."""
+        self.make_listing_call = lambda browser_session: (
+            browser_session.list_methods("Order", "all", True)
+        )
+
+
+@with_fixtures(BrowserListingFixture, ListingCallScenarios)
+def test_browsing_listings_cost_one_round_trip(browser_listing_fixture, scenario):
+    """AI: Every browsing listing must transfer its names as one lf-joined string in a
+    single server round trip. Per-element proxy fetches make UI latency scale with the
+    size of the package or class being browsed (hundreds of round trips for Kernel)."""
+    browser_session = browser_listing_fixture.browser_session
+    scenario.make_listing_call(browser_session)
+    assert len(browser_session.executed_sources) == 1
+    assert "(String with: Character lf) join:" in browser_session.executed_sources[0]
 
 
 @with_fixtures(BrowserDictionariesFixture)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1757,6 +1757,62 @@ def test_method_inheritance_hierarchy_refreshes_on_method_selection_change(fixtu
 
 
 @with_fixtures(SwordfishGuiFixture)
+def test_method_hierarchy_sync_is_not_mistaken_for_a_user_jump(fixture):
+    """AI: Selecting a method programmatically syncs the hierarchy tree selection, which makes
+    ttk queue <<TreeviewSelect>> events for later delivery. Those echoes must not be treated
+    as the user jumping to a class: the selection already matches the session state, so no
+    jump (and none of its GemStone lookups) may be triggered."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    methods_widget = fixture.browser_window.methods_widget
+    methods_widget.show_method_hierarchy_var.set(True)
+    methods_widget.toggle_method_hierarchy()
+    fixture.root.update()
+    fixture.mock_browser.get_method_category.reset_mock()
+
+    methods_listbox = methods_widget.selection_list.selection_listbox
+    methods_listbox.selection_clear(0, "end")
+    fixture.select_in_listbox(
+        methods_listbox,
+        "description",
+    )
+    fixture.root.update()
+
+    fixture.mock_browser.get_method_category.assert_not_called()
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_selecting_a_method_preserves_the_all_category_selection(fixture):
+    """AI: Clicking a method while browsing the 'all' pseudo-category must not narrow the
+    category selection to the method's home category."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    fixture.select_in_listbox(
+        fixture.browser_window.classes_widget.selection_list.selection_listbox,
+        "OrderLine",
+    )
+    fixture.select_in_listbox(
+        fixture.browser_window.categories_widget.selection_list.selection_listbox,
+        "all",
+    )
+    assert fixture.session_record.selected_method_category == "all"
+    methods_widget = fixture.browser_window.methods_widget
+    methods_widget.show_method_hierarchy_var.set(True)
+    methods_widget.toggle_method_hierarchy()
+    fixture.root.update()
+
+    fixture.select_in_listbox(
+        methods_widget.selection_list.selection_listbox,
+        "total",
+    )
+    fixture.root.update()
+
+    assert fixture.session_record.selected_method_symbol == "total"
+    assert fixture.session_record.selected_method_category == "all"
+
+
+@with_fixtures(SwordfishGuiFixture)
 def test_method_list_can_show_inherited_methods_in_grey(fixture):
     """AI: Enabling inherited methods should add inherited selectors to the current class method list and render them in grey."""
 

--- a/tests/test_mcp_activity_linger.py
+++ b/tests/test_mcp_activity_linger.py
@@ -1,0 +1,76 @@
+'''AI: Tests for ActivityLinger - the minimum visible time the MCP activity indicator owes every
+operation. A fast MCP tool call begins and ends before the Tk thread renders its busy state, so an
+indicator driven by raw busy-state edges shows nothing for exactly the workloads - bursts of small,
+quick calls - a user most wants reassurance about. The linger is the pure decision object; the Tk
+wiring stays thin around it.'''
+
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.main import ActivityLinger
+
+
+class SteppableClock:
+    '''AI: A clock the test advances by hand, so linger expiry is asserted exactly rather than
+    raced against real time.'''
+
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now = self.now + seconds
+
+
+class LingerScenarios(Fixture):
+    @scenario
+    def fast_operation_remains_visible(self):
+        '''AI: An operation that finished instantly still earns the minimum visible time - the
+        point of the linger: raw busy edges render nothing for sub-second tool calls.'''
+        self.advance_before_check = 0.3
+        self.expected_lingering = True
+
+    @scenario
+    def linger_expires_after_minimum(self):
+        '''AI: Once the minimum has passed the indicator owes nothing more - it must go dark
+        rather than suggest activity that is no longer happening.'''
+        self.advance_before_check = 0.6
+        self.expected_lingering = False
+
+
+@with_fixtures(LingerScenarios)
+def test_linger_holds_for_minimum_visible_time(linger_scenario):
+    clock = SteppableClock()
+    linger = ActivityLinger(minimum_visible_seconds=0.5, clock=clock)
+
+    linger.note_activity()
+    clock.advance(linger_scenario.advance_before_check)
+
+    assert linger.is_lingering() == linger_scenario.expected_lingering
+
+
+def test_burst_of_activity_reads_as_one_steady_period():
+    '''AI: Each busy signal restarts the hold, so a burst of quick operations shows as one
+    continuous period of activity ending a minimum time after the last call - not a flicker
+    per call and not a gap in the middle.'''
+    clock = SteppableClock()
+    linger = ActivityLinger(minimum_visible_seconds=0.5, clock=clock)
+
+    linger.note_activity()
+    clock.advance(0.4)
+    linger.note_activity()
+    clock.advance(0.4)
+    assert linger.is_lingering()
+
+    clock.advance(0.2)
+    assert not linger.is_lingering()
+
+
+def test_fresh_linger_owes_nothing():
+    '''AI: Before any operation has run the indicator must be dark - the linger starts inert,
+    it does not invent activity at startup.'''
+    clock = SteppableClock()
+    linger = ActivityLinger(minimum_visible_seconds=0.5, clock=clock)
+
+    assert not linger.is_lingering()

--- a/tests/test_mcp_live_gemstone.py
+++ b/tests/test_mcp_live_gemstone.py
@@ -280,6 +280,9 @@ class LiveMcpConnectionFixture(Fixture):
     def new_gs_compile_method(self):
         return self.registered_mcp_tools["gs_compile_method"]
 
+    def new_gs_compile_methods(self):
+        return self.registered_mcp_tools["gs_compile_methods"]
+
     def new_gs_get_class_definition(self):
         return self.registered_mcp_tools["gs_get_class_definition"]
 
@@ -3524,3 +3527,79 @@ def test_live_breakpoint_tools_set_list_and_clear_breakpoints(live_connection):
     )
     assert list_after_clear_result["ok"], list_after_clear_result
     assert not list_after_clear_result["breakpoints"]
+
+
+@with_fixtures(LiveMcpConnectionFixture)
+def test_live_compile_methods_batches_outcomes_per_row(live_connection):
+    """AI: Against a real gem, one gs_compile_methods call installs several methods, reports a
+    per-row outcome for each, and isolates failures: an unparseable source, an unknown class and a
+    genuine compiler error each fail only their own row while their well-formed siblings install -
+    proving the batched dynamic-array program actually runs and that a bad entry never aborts the
+    batch (the round-trip storm that previously hammered the gem is gone)."""
+    begin_result = live_connection.gs_begin_if_needed(live_connection.connection_id)
+    assert begin_result["ok"], begin_result
+    class_name = "McpBatchCompile%s" % uuid.uuid4().hex[:8]
+    create_result = live_connection.gs_create_class(
+        live_connection.connection_id, class_name
+    )
+    assert create_result["ok"], create_result
+
+    batch_result = live_connection.gs_compile_methods(
+        live_connection.connection_id,
+        [
+            {"class_name": class_name, "source": "answerOne\n\t^1"},
+            {"class_name": class_name, "source": "answerTwo\n\t^2", "show_instance_side": False},
+            {"class_name": class_name, "source": "123 not a method"},
+            {"class_name": class_name, "source": "broken\n\t^self +"},
+            {"class_name": "NoSuchClass%s" % uuid.uuid4().hex[:8], "source": "x\n\t^0"},
+        ],
+    )
+    assert batch_result["ok"] is False, batch_result
+    rows = batch_result["results"]
+    assert [row["ok"] for row in rows] == [True, True, False, False, False]
+    assert "parseable" in rows[2]["error"]
+    assert rows[3]["error"]
+    assert "not found" in rows[4]["error"].lower()
+
+    instance_source = live_connection.gs_get_method_source(
+        live_connection.connection_id, class_name, "answerOne"
+    )
+    assert instance_source["ok"], instance_source
+    class_side_source = live_connection.gs_get_method_source(
+        live_connection.connection_id, class_name, "answerTwo", show_instance_side=False
+    )
+    assert class_side_source["ok"], class_side_source
+
+    abort_result = live_connection.gs_abort(live_connection.connection_id)
+    assert abort_result["ok"], abort_result
+
+
+@with_fixtures(LiveMcpConnectionFixture)
+def test_live_compile_methods_preserves_protocol_when_category_omitted(live_connection):
+    """AI: Recompiling an existing method through the batch with no category named must keep its
+    current protocol rather than reclassifying it - the server-side preserve-or-default the batch
+    now owns, and the behaviour the consolidated dictionary path inherits."""
+    begin_result = live_connection.gs_begin_if_needed(live_connection.connection_id)
+    assert begin_result["ok"], begin_result
+    class_name = "McpBatchProtocol%s" % uuid.uuid4().hex[:8]
+    create_result = live_connection.gs_create_class(
+        live_connection.connection_id, class_name
+    )
+    assert create_result["ok"], create_result
+    seed_result = live_connection.gs_compile_method(
+        live_connection.connection_id,
+        class_name,
+        "balance\n\t^0",
+        method_category="accounting",
+    )
+    assert seed_result["ok"], seed_result
+
+    batch_result = live_connection.gs_compile_methods(
+        live_connection.connection_id,
+        [{"class_name": class_name, "source": "balance\n\t^1"}],
+    )
+    assert batch_result["ok"], batch_result
+    assert batch_result["results"][0]["method_category"] == "accounting"
+
+    abort_result = live_connection.gs_abort(live_connection.connection_id)
+    assert abort_result["ok"], abort_result

--- a/tests/test_mcp_operation_gate.py
+++ b/tests/test_mcp_operation_gate.py
@@ -1,0 +1,92 @@
+import threading
+
+from reahl.swordfish.mcp.session_serialization import OperationGate
+
+
+def test_a_different_operation_is_excluded_until_the_holder_leaves():
+    """AI: The gate serializes whole operations: while one operation holds the session, a
+    different operation cannot enter. This is the core mutual exclusion that keeps an IDE
+    operation's GCI calls from interleaving with an MCP operation's GCI calls."""
+    gate = OperationGate()
+    holder_has_it = threading.Event()
+    holder_may_release = threading.Event()
+
+    def hold_as(operation_token):
+        gate.enter(operation_token)
+        holder_has_it.set()
+        holder_may_release.wait()
+        gate.leave(operation_token)
+
+    holder = threading.Thread(target=hold_as, args=('mcp-op-1',))
+    holder.start()
+    holder_has_it.wait()
+
+    assert gate.try_enter('ide-op-1') is False
+
+    holder_may_release.set()
+    holder.join()
+
+    assert gate.try_enter('ide-op-1') is True
+    gate.leave('ide-op-1')
+
+
+def test_the_same_operation_re_enters_from_another_thread_without_blocking():
+    """AI: One operation can span two threads - an MCP operation holds the session on its worker
+    thread, then drives IDE work that runs on the Tk thread. That second thread must be admitted
+    under the same operation token rather than deadlocking against the operation's own hold, which
+    a thread-based lock could never express."""
+    gate = OperationGate()
+    holder_has_it = threading.Event()
+    holder_may_release = threading.Event()
+
+    def hold_as(operation_token):
+        gate.enter(operation_token)
+        holder_has_it.set()
+        holder_may_release.wait()
+        gate.leave(operation_token)
+
+    holder = threading.Thread(target=hold_as, args=('mcp-op-1',))
+    holder.start()
+    holder_has_it.wait()
+
+    assert gate.try_enter('mcp-op-1') is True
+    gate.leave('mcp-op-1')
+
+    holder_may_release.set()
+    holder.join()
+
+
+def test_blocking_enter_proceeds_only_after_the_holder_leaves():
+    """AI: The chosen contention policy is to wait, not reject. A second operation that blocks on
+    enter must not proceed until the holder leaves, so the two never run concurrently."""
+    gate = OperationGate()
+    order = []
+    order_lock = threading.Lock()
+    holder_has_it = threading.Event()
+    waiter_started = threading.Event()
+
+    def hold_then_release():
+        gate.enter('mcp-op-1')
+        holder_has_it.set()
+        waiter_started.wait()
+        with order_lock:
+            order.append('holder-leaving')
+        gate.leave('mcp-op-1')
+
+    def wait_to_enter():
+        waiter_started.set()
+        gate.enter('ide-op-1')
+        with order_lock:
+            order.append('waiter-entered')
+        gate.leave('ide-op-1')
+
+    holder = threading.Thread(target=hold_then_release)
+    holder.start()
+    holder_has_it.wait()
+    waiter = threading.Thread(target=wait_to_enter)
+    waiter.start()
+
+    holder.join()
+    waiter.join()
+
+    assert order == ['holder-leaving', 'waiter-entered']

--- a/tests/test_mcp_session_serialization.py
+++ b/tests/test_mcp_session_serialization.py
@@ -2,21 +2,25 @@ import threading
 import time
 
 from reahl.swordfish.mcp.integration_state import IntegratedSessionState
-from reahl.swordfish.mcp.session_serialization import exclusive_session_access
+from reahl.swordfish.mcp.session_serialization import (
+    leave_session_operation,
+    session_operation,
+    try_enter_session_operation,
+)
 from reahl.swordfish.mcp.tools import register_tools
 
 
 def peak_overlap_across(connection_ids):
-    """AI: Run one thread per connection_id, each holding exclusive_session_access
-    briefly, and report the largest number of threads that were ever inside the
-    critical section at the same instant."""
+    """AI: Run one thread per connection_id as a distinct operation, each holding the session
+    briefly, and report the largest number of threads that were ever inside the critical section
+    at the same instant."""
     state_lock = threading.Lock()
     occupancy = {'current': 0, 'peak': 0}
     start_barrier = threading.Barrier(len(connection_ids))
 
     def hold_session(connection_id):
         start_barrier.wait()
-        with exclusive_session_access(connection_id):
+        with session_operation(connection_id, ('op', threading.get_ident())):
             with state_lock:
                 occupancy['current'] = occupancy['current'] + 1
                 occupancy['peak'] = max(occupancy['peak'], occupancy['current'])
@@ -123,3 +127,31 @@ def test_coordinated_tool_lets_distinct_connections_run_in_parallel():
     probe, coordinated_call = probe_wrapped_through_coordinated_tool()
     peak_overlap_through(coordinated_call, ['session-a', 'session-b'])
     assert probe.peak == 2
+
+
+def test_ide_can_discover_a_busy_session_without_blocking():
+    """AI: The Tk thread is single-threaded and also services MCP-driven navigation, so it must
+    never block waiting for the session lock - that would deadlock an MCP operation waiting on Tk.
+    Instead it asks non-blockingly whether the session is free, so a busy answer lets it defer the
+    work onto the event loop. While another thread holds the session, try_enter must report False;
+    once that thread releases, a later try_enter must succeed."""
+    connection_id = 'ide-session'
+    holder_has_it = threading.Event()
+    holder_may_release = threading.Event()
+
+    def hold_until_released():
+        with session_operation(connection_id, ('mcp-op', 1)):
+            holder_has_it.set()
+            holder_may_release.wait()
+
+    holder = threading.Thread(target=hold_until_released)
+    holder.start()
+    holder_has_it.wait()
+
+    assert try_enter_session_operation(connection_id, ('ide-op', 1)) is False
+
+    holder_may_release.set()
+    holder.join()
+
+    assert try_enter_session_operation(connection_id, ('ide-op', 1)) is True
+    leave_session_operation(connection_id, ('ide-op', 1))

--- a/tests/test_mcp_session_serialization.py
+++ b/tests/test_mcp_session_serialization.py
@@ -1,7 +1,9 @@
 import threading
 import time
 
+from reahl.swordfish.mcp.integration_state import IntegratedSessionState
 from reahl.swordfish.mcp.session_serialization import exclusive_session_access
+from reahl.swordfish.mcp.tools import register_tools
 
 
 def peak_overlap_across(connection_ids):
@@ -46,3 +48,78 @@ def test_different_connections_may_overlap():
     them would needlessly block unrelated work. Only calls sharing one session are
     gated."""
     assert peak_overlap_across(['session-a', 'session-b']) == 2
+
+
+class RecordingProbe:
+    """AI: A stand-in MCP tool whose body is slow enough for two callers to overlap, and which
+    records the largest number of callers that were ever inside it at the same instant."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.current = 0
+        self.peak = 0
+
+    def run(self, connection_id=None):
+        with self.lock:
+            self.current = self.current + 1
+            self.peak = max(self.peak, self.current)
+        time.sleep(0.05)
+        with self.lock:
+            self.current = self.current - 1
+        return {'ok': True}
+
+
+class CapturingMcpServer:
+    """AI: Minimal stand-in for the FastMCP server. register_tools only ever touches `.tool`:
+    it captures the raw decorator factory and then replaces it with the coordinated one, so a
+    bare `.tool` that registers functions unchanged is the whole contract we must honour."""
+
+    def tool(self, *decorator_arguments, **decorator_keywords):
+        return lambda registered_function: registered_function
+
+
+def probe_wrapped_through_coordinated_tool():
+    """AI: Wrap a probe through the *real* coordinated_tool that register_tools installs onto
+    mcp_server.tool, so the test exercises the production gate wiring rather than a copy of it."""
+    mcp_server = CapturingMcpServer()
+    register_tools(mcp_server, integrated_session_state=IntegratedSessionState())
+    probe = RecordingProbe()
+    coordinated_call = mcp_server.tool('probe')(probe.run)
+    return probe, coordinated_call
+
+
+def peak_overlap_through(coordinated_call, connection_ids):
+    """AI: Fire one thread per connection_id at the coordinated wrapper at once and report the
+    peak number of callers the probe ever saw inside itself simultaneously."""
+    start_barrier = threading.Barrier(len(connection_ids))
+
+    def fire(connection_id):
+        start_barrier.wait()
+        coordinated_call(connection_id=connection_id)
+
+    threads = [
+        threading.Thread(target=fire, args=(connection_id,))
+        for connection_id in connection_ids
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def test_coordinated_tool_serializes_concurrent_calls_on_one_connection():
+    """AI: The gate must be wired into coordinated_tool itself, not merely available as a
+    primitive. Two MCP calls sharing a connection, driven through the real wrapper, must never
+    be inside the tool body at the same time - otherwise overlapping GCI raises error 2203 and
+    the IDE falls over, exactly as observed live while the unit test of the primitive passed."""
+    probe, coordinated_call = probe_wrapped_through_coordinated_tool()
+    peak_overlap_through(coordinated_call, ['ide-session', 'ide-session'])
+    assert probe.peak == 1
+
+
+def test_coordinated_tool_lets_distinct_connections_run_in_parallel():
+    """AI: The wiring keys the gate on connection_id, so calls on different sessions still run
+    concurrently through the wrapper - the serialization is targeted, not a global stall."""
+    probe, coordinated_call = probe_wrapped_through_coordinated_tool()
+    peak_overlap_through(coordinated_call, ['session-a', 'session-b'])
+    assert probe.peak == 2

--- a/tests/test_mcp_session_serialization.py
+++ b/tests/test_mcp_session_serialization.py
@@ -1,0 +1,48 @@
+import threading
+import time
+
+from reahl.swordfish.mcp.session_serialization import exclusive_session_access
+
+
+def peak_overlap_across(connection_ids):
+    """AI: Run one thread per connection_id, each holding exclusive_session_access
+    briefly, and report the largest number of threads that were ever inside the
+    critical section at the same instant."""
+    state_lock = threading.Lock()
+    occupancy = {'current': 0, 'peak': 0}
+    start_barrier = threading.Barrier(len(connection_ids))
+
+    def hold_session(connection_id):
+        start_barrier.wait()
+        with exclusive_session_access(connection_id):
+            with state_lock:
+                occupancy['current'] = occupancy['current'] + 1
+                occupancy['peak'] = max(occupancy['peak'], occupancy['current'])
+            time.sleep(0.05)
+            with state_lock:
+                occupancy['current'] = occupancy['current'] - 1
+
+    threads = [
+        threading.Thread(target=hold_session, args=(connection_id,))
+        for connection_id in connection_ids
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return occupancy['peak']
+
+
+def test_same_connection_calls_do_not_overlap():
+    """AI: Two MCP calls on one GemStone session must run one at a time. GCI is
+    single-threaded per session and raises error 2203 ('a call in progress') if a
+    second call starts before the first returns, which the IDE surfaces as a fatal
+    GemStone error window."""
+    assert peak_overlap_across(['ide-session', 'ide-session']) == 1
+
+
+def test_different_connections_may_overlap():
+    """AI: Independent sessions have independent GCI state, so serializing across
+    them would needlessly block unrelated work. Only calls sharing one session are
+    gated."""
+    assert peak_overlap_across(['session-a', 'session-b']) == 2

--- a/tests/test_mcp_tool_policies.py
+++ b/tests/test_mcp_tool_policies.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List
+
 from reahl.tofu import Fixture, NoException, expected, set_up, tear_down, with_fixtures
 
 from reahl.swordfish.mcp.debug_registry import add_debug_session, clear_debug_sessions
@@ -770,6 +772,30 @@ def test_gs_capabilities_safe_write_includes_package_tools(tools_fixture):
     assert "gs_install_package" in safe_write_tools
     assert "gs_create_class_in_package" in safe_write_tools
     assert "gs_create_test_case_class" in safe_write_tools
+
+
+@with_fixtures(AllowedToolsFixture)
+def test_gs_capabilities_safe_write_advertises_batched_compile(tools_fixture):
+    """AI: An agent that learns the write tools from the gs_capabilities catalog (the
+    recommended bootstrap) must find the batched compile there, or it will loop
+    gs_compile_method - the exact round-trip storm gs_compile_methods exists to prevent.
+    This gap was found by dog-fooding against a fresh connection."""
+    capabilities_result = tools_fixture.gs_capabilities()
+    assert capabilities_result["ok"], capabilities_result
+    safe_write_tools = capabilities_result["tool_groups"]["safe_write"]
+    assert "gs_compile_methods" in safe_write_tools
+
+
+@with_fixtures(AllowedToolsFixture)
+def test_gs_compile_methods_advertises_an_array_parameter(tools_fixture):
+    """AI: FastMCP derives the advertised JSON schema from the Python signature; an
+    unannotated methods parameter is advertised as type 'string', leaving a strict MCP
+    client to guess at JSON-in-a-string coercion or fall back to looping the singular
+    tool. The annotation makes the schema say what the validator demands: a list of
+    objects."""
+    gs_compile_methods = tools_fixture.registered_mcp_tools["gs_compile_methods"]
+    methods_annotation = gs_compile_methods.__annotations__["methods"]
+    assert methods_annotation == List[Dict[str, Any]]
 
 
 @with_fixtures(AllowedToolsFixture)


### PR DESCRIPTION
   ## Summary

   Two related strands of work against the shared GemStone session.

   ### 1. Batched method compilation (`gs_compile_methods`)
   Collapses the per-method compile round-trip storm into one GCI round-trip per chunk. Profiling on a live extent: 30 methods one-at-a-time ≈ 290–650 ms (~10–22 ms/call, mostly
   round-trip + per-method `ClassOrganizer` rebuild) vs the batch at 25–35 ms (<1 ms/method) — ~12–20×. Refactoring fan-outs route through it; browsing listings collapsed to one
   round-trip each.

   ### 2. Operation-level MCP/IDE session serialization
   Profiling the above surfaced a latent crash: GCI is single-threaded per session, and the IDE issued GCI (model-refresh repopulates) with **no** mutual exclusion against MCP
   operations. A concurrent compile burst raced the IDE's refresh and crashed the gem with error 2203. The MCP busy indicator was only ever cosmetic (a counter + UI disable), never
   a real lock.

   The fix serializes at the granularity of a whole **operation** (an MCP tool call, an IDE action), via an **operation-token gate** — mutual exclusion keyed by an operation token
   rather than a thread, because one operation can span two threads (an MCP operation holds the session on its worker thread, then drives IDE work on the Tk thread). The same token
   re-enters without blocking; a different token waits.

   - **MCP side:** `OperationGate` + `coordinated_tool` holds `session_operation` per call.
   - **IDE side:** `EventQueue.process_events` (the drain where many widget repopulates run for one logical refresh) takes the session as a whole operation via
   `SessionOperationAdmission` — non-blocking, because the Tk thread also services MCP-driven navigation and must never block; a denied admission defers the whole drain and retries.
   - **Navigation:** `perform_mcp_ide_navigation_action` dispatches off the gated drain and re-enters under the carried operation token, so the Tk-side work is part of that MCP
   operation rather than a competitor.

   ## Verification
   - **706 hermetic tests green** (incl. `OperationGate`, the `coordinated_tool` wiring, and a Tk/xvfb drain-gating test — the latter mutation-checked).
   - **Live, on the running IDE:** read-only 2-client concurrency = 0 collisions; **2 clients × 30 concurrent compiles = 60/60, zero 2203** (previously 60/60 collisions + a crashed
   IDE); concurrent navigation + compile = zero timeouts, zero collisions.

   ## Follow-up (not blocking)
   Confirm no background, non-event IDE GCI (e.g. the periodic `synchronise_collaboration_state` poll) bypasses the drain — the live burst didn't surface any.
