### PR TITLE
Menu changes

### DIFF
--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -20,7 +20,7 @@ from reahl.swordfish.text_editing import (
     TextCursorPositionIndicator,
 )
 from reahl.swordfish.ui_context import UiContext
-from reahl.swordfish.ui_support import add_close_command_to_popup_menu, popup_menu
+from reahl.swordfish.ui_support import popup_menu
 
 
 class CoveringTestsDiscoveryWorkflow:
@@ -756,7 +756,6 @@ class PackageSelection(FramedWidget):
             command=self.file_in_class_category,
             state=file_command_state,
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def file_out_class_category(self):
@@ -1204,7 +1203,6 @@ class ClassSelection(FramedWidget):
             command=self.file_in_class,
             state=file_command_state,
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def file_out_class(self):
@@ -1302,7 +1300,6 @@ class ClassSelection(FramedWidget):
             command=self.add_selected_hierarchy_classes_to_class_diagram,
             state=tk.NORMAL if has_selection else tk.DISABLED,
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def add_class(self):
@@ -1593,7 +1590,6 @@ class CategorySelection(FramedWidget):
             command=self.file_in_method_category,
             state=file_command_state,
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def file_out_method_category(self):
@@ -2197,7 +2193,6 @@ class MethodSelection(FramedWidget):
             command=self.file_in_method,
             state=file_command_state,
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def file_out_method(self):

--- a/src/reahl/swordfish/class_diagram.py
+++ b/src/reahl/swordfish/class_diagram.py
@@ -19,7 +19,6 @@ from reahl.swordfish.ui_support import (
     UML_NODES_PER_ROW,
     UML_ORIGIN_X,
     UML_ORIGIN_Y,
-    add_close_command_to_popup_menu,
     popup_menu,
 )
 
@@ -999,7 +998,6 @@ class UmlClassDiagramTab(ttk.Frame):
             label="Remove From Class Diagram",
             command=lambda: self.remove_class_from_diagram(node.class_name),
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def open_relationship_menu(self, relationship, event):
@@ -1020,7 +1018,6 @@ class UmlClassDiagramTab(ttk.Frame):
                 label="Add Inheritance Details",
                 state=tk.DISABLED,
             )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def browse_class(self, class_name):

--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -22,6 +22,7 @@ from reahl.swordfish.ui_support import (
     class_name_at_widget_cursor,
     is_compile_error,
     popup_menu,
+    selector_at_widget_cursor,
 )
 
 
@@ -268,6 +269,59 @@ class RunTab(ttk.Frame):
             return
         self.application.browse_class(class_name, show_instance_side=True)
 
+    def open_implementors_from_source(self):
+        # AI: Implementors from the Run tab's source editor. Mirrors the CodePanel
+        # version so the selector under the cursor (or the selection) drives the
+        # same Find dialog wherever code is shown.
+        selector = selector_at_widget_cursor(
+            self.source_text, self.selected_source_text()
+        )
+        if selector is None:
+            messagebox.showwarning(
+                'No Selector',
+                'Place the cursor on a selector or select one before '
+                'running this.',
+            )
+            return
+        self.application.event_queue.publish(
+            'ImplementorsOpened', log_context={'selector': selector}
+        )
+        self.application.open_implementors_dialog(method_symbol=selector)
+
+    def open_senders_from_source(self):
+        # AI: Senders from the Run tab's source editor. Mirrors the CodePanel
+        # version so behaviour stays uniform across every source window.
+        selector = selector_at_widget_cursor(
+            self.source_text, self.selected_source_text()
+        )
+        if selector is None:
+            messagebox.showwarning(
+                'No Selector',
+                'Place the cursor on a selector or select one before '
+                'running this.',
+            )
+            return
+        self.application.event_queue.publish(
+            'SendersOpened', log_context={'selector': selector}
+        )
+        self.application.open_senders_dialog(method_symbol=selector)
+
+    def find_references_from_source(self):
+        # AI: References from the Run tab's source editor. Mirrors the CodePanel
+        # version: resolve the class name under the cursor (or the selection) and
+        # open an exact class-reference search for it.
+        class_name = class_name_at_widget_cursor(
+            self.source_text, self.selected_source_text()
+        )
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        self.application.open_find_dialog_for_class(class_name)
+
     def editable_text_for_widget(self, text_widget):
         if text_widget is self.source_text:
             return self.editable_source
@@ -469,6 +523,18 @@ class RunTab(ttk.Frame):
                 self,
                 selected_text,
                 enabled=not self.is_read_only(),
+            )
+            self.current_text_menu.add_command(
+                label='Implementors',
+                command=self.open_implementors_from_source,
+            )
+            self.current_text_menu.add_command(
+                label='Senders',
+                command=self.open_senders_from_source,
+            )
+            self.current_text_menu.add_command(
+                label='References',
+                command=self.find_references_from_source,
             )
             self.current_text_menu.add_command(
                 label='Browse Class',

--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -18,7 +18,6 @@ from reahl.swordfish.text_editing import (
 )
 from reahl.swordfish.ui_context import UiContext
 from reahl.swordfish.ui_support import (
-    add_close_command_to_popup_menu,
     add_source_code_commands,
     class_name_at_widget_cursor,
     is_compile_error,
@@ -475,16 +474,21 @@ class RunTab(ttk.Frame):
                 label='Browse Class',
                 command=self.browse_class_from_source,
             )
-        add_close_command_to_popup_menu(self.current_text_menu)
         self.current_text_menu.bind(
             '<Escape>',
             lambda popup_event: self.close_text_menu(popup_event),
         )
-        self.current_text_menu.post(event.x_root, event.y_root)
+        self.current_text_menu.tk_popup(event.x_root, event.y_root)
 
     def close_text_menu(self, event):
         if self.current_text_menu is not None:
             self.current_text_menu.unpost()
+            # AI: tk_popup installs an input grab; release it on explicit close so
+            # the rest of the UI is not left frozen behind the dismissed menu.
+            try:
+                self.current_text_menu.grab_release()
+            except tk.TclError:
+                pass
             self.current_text_menu = None
 
     @property
@@ -1067,7 +1071,6 @@ class DebuggerWindow(ttk.PanedWindow):
             label='Browse Method',
             command=self.open_selected_frame_method,
         )
-        add_close_command_to_popup_menu(stack_frame_menu)
         self.current_stack_frame_menu = stack_frame_menu
         popup_menu(stack_frame_menu, event)
 

--- a/src/reahl/swordfish/inspector.py
+++ b/src/reahl/swordfish/inspector.py
@@ -7,7 +7,7 @@ from reahl.ptongue import GemstoneError
 from reahl.swordfish.closable_notebook import install_close_buttons
 from reahl.swordfish.navigation import NavigationHistory
 from reahl.swordfish.tab_registry import DeduplicatedTabRegistry
-from reahl.swordfish.ui_support import add_close_command_to_popup_menu, popup_menu
+from reahl.swordfish.ui_support import popup_menu
 
 
 class ObjectInspector(ttk.Frame):
@@ -552,7 +552,6 @@ class ObjectInspector(ttk.Frame):
         has_menu_entries = object_menu.index('end') is not None
         if not has_menu_entries:
             return
-        add_close_command_to_popup_menu(object_menu)
         self.current_object_menu = object_menu
         popup_menu(object_menu, event)
 

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -2685,6 +2685,8 @@ class MainMenu(tk.Menu):
         self.parent = parent
         self.event_queue = event_queue
         self.file_menu = tk.Menu(self, tearoff=0)
+        self.find_menu = tk.Menu(self, tearoff=0)
+        self.debug_menu = tk.Menu(self, tearoff=0)
         self.session_menu = tk.Menu(self, tearoff=0)
         self.mcp_menu = tk.Menu(self, tearoff=0)
         self.filetree_menu = tk.Menu(self, tearoff=0)
@@ -2696,6 +2698,14 @@ class MainMenu(tk.Menu):
         # File Menu
         self.add_cascade(label="File", menu=self.file_menu)
         self.update_file_menu()
+
+        # Find Menu
+        self.add_cascade(label="Find", menu=self.find_menu)
+        self.update_find_menu()
+
+        # Debug Menu
+        self.add_cascade(label="Debug", menu=self.debug_menu)
+        self.update_debug_menu()
 
         # Session Menu
         self.add_cascade(label="Session", menu=self.session_menu)
@@ -2714,6 +2724,8 @@ class MainMenu(tk.Menu):
     def update_menus(self, gemstone_session_record=None, **kwargs):
         self.update_session_menu()
         self.update_file_menu()
+        self.update_find_menu()
+        self.update_debug_menu()
         self.update_mcp_menu()
         self.update_filetree_menu()
 
@@ -2830,6 +2842,27 @@ class MainMenu(tk.Menu):
 
     def update_file_menu(self):
         self.file_menu.delete(0, tk.END)
+        self.file_menu.add_command(label="Exit", command=self.parent.quit)
+
+    def update_find_menu(self):
+        self.find_menu.delete(0, tk.END)
+        if self.parent.is_logged_in:
+            self.find_menu.add_command(label="Find", command=self.show_find_dialog)
+            self.find_menu.add_command(
+                label="Implementors",
+                command=self.show_find_implementors_dialog,
+            )
+            self.find_menu.add_command(
+                label="Senders",
+                command=self.show_find_senders_dialog,
+            )
+            self.find_menu.add_command(
+                label="References",
+                command=self.show_find_references_dialog,
+            )
+
+    def update_debug_menu(self):
+        self.debug_menu.delete(0, tk.END)
         if self.parent.is_logged_in:
             is_busy = self.parent.integrated_session_state.is_mcp_busy()
             run_command_state = self.parent.action_gate.state_for(
@@ -2839,27 +2872,16 @@ class MainMenu(tk.Menu):
                 'breakpoints',
                 is_busy=is_busy,
             )
-            self.file_menu.add_command(label="Find", command=self.show_find_dialog)
-            self.file_menu.add_command(
-                label="Implementors",
-                command=self.show_find_implementors_dialog,
-            )
-            self.file_menu.add_command(
-                label="Senders",
-                command=self.show_find_senders_dialog,
-            )
-            self.file_menu.add_command(
-                label="Run",
+            self.debug_menu.add_command(
+                label="Workspace",
                 command=self.show_run_dialog,
                 state=run_command_state,
             )
-            self.file_menu.add_command(
+            self.debug_menu.add_command(
                 label="Breakpoints",
                 command=self.show_breakpoints_dialog,
                 state=breakpoints_state,
             )
-            self.file_menu.add_separator()
-        self.file_menu.add_command(label="Exit", command=self.parent.quit)
 
     def show_find_dialog(self):
         self.event_queue.publish('MenuCommandInvoked', command='Find')
@@ -2872,6 +2894,10 @@ class MainMenu(tk.Menu):
     def show_find_senders_dialog(self):
         self.event_queue.publish('MenuCommandInvoked', command='Senders')
         self.parent.open_senders_dialog()
+
+    def show_find_references_dialog(self):
+        self.event_queue.publish('MenuCommandInvoked', command='References')
+        self.parent.open_references_dialog()
 
     def show_run_dialog(self):
         self.event_queue.publish('MenuCommandInvoked', command='Run')
@@ -5992,7 +6018,7 @@ class Swordfish(tk.Tk):
             self.record_global_navigation_entry(
                 GlobalNavigationEntry(
                     'run_session',
-                    'Run',
+                    'Workspace',
                     {'session_key': self.run_tab.global_navigation_session_key},
                     place_key=(
                         'run_session',
@@ -7606,7 +7632,7 @@ class Swordfish(tk.Tk):
             self.run_tab.global_navigation_session_key = (
                 self.allocate_global_navigation_session_key('run')
             )
-            self.notebook.add(self.run_tab, text='Run')
+            self.notebook.add(self.run_tab, text='Workspace')
         self.run_tab.set_read_only(self.integrated_session_state.is_mcp_busy())
         self.notebook.select(self.run_tab)
 
@@ -7849,6 +7875,16 @@ class Swordfish(tk.Tk):
             match_mode='exact',
             reference_target='method',
             sender_source_class_name=source_class_name,
+        )
+
+    def open_references_dialog(self, class_name=None):
+        initial_class_name = (class_name or '').strip()
+        return self.open_find_dialog(
+            search_type='reference',
+            search_query=initial_class_name,
+            run_search=bool(initial_class_name),
+            match_mode='exact',
+            reference_target='class',
         )
 
     def open_breakpoints_dialog(self):

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -107,7 +107,6 @@ from reahl.swordfish.ui_support import (
     UML_NODES_PER_ROW,
     UML_ORIGIN_X,
     UML_ORIGIN_Y,
-    add_close_command_to_popup_menu,
     close_popup_menu,
     popup_menu,
 )

--- a/src/reahl/swordfish/object_diagram.py
+++ b/src/reahl/swordfish/object_diagram.py
@@ -12,7 +12,6 @@ from reahl.swordfish.ui_support import (
     GRAPH_NODES_PER_ROW,
     GRAPH_ORIGIN_X,
     GRAPH_ORIGIN_Y,
-    add_close_command_to_popup_menu,
     popup_menu,
 )
 
@@ -374,7 +373,6 @@ class UmlObjectDiagramCanvas(ttk.Frame):
             label='Browse Class',
             command=lambda: self.browse_class_action(node.gemstone_object),
         )
-        add_close_command_to_popup_menu(menu)
         popup_menu(menu, event)
 
     def expand_scroll_region(self):

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -14,7 +14,6 @@ from reahl.swordfish.gemstone.smalltalk_source_scanner import (
     SmalltalkTokenKind,
 )
 from reahl.swordfish.ui_support import (
-    add_close_command_to_popup_menu,
     add_source_code_commands,
     close_popup_menu,
     is_compile_error,
@@ -664,12 +663,11 @@ class CodePanel(tk.Frame):
                 command=self.apply_method_inline,
                 state=write_command_state,
             )
-        add_close_command_to_popup_menu(self.current_context_menu)
         self.current_context_menu.bind(
             '<Escape>',
             lambda popup_event: close_popup_menu(self.current_context_menu),
         )
-        self.current_context_menu.post(event.x_root, event.y_root)
+        self.current_context_menu.tk_popup(event.x_root, event.y_root)
 
     def active_editor_tab(self):
         parent_widget = self.master
@@ -2018,12 +2016,11 @@ class EditorTab(tk.Frame):
             label='Close All to the Right',
             command=lambda: self.method_editor.close_tabs_to_right(self),
         )
-        add_close_command_to_popup_menu(menu)
         menu.bind(
             '<Escape>',
             lambda popup_event: close_popup_menu(menu),
         )
-        menu.post(event.x_root, event.y_root)
+        menu.tk_popup(event.x_root, event.y_root)
 
     def mark_dirty(self):
         if not self.is_dirty:

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -18,6 +18,7 @@ from reahl.swordfish.ui_support import (
     close_popup_menu,
     is_compile_error,
 )
+from reahl.swordfish.ui_support import selector_token as resolve_selector_token
 
 # AI: Maps Smalltalk token kinds to the Tk text tags that colour them. Kinds absent here are left uncoloured.
 SYNTAX_TOKEN_TAGS = {
@@ -471,25 +472,9 @@ class CodePanel(tk.Frame):
         self.editable_text.delete_selection_before_typing(event)
 
     def selector_token(self, token_text):
-        candidate = (token_text or '').strip()
-        if not candidate:
-            return None
-        is_identifier_selector = re.fullmatch(
-            r'[A-Za-z_]\w*(?::[A-Za-z_]\w*)*:?',
-            candidate,
-        )
-        if is_identifier_selector:
-            return candidate
-        keyword_tokens = re.findall(
-            r'[A-Za-z_]\w*:',
-            candidate,
-        )
-        if keyword_tokens:
-            return ''.join(keyword_tokens)
-        is_binary_selector = re.fullmatch(r'[-+*/\\~<>=@%,|&?!]+', candidate)
-        if is_binary_selector:
-            return candidate
-        return None
+        # AI: Delegate to the shared selector resolver so CodePanel and RunTab
+        # reduce a source fragment to a selector by exactly the same rules.
+        return resolve_selector_token(token_text)
 
     def cursor_offset(self):
         cursor_index = self.text_editor.index(tk.INSERT)

--- a/src/reahl/swordfish/ui_support.py
+++ b/src/reahl/swordfish/ui_support.py
@@ -114,3 +114,39 @@ def class_name_at_widget_cursor(text_widget, selected_text):
     if class_name_match is None:
         return None
     return class_name_match.group(0)
+
+
+def selector_token(token_text):
+    # AI: Reduce a fragment of source to the Smalltalk selector it names, or None.
+    # Handles unary/keyword identifiers (foo, foo:bar:), bare keyword runs, and
+    # binary selectors (+, ->, etc.). Shared by every source window so cursor->
+    # selector resolution stays identical across CodePanel and RunTab.
+    candidate = (token_text or '').strip()
+    if not candidate:
+        return None
+    is_identifier_selector = re.fullmatch(
+        r'[A-Za-z_]\w*(?::[A-Za-z_]\w*)*:?',
+        candidate,
+    )
+    if is_identifier_selector:
+        return candidate
+    keyword_tokens = re.findall(
+        r'[A-Za-z_]\w*:',
+        candidate,
+    )
+    if keyword_tokens:
+        return ''.join(keyword_tokens)
+    is_binary_selector = re.fullmatch(r'[-+*/\\~<>=@%,|&?!]+', candidate)
+    if is_binary_selector:
+        return candidate
+    return None
+
+
+def selector_at_widget_cursor(text_widget, selected_text):
+    # AI: Prefer the selection if it names a selector; otherwise fall back to the
+    # selector token under the cursor. Mirrors class_name_at_widget_cursor so the
+    # Run tab and CodePanel resolve selectors for Implementors/Senders the same way.
+    selector_from_selection = selector_token(selected_text)
+    if selector_from_selection is not None:
+        return selector_from_selection
+    return selector_token(word_under_text_cursor(text_widget))

--- a/src/reahl/swordfish/ui_support.py
+++ b/src/reahl/swordfish/ui_support.py
@@ -22,19 +22,17 @@ UML_HEADER_HEIGHT = 26
 
 
 def close_popup_menu(menu):
+    # AI: Unpost AND release the input grab. tk_popup installs a grab that lets a
+    # click outside the menu dismiss it; the explicit-close path (Escape) must
+    # release that grab so the rest of the UI is not left frozen behind it.
     try:
         menu.unpost()
     except tk.TclError:
         pass
-
-
-def add_close_command_to_popup_menu(menu):
-    if menu.index('end') is not None:
-        menu.add_separator()
-    menu.add_command(
-        label='Close Menu',
-        command=lambda current_menu=menu: close_popup_menu(current_menu),
-    )
+    try:
+        menu.grab_release()
+    except tk.TclError:
+        pass
 
 
 def popup_menu(menu, event):
@@ -42,10 +40,11 @@ def popup_menu(menu, event):
         '<Escape>',
         lambda popup_event, current_menu=menu: close_popup_menu(current_menu),
     )
-    try:
-        menu.tk_popup(event.x_root, event.y_root)
-    finally:
-        menu.grab_release()
+    # AI: Do NOT grab_release() here. tk_popup installs the input grab that makes a
+    # click outside the menu dismiss it; releasing it synchronously (tk_popup returns
+    # immediately on X11) left the menu stuck open. Tk releases the grab itself when
+    # the menu is dismissed normally, and close_popup_menu releases it on Escape/Close.
+    menu.tk_popup(event.x_root, event.y_root)
 
 
 def is_compile_error(exception):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3037,53 +3037,108 @@ def test_filetree_menu_holds_sync_config_and_filing_commands(fixture):
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_file_menu_contains_breakpoints_command_when_logged_in(fixture):
-    """AI: File menu should expose a Breakpoints dialog action after login."""
+def test_debug_menu_contains_breakpoints_command_when_logged_in(fixture):
+    """AI: Debug menu should expose a Breakpoints dialog action after login."""
+    fixture.simulate_login()
+    fixture.app.menu_bar.update_menus()
+
+    debug_menu_labels = menu_command_labels(fixture.app.menu_bar.debug_menu)
+    assert "Breakpoints" in debug_menu_labels
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_debug_menu_renames_run_action_to_workspace(fixture):
+    """AI: The Debug menu surfaces the run-tab action under the Workspace label."""
+    fixture.simulate_login()
+    fixture.app.menu_bar.update_menus()
+
+    debug_menu_labels = menu_command_labels(fixture.app.menu_bar.debug_menu)
+    assert "Workspace" in debug_menu_labels
+    assert "Run" not in debug_menu_labels
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_menu_contains_find_implementors_senders_and_references_shortcuts(
+    fixture,
+):
+    """AI: Find menu should gather every search entry point in one place: Find, Implementors, Senders, References."""
+    fixture.simulate_login()
+    fixture.app.menu_bar.update_menus()
+
+    find_menu_labels = menu_command_labels(fixture.app.menu_bar.find_menu)
+    assert "Find" in find_menu_labels
+    assert "Implementors" in find_menu_labels
+    assert "Senders" in find_menu_labels
+    assert "References" in find_menu_labels
+    assert find_menu_labels.index("Find") < find_menu_labels.index("Implementors")
+    assert find_menu_labels.index("Implementors") < find_menu_labels.index("Senders")
+    assert find_menu_labels.index("Senders") < find_menu_labels.index("References")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_file_menu_no_longer_carries_find_or_debug_shortcuts(fixture):
+    """AI: The File menu sheds the search and debug actions once they move to dedicated menus."""
     fixture.simulate_login()
     fixture.app.menu_bar.update_menus()
 
     file_menu_labels = menu_command_labels(fixture.app.menu_bar.file_menu)
-    assert "Breakpoints" in file_menu_labels
+    assert "Find" not in file_menu_labels
+    assert "Implementors" not in file_menu_labels
+    assert "Senders" not in file_menu_labels
+    assert "Breakpoints" not in file_menu_labels
+    assert "Workspace" not in file_menu_labels
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_file_menu_contains_find_implementors_and_senders_shortcuts(
+def test_find_menu_find_implementors_command_delegates_to_swordfish_handler(
     fixture,
 ):
-    """AI: File menu should include Find shortcuts for implementors and senders directly below Find."""
+    """AI: Find menu Implementors action should delegate to Swordfish find-implementors handler."""
     fixture.simulate_login()
-    fixture.app.menu_bar.update_menus()
-
-    file_menu_labels = menu_command_labels(fixture.app.menu_bar.file_menu)
-    assert "Find" in file_menu_labels
-    assert "Implementors" in file_menu_labels
-    assert "Senders" in file_menu_labels
-    assert file_menu_labels.index("Find") < file_menu_labels.index("Implementors")
-    assert file_menu_labels.index("Implementors") < file_menu_labels.index("Senders")
-
-
-@with_fixtures(SwordfishAppFixture)
-def test_file_menu_find_implementors_command_delegates_to_swordfish_handler(
-    fixture,
-):
-    """AI: File menu Implementors action should delegate to Swordfish find-implementors handler."""
-    fixture.simulate_login()
-    file_menu = fixture.app.menu_bar.file_menu
+    find_menu = fixture.app.menu_bar.find_menu
     with patch.object(fixture.app, "open_implementors_dialog") as open_dialog:
-        invoke_menu_command_by_label(file_menu, "Implementors")
+        invoke_menu_command_by_label(find_menu, "Implementors")
     open_dialog.assert_called_once_with()
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_file_menu_find_senders_command_delegates_to_swordfish_handler(
+def test_find_menu_find_senders_command_delegates_to_swordfish_handler(
     fixture,
 ):
-    """AI: File menu Senders action should delegate to Swordfish find-senders handler."""
+    """AI: Find menu Senders action should delegate to Swordfish find-senders handler."""
     fixture.simulate_login()
-    file_menu = fixture.app.menu_bar.file_menu
+    find_menu = fixture.app.menu_bar.find_menu
     with patch.object(fixture.app, "open_senders_dialog") as open_dialog:
-        invoke_menu_command_by_label(file_menu, "Senders")
+        invoke_menu_command_by_label(find_menu, "Senders")
     open_dialog.assert_called_once_with()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_menu_references_command_delegates_to_swordfish_handler(
+    fixture,
+):
+    """AI: Find menu References action should delegate to Swordfish find-references handler."""
+    fixture.simulate_login()
+    find_menu = fixture.app.menu_bar.find_menu
+    with patch.object(fixture.app, "open_references_dialog") as open_dialog:
+        invoke_menu_command_by_label(find_menu, "References")
+    open_dialog.assert_called_once_with()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_open_references_dialog_configures_find_dialog_for_exact_class_references(
+    fixture,
+):
+    """AI: Opening references dialog should configure Find for exact class reference lookup."""
+    with patch.object(fixture.app, "open_find_dialog") as open_find_dialog:
+        fixture.app.open_references_dialog(class_name="OrderLine")
+    open_find_dialog.assert_called_once_with(
+        search_type="reference",
+        search_query="OrderLine",
+        run_search=True,
+        match_mode="exact",
+        reference_target="class",
+    )
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -3119,15 +3174,27 @@ def test_open_senders_dialog_configures_find_dialog_for_exact_method_references(
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_file_menu_breakpoints_command_delegates_to_swordfish_handler(
+def test_debug_menu_breakpoints_command_delegates_to_swordfish_handler(
     fixture,
 ):
-    """AI: File menu Breakpoints action should delegate to Swordfish dialog handler."""
+    """AI: Debug menu Breakpoints action should delegate to Swordfish dialog handler."""
     fixture.simulate_login()
-    file_menu = fixture.app.menu_bar.file_menu
+    debug_menu = fixture.app.menu_bar.debug_menu
     with patch.object(fixture.app, "open_breakpoints_dialog") as open_dialog:
-        invoke_menu_command_by_label(file_menu, "Breakpoints")
+        invoke_menu_command_by_label(debug_menu, "Breakpoints")
     open_dialog.assert_called_once()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_debug_menu_workspace_command_opens_run_tab(
+    fixture,
+):
+    """AI: Debug menu Workspace action should still open the run tab it was renamed from."""
+    fixture.simulate_login()
+    debug_menu = fixture.app.menu_bar.debug_menu
+    with patch.object(fixture.app, "open_run_tab") as open_run_tab:
+        invoke_menu_command_by_label(debug_menu, "Workspace")
+    open_run_tab.assert_called_once()
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -4948,7 +5015,7 @@ def test_global_back_and_forward_navigate_places_across_browser_and_run(fixture)
     fixture.app.open_run_tab()
     fixture.app.update()
 
-    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Run'
+    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Workspace'
 
     fixture.app.global_back_button.invoke()
     fixture.app.update()
@@ -4959,7 +5026,7 @@ def test_global_back_and_forward_navigate_places_across_browser_and_run(fixture)
     fixture.app.global_forward_button.invoke()
     fixture.app.update()
 
-    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Run'
+    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Workspace'
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -5236,7 +5303,7 @@ def test_browsing_more_in_browser_after_global_back_keeps_forward_history(fixtur
 
     fixture.app.global_forward_button.invoke()
     fixture.app.update()
-    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Run'
+    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Workspace'
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -5280,7 +5347,7 @@ def test_global_history_dropdown_marks_stale_entries_unavailable(fixture):
     unavailable_indices = [
         index
         for index, value in enumerate(history_values)
-        if value == 'Run (unavailable)'
+        if value == 'Workspace (unavailable)'
     ]
     target_index = unavailable_indices[0]
 
@@ -5338,7 +5405,7 @@ def test_global_back_skips_replaced_debugger_session_entries(fixture):
 
     fixture.app.global_back_button.invoke()
     fixture.app.update()
-    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Run'
+    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Workspace'
 
     fixture.app.global_back_button.invoke()
     fixture.app.update()
@@ -5347,7 +5414,7 @@ def test_global_back_skips_replaced_debugger_session_entries(fixture):
 
     fixture.app.global_back_button.invoke()
     fixture.app.update()
-    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Run'
+    assert fixture.app.notebook.tab(fixture.app.notebook.select(), 'text') == 'Workspace'
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -6147,7 +6214,7 @@ def test_debugger_source_context_menu_inspect_reads_self_instance_variable(
 
 @with_fixtures(SwordfishAppFixture)
 def test_file_run_command_opens_run_tab_in_notebook(fixture):
-    """Choosing File > Run should open and select a Run tab in the main notebook."""
+    """Choosing Debug > Workspace should open and select a Workspace tab in the main notebook."""
     fixture.simulate_login()
 
     fixture.app.run_code()
@@ -6157,9 +6224,9 @@ def test_file_run_command_opens_run_tab_in_notebook(fixture):
         fixture.app.notebook.tab(tab_id, "text")
         for tab_id in fixture.app.notebook.tabs()
     ]
-    assert "Run" in tab_labels
+    assert "Workspace" in tab_labels
     selected_tab_text = fixture.app.notebook.tab(fixture.app.notebook.select(), "text")
-    assert selected_tab_text == "Run"
+    assert selected_tab_text == "Workspace"
 
 
 @with_fixtures(SwordfishAppFixture)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3670,6 +3670,86 @@ def test_run_context_menu_graph_inspect_opens_graph_for_selected_result(fixture)
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_includes_implementors_senders_and_references(fixture):
+    """AI: The workspace source menu should expose the same navigation group
+    (Implementors, Senders, References) as the method editor, so a selector or
+    class can be explored from any source window."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "anArray do: aBlock")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.6")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    labels = menu_command_labels(run_tab.current_text_menu)
+    assert "Implementors" in labels
+    assert "Senders" in labels
+    assert "References" in labels
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_implementors_opens_dialog_for_selected_selector(
+    fixture,
+):
+    """AI: Implementors from the workspace should resolve the selected selector and
+    open the implementors dialog for it."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "total\n5 + 6")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.5")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    with patch.object(fixture.app, "open_implementors_dialog") as open_dialog:
+        invoke_menu_command_by_label(run_tab.current_text_menu, "Implementors")
+    open_dialog.assert_called_once_with(method_symbol="total")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_senders_opens_dialog_for_selected_selector(
+    fixture,
+):
+    """AI: Senders from the workspace should resolve the selected selector and open
+    the senders dialog for it."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "total\n5 + 6")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.5")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    with patch.object(fixture.app, "open_senders_dialog") as open_dialog:
+        invoke_menu_command_by_label(run_tab.current_text_menu, "Senders")
+    open_dialog.assert_called_once_with(method_symbol="total")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_references_opens_class_reference_search(
+    fixture,
+):
+    """AI: References from the workspace should resolve the class name under the
+    cursor and open an exact class-reference search for it."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "OrderLine new")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.9")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    with patch.object(fixture.app, "open_find_dialog_for_class") as open_dialog:
+        invoke_menu_command_by_label(run_tab.current_text_menu, "References")
+    open_dialog.assert_called_once_with("OrderLine")
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_run_source_context_menu_includes_debug_for_selected_text(fixture):
     """AI: The Run source context menu must offer Debug wherever it already offers Run and Inspect."""
     fixture.simulate_login()

--- a/tests/test_popup_menus.py
+++ b/tests/test_popup_menus.py
@@ -1,0 +1,50 @@
+import tkinter as tk
+import types
+from unittest.mock import patch
+
+from reahl.swordfish.ui_support import close_popup_menu, popup_menu
+
+
+def test_popup_menu_retains_grab_so_a_click_outside_dismisses_it():
+    """AI: A right-click menu must keep the input grab that tk_popup installs.
+
+    On X11 that grab is what makes a click outside the menu reach it and dismiss
+    it. Releasing the grab synchronously (the previous behaviour) tore down the
+    only mechanism that closed the menu on an outside click, so it stayed open
+    until the user selected an item or pressed Escape.
+    """
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        menu = tk.Menu(root, tearoff=0)
+        menu.add_command(label='Something', command=lambda: None)
+        event = types.SimpleNamespace(x_root=0, y_root=0)
+        with patch.object(menu, 'tk_popup') as posted, patch.object(
+            menu, 'grab_release'
+        ) as released:
+            popup_menu(menu, event)
+        posted.assert_called_once_with(0, 0)
+        released.assert_not_called()
+    finally:
+        root.destroy()
+
+
+def test_closing_a_popup_menu_releases_its_grab():
+    """AI: Dismissing a popup explicitly must release the grab it holds.
+
+    The click-away grab is desirable while the menu is up, but the explicit-close
+    path (Escape) has to release it; otherwise the rest of the UI would stay
+    frozen behind the dismissed menu's input grab.
+    """
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        menu = tk.Menu(root, tearoff=0)
+        with patch.object(menu, 'unpost') as unposted, patch.object(
+            menu, 'grab_release'
+        ) as released:
+            close_popup_menu(menu)
+        unposted.assert_called_once()
+        released.assert_called_once()
+    finally:
+        root.destroy()


### PR DESCRIPTION
 ## Summary

  A set of related menu/UX improvements to the IDE:

  1. **Reorganise the main menu bar** — split the overloaded File menu into focused top-level menus.
  2. **Fix right-click popup menus that stayed open** when clicking elsewhere.
  3. **Give the Workspace source editor the same selector/class navigation** as the method editor.

  ## Main menu structure (`0ffa224`)

  The menu bar is now **File · Find · Debug · Session · MCP · FileTree**:

  - **Find** (new): `Find`, `Implementors`, `Senders`, and a new `References` (class-reference search) — moved off File.
  - **Debug** (new): `Workspace` (renamed from `Run`) and `Breakpoints` — moved off File.
  - **File** now carries only `Exit`.

  The `Run` tab is renamed to `Workspace` (tab title and navigation-history label); the underlying run-session identity and telemetry are unchanged.

  ## Popup menus dismiss on click-away (`5edebc3`)

  Right-click context menus often stayed open after clicking outside them. Root cause: no input grab was active while a menu was posted —

  - the shared `popup_menu()` helper released `tk_popup`'s grab synchronously, and
  - three other sites posted with plain `Menu.post()` (no grab at all).

  Without a grab, X11 never routes the outside-click to the menu. Fix: keep `tk_popup`'s grab alive for the menu's lifetime, release it only on explicit close, and route the
  direct-`post()` sites through `tk_popup`. With click-away working, the now-redundant "Close Menu" entries are removed (Escape still dismisses as a keyboard fallback).

  ## Workspace source navigation (`5db1251`)

  The Workspace (Run tab) source menu only had `Browse Class`. It now exposes the full navigation group — **Implementors, Senders, References** — matching the method editor. The
  selector-resolution logic (`selector_token`) was lifted out of `CodePanel` into `ui_support` as a shared function (plus a new `selector_at_widget_cursor` helper mirroring
  `class_name_at_widget_cursor`), so both source windows resolve the thing under the cursor by identical rules.

  ## Testing

  - New `tests/test_popup_menus.py` pins the grab contract (retain on post, release on close).
  - New `test_gui.py` coverage for the Find/Debug menus, the Workspace rename, and the workspace Implementors/Senders/References items (presence + delegation).
  - Full suite green except the pre-existing live-GemStone tests, which fail only due to the local 3.6.5-vs-3.7.4.3 stone-version mismatch in the dev container (environmental,
  unrelated to this branch).

  > Note: popup click-away dismissal is a windowing-system behaviour that Xvfb-based tests can't fully reproduce; it was verified manually in the running app.

