### PR TITLE
Add adaptive columns and inheritance nesting to Find dialog and Debugger

### DIFF
--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -1033,31 +1033,7 @@ class ClassSelection(FramedWidget):
             self.synchronizing_hierarchy_selection = False
 
     def class_definition_map_for_classes(self, class_names):
-        class_definition_by_class_name = {}
-        classes_to_query = list(class_names)
-        while classes_to_query:
-            class_name = classes_to_query.pop()
-            if class_name not in class_definition_by_class_name:
-                class_definition = {
-                    'class_name': class_name,
-                    'superclass_name': None,
-                    'package_name': '',
-                }
-                try:
-                    fetched_class_definition = self.gemstone_session_record.gemstone_browser_session.get_class_definition(
-                        class_name,
-                    )
-                    class_definition.update(fetched_class_definition)
-                except GemstoneDomainException:
-                    pass
-                superclass_name = class_definition.get('superclass_name')
-                class_definition_by_class_name[class_name] = class_definition
-                if (
-                    superclass_name is not None
-                    and superclass_name not in class_definition_by_class_name
-                ):
-                    classes_to_query.append(superclass_name)
-        return class_definition_by_class_name
+        return self.gemstone_session_record.class_definition_map(class_names)
 
     def add_hierarchy_children(
         self,

--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -1016,12 +1016,20 @@ class DebuggerWindow(ttk.PanedWindow):
 
         self.listbox = ttk.Treeview(
             self.call_stack_frame,
-            columns=('Level', 'Column1', 'Column2'),
+            columns=(
+                'Level',
+                'ClassName',
+                'ClassCategory',
+                'MethodName',
+                'MethodCategory',
+            ),
             show='headings',
         )
         self.listbox.heading('Level', text='Level')
-        self.listbox.heading('Column1', text='Class Name')
-        self.listbox.heading('Column2', text='Method Name')
+        self.listbox.heading('ClassName', text='Class Name')
+        self.listbox.heading('ClassCategory', text='Class Category')
+        self.listbox.heading('MethodName', text='Method Name')
+        self.listbox.heading('MethodCategory', text='Method Category')
         self.listbox.grid(row=1, column=0, sticky='nsew')
 
         self.debug_session = GemstoneDebugSession(self.exception)
@@ -1061,13 +1069,24 @@ class DebuggerWindow(ttk.PanedWindow):
         for item in self.listbox.get_children():
             self.listbox.delete(item)
 
+        class_category_by_name = {}
         for frame in self.stack_frames:
             iid = str(frame.level)
+            class_category, method_category = self.frame_categories(
+                frame,
+                class_category_by_name,
+            )
             self.listbox.insert(
                 '',
                 'end',
                 iid=iid,
-                values=(frame.level, frame.class_name, frame.method_name),
+                values=(
+                    frame.level,
+                    frame.class_name,
+                    class_category,
+                    frame.method_name,
+                    method_category,
+                ),
             )
 
         if self.stack_frames:
@@ -1291,6 +1310,46 @@ class DebuggerWindow(ttk.PanedWindow):
         if not class_name or not frame.method_name:
             return None
         return class_name, show_instance_side, frame.method_name
+
+    def frame_categories(self, frame, class_category_by_name):
+        # AI: Resolve the class category (package_name) and method category for a
+        # AI: stack frame, mirroring frame_method_context's handling of the
+        # AI: ' class' suffix for class-side activations. class_category_by_name
+        # AI: caches the per-class lookup so a deep recursive stack costs one
+        # AI: round-trip per distinct class, not per frame. Frames that are not
+        # AI: ordinary method activations (executed code, blocks) yield blanks.
+        class_name = frame.class_name
+        show_instance_side = True
+        class_side_suffix = ' class'
+        if class_name.endswith(class_side_suffix):
+            class_name = class_name[: -len(class_side_suffix)]
+            show_instance_side = False
+        class_category = ''
+        method_category = ''
+        if class_name:
+            if class_name not in class_category_by_name:
+                resolved_class_category = ''
+                try:
+                    class_definition = self.gemstone_session_record.gemstone_browser_session.get_class_definition(
+                        class_name,
+                    )
+                    resolved_class_category = (
+                        class_definition.get('package_name') or ''
+                    )
+                except (GemstoneDomainException, GemstoneError):
+                    resolved_class_category = ''
+                class_category_by_name[class_name] = resolved_class_category
+            class_category = class_category_by_name[class_name]
+            if frame.method_name:
+                try:
+                    method_category = self.gemstone_session_record.gemstone_browser_session.get_method_category(
+                        class_name,
+                        frame.method_name,
+                        show_instance_side,
+                    )
+                except (GemstoneDomainException, GemstoneError):
+                    method_category = ''
+        return class_category, method_category
 
     def open_selected_frame_method(self):
         frame = self.get_selected_stack_frame()

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -383,6 +383,37 @@ class GemstoneSessionRecord:
             return
         yield from self.gemstone_browser_session.list_classes_in_rowan_package(category)
 
+    def class_definition_map(self, class_names):
+        # AI: Build a {class_name: definition} map covering the given classes and
+        # AI: all of their ancestors, so callers can derive inheritance
+        # AI: relationships and class categories (package_name) from one cached
+        # AI: structure rather than re-walking the superclass chain per row.
+        class_definition_by_class_name = {}
+        classes_to_query = list(class_names)
+        while classes_to_query:
+            class_name = classes_to_query.pop()
+            if class_name not in class_definition_by_class_name:
+                class_definition = {
+                    'class_name': class_name,
+                    'superclass_name': None,
+                    'package_name': '',
+                }
+                try:
+                    fetched_class_definition = (
+                        self.gemstone_browser_session.get_class_definition(class_name)
+                    )
+                    class_definition.update(fetched_class_definition)
+                except GemstoneDomainException:
+                    pass
+                superclass_name = class_definition.get('superclass_name')
+                class_definition_by_class_name[class_name] = class_definition
+                if (
+                    superclass_name is not None
+                    and superclass_name not in class_definition_by_class_name
+                ):
+                    classes_to_query.append(superclass_name)
+        return class_definition_by_class_name
+
     def get_categories_in_class(self, class_name, show_instance_side):
         categories = self.gemstone_browser_session.list_method_categories(
             class_name,
@@ -3238,16 +3269,21 @@ class FindDialog(tk.Toplevel):
         )
         self.apply_regex_filter_button.grid(row=1, column=2, columnspan=2, sticky="w")
 
-        self.results_listbox = tk.Listbox(self)
-        self.results_listbox.grid(
+        # AI: A Treeview (tree + headings) so results can carry the adaptive
+        # AI: Class / Class Category / Method / Method Category columns and so
+        # AI: column #0 can indent overrides under the method/class they override.
+        self.result_rows_by_iid = {}
+        self.results_tree = ttk.Treeview(self, show='tree headings')
+        self.results_tree.grid(
             row=8,
             column=0,
             columnspan=6,
             padx=10,
             pady=(10, 4),
-            sticky="nsew",
+            sticky='nsew',
         )
-        self.results_listbox.bind("<Double-Button-1>", self.on_result_double_click)
+        self.results_tree.bind('<Double-Button-1>', self.on_result_double_click)
+        self.configure_result_columns('method')
 
         self.status_label = ttk.Label(
             self,
@@ -3421,21 +3457,6 @@ class FindDialog(tk.Toplevel):
     def finish_stopped_find(self):
         self.status_var.set("Find stopped. Showing partial results.")
         self.sender_tracing_selector = None
-
-    def format_method_navigation_label(
-        self,
-        class_name,
-        show_instance_side,
-        method_selector,
-    ):
-        class_side_label = ""
-        if not show_instance_side:
-            class_side_label = " class"
-        return "%s%s>>%s" % (
-            class_name,
-            class_side_label,
-            method_selector,
-        )
 
     def class_match_query_pattern(self, query_text, match_mode):
         escaped_query = re.escape(query_text)
@@ -3630,26 +3651,206 @@ class FindDialog(tk.Toplevel):
             )
         )
 
-    def display_results(self, results):
-        self.results_listbox.delete(0, tk.END)
-        for result in results:
-            self.results_listbox.insert(tk.END, result)
-        self.results_listbox.grid()
+    def configure_result_columns(self, column_kind):
+        # AI: The find results are adaptive: a class search only needs Class and
+        # AI: Class Category; a method/sender/reference search adds Method and
+        # AI: Method Category; a 'contains' selector search has only bare
+        # AI: selectors, so it shows a single Method column with no nesting.
+        if column_kind == 'method':
+            data_columns = ('ClassCategory', 'Method', 'MethodCategory')
+            headings = {
+                '#0': 'Class',
+                'ClassCategory': 'Class Category',
+                'Method': 'Method',
+                'MethodCategory': 'Method Category',
+            }
+            primary_heading = 'Class'
+        elif column_kind == 'class':
+            data_columns = ('ClassCategory',)
+            headings = {'#0': 'Class', 'ClassCategory': 'Class Category'}
+            primary_heading = 'Class'
+        else:
+            data_columns = ()
+            headings = {'#0': 'Method'}
+            primary_heading = 'Method'
+        self.results_tree.configure(columns=data_columns)
+        self.results_tree.heading('#0', text=primary_heading)
+        self.results_tree.column('#0', width=220, stretch=True)
+        for data_column in data_columns:
+            self.results_tree.heading(data_column, text=headings[data_column])
+            self.results_tree.column(data_column, width=150, stretch=True)
+
+    def clear_results(self):
+        for iid in self.results_tree.get_children():
+            self.results_tree.delete(iid)
+        self.result_rows_by_iid = {}
+
+    def ancestor_class_names(self, class_name, class_definition_by_name):
+        # AI: Superclass chain (nearest ancestor first) drawn from the cached
+        # AI: class-definition map, so nesting can place an override under the
+        # AI: nearest ancestor that is also present in the result set.
+        ancestor_class_names = []
+        current_class_name = class_definition_by_name.get(class_name, {}).get(
+            'superclass_name'
+        )
+        while current_class_name:
+            ancestor_class_names.append(current_class_name)
+            current_class_name = class_definition_by_name.get(
+                current_class_name, {}
+            ).get('superclass_name')
+        return ancestor_class_names
+
+    def render_hierarchy_rows(self, rows, column_kind, class_definition_by_name):
+        # AI: Nest each row under the nearest ancestor that is also in the result
+        # AI: set and shares its side+selector (an override), while preserving the
+        # AI: incoming order among siblings. Parent links are computed up front
+        # AI: from the full key set, then rows are inserted with a pre-order walk
+        # AI: from the roots, so a parent is always inserted before its children
+        # AI: (which Treeview requires).
+        self.clear_results()
+        row_keys = set(
+            (row['class_name'], row['show_instance_side'], row['method_selector'])
+            for row in rows
+        )
+        children_by_parent_key = {}
+        root_rows = []
+        for row in rows:
+            present_ancestor_keys = [
+                (ancestor, row['show_instance_side'], row['method_selector'])
+                for ancestor in self.ancestor_class_names(
+                    row['class_name'], class_definition_by_name
+                )
+                if (ancestor, row['show_instance_side'], row['method_selector'])
+                in row_keys
+            ]
+            if present_ancestor_keys:
+                children_by_parent_key.setdefault(
+                    present_ancestor_keys[0], []
+                ).append(row)
+            else:
+                root_rows.append(row)
+
+        def insert_row(row, parent_iid):
+            class_display = row['class_name']
+            if not row['show_instance_side']:
+                class_display = '%s class' % row['class_name']
+            if column_kind == 'method':
+                values = (
+                    row['class_category'] or '',
+                    row['method_selector'],
+                    row['method_category'] or '',
+                )
+            else:
+                values = (row['class_category'] or '',)
+            iid = self.results_tree.insert(
+                parent_iid,
+                'end',
+                text=class_display,
+                values=values,
+                open=True,
+            )
+            self.result_rows_by_iid[iid] = row
+            key = (
+                row['class_name'],
+                row['show_instance_side'],
+                row['method_selector'],
+            )
+            for child_row in children_by_parent_key.get(key, []):
+                insert_row(child_row, iid)
+
+        for root_row in root_rows:
+            insert_row(root_row, '')
+
+    def display_class_results(self, class_names):
+        class_definition_by_name = self.gemstone_session_record.class_definition_map(
+            class_names
+        )
+        rows = [
+            {
+                'class_name': class_name,
+                'show_instance_side': True,
+                'method_selector': None,
+                'class_category': class_definition_by_name.get(class_name, {}).get(
+                    'package_name'
+                )
+                or '',
+                'method_category': None,
+            }
+            for class_name in class_names
+        ]
+        self.configure_result_columns('class')
+        self.render_hierarchy_rows(rows, 'class', class_definition_by_name)
+
+    def display_selector_results(self, selector_names):
+        self.configure_result_columns('selector')
+        self.clear_results()
+        for selector_name in selector_names:
+            iid = self.results_tree.insert('', 'end', text=selector_name, values=())
+            self.result_rows_by_iid[iid] = {
+                'class_name': None,
+                'show_instance_side': True,
+                'method_selector': selector_name,
+                'class_category': None,
+                'method_category': None,
+            }
+
+    def method_category_for(self, class_name, method_selector, show_instance_side):
+        try:
+            return (
+                self.gemstone_session_record.gemstone_browser_session.get_method_category(
+                    class_name,
+                    method_selector,
+                    show_instance_side,
+                )
+                or ''
+            )
+        except (GemstoneDomainException, GemstoneError):
+            return ''
+
+    def enriched_navigation_row(self, sender_entry, class_definition_by_name):
+        # AI: Sender (method-reference) entries already carry class/method
+        # AI: categories; implementor and class-reference results do not, so we
+        # AI: fill the gaps from the cached class-definition map (class category)
+        # AI: and a categoryOfSelector lookup (method category).
+        class_name = sender_entry['class_name']
+        show_instance_side = sender_entry['show_instance_side']
+        method_selector = sender_entry['method_selector']
+        class_category = sender_entry.get('class_category')
+        if not class_category:
+            class_category = class_definition_by_name.get(class_name, {}).get(
+                'package_name'
+            ) or ''
+        method_category = sender_entry.get('method_category')
+        if not method_category:
+            method_category = self.method_category_for(
+                class_name,
+                method_selector,
+                show_instance_side,
+            )
+        return {
+            'class_name': class_name,
+            'show_instance_side': show_instance_side,
+            'method_selector': method_selector,
+            'class_category': class_category,
+            'method_category': method_category,
+        }
 
     def populate_navigation_results(self, method_results):
         self.navigation_method_results = list(method_results)
-        self.display_results(
-            [
-                self.format_method_navigation_label(
-                    class_name,
-                    show_instance_side,
-                    method_selector,
-                )
-                for class_name, show_instance_side, method_selector in (
-                    self.navigation_method_results
-                )
-            ]
+        sender_entries = [
+            self.sender_entry_for_result(result)
+            for result in self.navigation_method_results
+        ]
+        class_names = [sender_entry['class_name'] for sender_entry in sender_entries]
+        class_definition_by_name = self.gemstone_session_record.class_definition_map(
+            class_names
         )
+        rows = [
+            self.enriched_navigation_row(sender_entry, class_definition_by_name)
+            for sender_entry in sender_entries
+        ]
+        self.configure_result_columns('method')
+        self.render_hierarchy_rows(rows, 'method', class_definition_by_name)
 
     def record_sender_entries_for_navigation(self, sender_entries):
         sender_results = [
@@ -4016,7 +4217,7 @@ class FindDialog(tk.Toplevel):
                 self.sender_entries_by_navigation_result = {}
                 self.last_reference_method_query = None
                 self.last_reference_method_match_mode = None
-                self.display_results([])
+                self.clear_results()
                 self.status_var.set('')
                 return
             if search_type == 'class':
@@ -4025,7 +4226,7 @@ class FindDialog(tk.Toplevel):
                     match_mode,
                     should_stop=self.find_should_stop,
                 )
-                self.display_results(class_names)
+                self.display_class_results(class_names)
                 self.static_sender_results = []
                 self.sender_entries_by_navigation_result = {}
                 self.last_reference_method_query = None
@@ -4043,7 +4244,7 @@ class FindDialog(tk.Toplevel):
                         )
                     )
                     if self.find_should_stop():
-                        self.display_results([])
+                        self.clear_results()
                         self.finish_stopped_find()
                         return
                     self.navigation_method_results = [
@@ -4067,7 +4268,7 @@ class FindDialog(tk.Toplevel):
                     match_mode,
                     should_stop=self.find_should_stop,
                 )
-                self.display_results(selector_names)
+                self.display_selector_results(selector_names)
                 self.static_sender_results = []
                 self.sender_entries_by_navigation_result = {}
                 self.last_reference_method_query = None
@@ -4409,37 +4610,31 @@ class FindDialog(tk.Toplevel):
         self.status_var.set(summary_text)
 
     def on_result_double_click(self, event):
-        selection = self.results_listbox.curselection()
-        if not selection:
-            pass
+        selected_iids = self.results_tree.selection()
+        if not selected_iids:
             return
-        selected_index = selection[0]
-        selected_text = self.results_listbox.get(selected_index)
+        selected_row = self.result_rows_by_iid.get(selected_iids[0])
+        if selected_row is None:
+            return
         search_type = self.search_type.get()
         match_mode = self.match_mode.get()
-        if search_type == "method" and match_mode == "contains":
+        if search_type == 'method' and match_mode == 'contains':
             self.find_entry.delete(0, tk.END)
-            self.find_entry.insert(0, selected_text)
-            self.match_mode.set("exact")
+            self.find_entry.insert(0, selected_row['method_selector'])
+            self.match_mode.set('exact')
             self.find_text()
             self.update_search_context_fields()
             return
         parent = self.parent
         self.destroy()
-        if search_type == "class":
-            parent.handle_find_selection(search_type == "class", selected_text)
+        if search_type == 'class':
+            parent.handle_find_selection(True, selected_row['class_name'])
             return
-        has_navigation_result = selected_index < len(self.navigation_method_results)
-        if has_navigation_result:
-            (
-                class_name,
-                show_instance_side,
-                method_selector,
-            ) = self.navigation_method_results[selected_index]
+        if selected_row['method_selector'] is not None:
             parent.handle_sender_selection(
-                class_name,
-                show_instance_side,
-                method_selector,
+                selected_row['class_name'],
+                selected_row['show_instance_side'],
+                selected_row['method_selector'],
             )
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -122,6 +122,53 @@ class FakeApplication:
         self.event_queue.publish("SelectedClassChanged")
 
 
+def find_result_label_for_row(row):
+    # AI: Reconstruct the legacy single-string label for a FindDialog result row
+    # ("Class>>selector" / "Class class>>selector" for method rows, the class name
+    # for class rows, or the bare selector for a 'contains' search), so tests can
+    # assert which results appear independently of the new columns and indentation.
+    if row["class_name"] is None:
+        return row["method_selector"]
+    class_label = row["class_name"]
+    if not row["show_instance_side"]:
+        class_label = "%s class" % row["class_name"]
+    if row["method_selector"] is None:
+        return class_label
+    return "%s>>%s" % (class_label, row["method_selector"])
+
+
+def find_result_labels(dialog):
+    # AI: Flatten the FindDialog results Treeview (depth-first, parents before
+    # their nested overrides) into the list of labels in display order.
+    labels = []
+
+    def collect(parent_iid):
+        for iid in dialog.results_tree.get_children(parent_iid):
+            labels.append(find_result_label_for_row(dialog.result_rows_by_iid[iid]))
+            collect(iid)
+
+    collect("")
+    return labels
+
+
+def find_result_iid_for_label(dialog, label):
+    # AI: Locate the results-tree row whose reconstructed label matches, so
+    # double-click tests can target a specific result without a listbox index.
+    def search(parent_iid):
+        found = []
+        for iid in dialog.results_tree.get_children(parent_iid):
+            if find_result_label_for_row(dialog.result_rows_by_iid[iid]) == label:
+                found.append(iid)
+            found.extend(search(iid))
+        return found
+
+    return search("")[0]
+
+
+def select_find_result(dialog, label):
+    dialog.results_tree.selection_set(find_result_iid_for_label(dialog, label))
+
+
 class SwordfishGuiFixture(Fixture):
     @set_up
     def create_app(self):
@@ -4758,7 +4805,7 @@ def test_mcp_ide_navigation_action_filters_sender_find_dialog_by_class_category(
     )
     assert include_extensions_response["ok"], include_extensions_response
     assert include_extensions_response["displayed_sender_count"] == 2
-    assert list(dialog.results_listbox.get(0, "end")) == [
+    assert find_result_labels(dialog) == [
         "OrderAudit>>recordTotalChange",
         "OrderLine>>recalculateTotal",
     ]
@@ -4772,7 +4819,7 @@ def test_mcp_ide_navigation_action_filters_sender_find_dialog_by_class_category(
     )
     assert exclude_extensions_response["ok"], exclude_extensions_response
     assert exclude_extensions_response["displayed_sender_count"] == 1
-    assert list(dialog.results_listbox.get(0, "end")) == ["OrderLine>>recalculateTotal"]
+    assert find_result_labels(dialog) == ["OrderLine>>recalculateTotal"]
     dialog.destroy()
 
 
@@ -5799,6 +5846,67 @@ def test_debugger_selected_stack_frame_matches_treeview_level_identifier(fixture
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_debugger_frame_list_shows_class_and_method_category_columns(fixture):
+    """AI: Each debugger frame shows the class category and method category of its
+    activation - mirroring the Find dialog - while keeping call-stack order. A
+    class-side activation resolves its categories from the instance-side class."""
+    fixture.simulate_login()
+    fixture.mock_browser.run_code.side_effect = FakeGemstoneError()
+    fixture.mock_browser.get_method_category.return_value = "printing"
+
+    fixture.app.run_code("1/0")
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.debug_button.invoke()
+    fixture.app.update()
+
+    debugger_tab = fixture.app.debugger_tab
+    instance_frame = types.SimpleNamespace(
+        level=1,
+        class_name="Order",
+        method_name="total",
+        method_source="total source",
+        step_point_offset=1,
+        self=Mock(),
+        vars={},
+    )
+    class_side_frame = types.SimpleNamespace(
+        level=2,
+        class_name="Order class",
+        method_name="default",
+        method_source="default source",
+        step_point_offset=1,
+        self=Mock(),
+        vars={},
+    )
+
+    class OneBasedStack:
+        def __init__(self, frames):
+            self.frames = list(frames)
+
+        def __iter__(self):
+            return iter(self.frames)
+
+        def __bool__(self):
+            return bool(self.frames)
+
+        def __getitem__(self, level):
+            return self.frames[level - 1]
+
+    debugger_tab.stack_frames = OneBasedStack([instance_frame, class_side_frame])
+    debugger_tab.refresh()
+
+    assert debugger_tab.listbox.set("1", "ClassCategory") == "Kernel"
+    assert debugger_tab.listbox.set("1", "MethodCategory") == "printing"
+    assert debugger_tab.listbox.set("2", "ClassName") == "Order class"
+    assert debugger_tab.listbox.set("2", "ClassCategory") == "Kernel"
+    assert [
+        debugger_tab.listbox.set(iid, "Level")
+        for iid in debugger_tab.listbox.get_children()
+    ] == ["1", "2"]
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_completed_debugger_can_be_dismissed_with_close_button(fixture):
     """AI: Once debugger execution completes, the UI should expose a close action that exits debugger mode."""
     fixture.simulate_login()
@@ -6322,7 +6430,7 @@ def test_find_dialog_class_search_populates_result_list(fixture):
     dialog.find_entry.insert(0, "Order")
     dialog.find_text()
 
-    results = list(dialog.results_listbox.get(0, "end"))
+    results = find_result_labels(dialog)
     assert "OrderLine" in results
     assert "OrderHistory" in results
     dialog.destroy()
@@ -6360,10 +6468,10 @@ def test_find_dialog_class_mode_supports_contains_and_exact_matching(
             match_mode="contains",
         )
 
-    assert list(dialog.results_listbox.get(0, "end")) == ["Order", "OrderLine"]
+    assert find_result_labels(dialog) == ["Order", "OrderLine"]
     dialog.match_mode.set("exact")
     dialog.find_text()
-    assert list(dialog.results_listbox.get(0, "end")) == ["Order"]
+    assert find_result_labels(dialog) == ["Order"]
     # AI: The contains search scanned once; the exact search resolved the symbol and
     # never scanned, so find_classes was not called a second time.
     fixture.mock_browser.find_classes.assert_called_once()
@@ -6400,7 +6508,7 @@ def test_find_dialog_can_stop_a_running_class_search(fixture):
     dialog.find_text()
 
     assert dialog.status_var.get() == "Find stopped. Showing partial results."
-    assert list(dialog.results_listbox.get(0, "end")) == [
+    assert find_result_labels(dialog) == [
         "Order0",
         "Order1",
         "Order2",
@@ -6431,13 +6539,125 @@ def test_find_dialog_method_mode_supports_contains_and_exact_matching(
             match_mode="contains",
         )
 
-    assert list(dialog.results_listbox.get(0, "end")) == ["subtotal", "total"]
+    assert find_result_labels(dialog) == ["subtotal", "total"]
     dialog.match_mode.set("exact")
     dialog.find_text()
-    assert list(dialog.results_listbox.get(0, "end")) == [
+    assert find_result_labels(dialog) == [
         "Order class>>total",
         "OrderLine>>total",
     ]
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_method_search_shows_class_and_method_category_columns(fixture):
+    """AI: An implementor search is a method listing, so each result row carries
+    the Class, Class Category, Method and Method Category that an IDE user needs
+    to tell overlapping implementors apart."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "OrderLine", "show_instance_side": True},
+    ]
+
+    with patch.object(FindDialog, "wait_visibility"):
+        dialog = FindDialog(
+            fixture.app,
+            search_type="method",
+            search_query="total",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    assert tuple(dialog.results_tree["columns"]) == (
+        "ClassCategory",
+        "Method",
+        "MethodCategory",
+    )
+    iid = find_result_iid_for_label(dialog, "OrderLine>>total")
+    assert dialog.results_tree.item(iid, "text") == "OrderLine"
+    assert dialog.results_tree.set(iid, "ClassCategory") == "Kernel"
+    assert dialog.results_tree.set(iid, "Method") == "total"
+    assert dialog.results_tree.set(iid, "MethodCategory") == "accessing"
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_nests_override_under_the_implementor_it_overrides(fixture):
+    """AI: When a subclass reimplements a selector, its implementor is nested
+    under the inherited implementor it overrides, so the inheritance relationship
+    between implementors is visible directly in the result list."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "Order", "show_instance_side": True},
+        {"class_name": "OrderLine", "show_instance_side": True},
+    ]
+
+    with patch.object(FindDialog, "wait_visibility"):
+        dialog = FindDialog(
+            fixture.app,
+            search_type="method",
+            search_query="total",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    superclass_iid = find_result_iid_for_label(dialog, "Order>>total")
+    override_iid = find_result_iid_for_label(dialog, "OrderLine>>total")
+    assert dialog.results_tree.parent(superclass_iid) == ""
+    assert dialog.results_tree.parent(override_iid) == superclass_iid
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_class_search_shows_category_column_and_nests_subclasses(fixture):
+    """AI: A class search lists classes with their class category, and a subclass
+    is nested under the superclass it inherits from."""
+    fixture.simulate_login()
+
+    def classes_for_pattern(pattern, should_stop=None):
+        return ["Order", "OrderLine"]
+
+    fixture.mock_browser.find_classes.side_effect = classes_for_pattern
+
+    with patch.object(FindDialog, "wait_visibility"):
+        dialog = FindDialog(
+            fixture.app,
+            search_type="class",
+            search_query="Order",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    assert tuple(dialog.results_tree["columns"]) == ("ClassCategory",)
+    superclass_iid = find_result_iid_for_label(dialog, "Order")
+    subclass_iid = find_result_iid_for_label(dialog, "OrderLine")
+    assert dialog.results_tree.set(superclass_iid, "ClassCategory") == "Kernel"
+    assert dialog.results_tree.parent(subclass_iid) == superclass_iid
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_selector_contains_search_shows_only_a_method_column(fixture):
+    """AI: A 'contains' selector search yields bare selectors with no owning
+    class, so it shows a single Method column and no inheritance nesting."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["subtotal", "total"]
+
+    with patch.object(FindDialog, "wait_visibility"):
+        dialog = FindDialog(
+            fixture.app,
+            search_type="method",
+            search_query="total",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    assert tuple(dialog.results_tree["columns"]) == ()
+    assert find_result_labels(dialog) == ["subtotal", "total"]
+    top_level_iids = dialog.results_tree.get_children("")
+    assert all(
+        dialog.results_tree.get_children(iid) == () for iid in top_level_iids
+    )
     dialog.destroy()
 
 
@@ -6495,8 +6715,7 @@ def test_method_contains_double_click_pivots_to_exact_search_in_place(fixture):
         )
 
     with patch.object(fixture.app, "open_implementors_dialog") as open_implementors:
-        selector_names = list(dialog.results_listbox.get(0, "end"))
-        dialog.results_listbox.selection_set(selector_names.index("total"))
+        select_find_result(dialog, "total")
         dialog.on_result_double_click(None)
 
     open_implementors.assert_not_called()
@@ -6504,7 +6723,7 @@ def test_method_contains_double_click_pivots_to_exact_search_in_place(fixture):
     assert dialog.winfo_exists() == 1
     assert dialog.match_mode.get() == "exact"
     assert dialog.find_entry.get() == "total"
-    assert list(dialog.results_listbox.get(0, "end")) == ["OrderLine>>total"]
+    assert find_result_labels(dialog) == ["OrderLine>>total"]
     assert dialog.search_intent_var.get() == 'Implementors of method "total".'
     dialog.destroy()
 
@@ -6580,7 +6799,7 @@ def test_find_dialog_reference_class_search_is_always_exact(
     assert str(dialog.match_contains_radio.cget("state")) == tk.DISABLED
     fixture.mock_browser.find_classes.assert_not_called()
     fixture.mock_browser.find_class_references.assert_called_once_with("Or")
-    assert list(dialog.results_listbox.get(0, "end")) == ["OrderBuilder>>fromOrder:"]
+    assert find_result_labels(dialog) == ["OrderBuilder>>fromOrder:"]
     dialog.destroy()
 
 
@@ -6621,7 +6840,7 @@ def test_open_find_dialog_for_class_prefills_and_executes_reference_search(
         "Finding references to class OrderLine...",
     )
     end_activity.assert_called_once_with()
-    assert list(dialog.results_listbox.get(0, "end")) == [
+    assert find_result_labels(dialog) == [
         "Order class>>defaultLineClass",
         "Order>>addLine:",
     ]
@@ -6645,9 +6864,8 @@ def test_find_dialog_double_click_navigates_to_selected_class_reference_method(
     dialog.search_type.set("reference")
     dialog.reference_target.set("class")
     dialog.match_mode.set("exact")
-    dialog.navigation_method_results = [("Order", False, "defaultLineClass")]
-    dialog.results_listbox.insert(tk.END, "Order class>>defaultLineClass")
-    dialog.results_listbox.selection_set(0)
+    dialog.populate_navigation_results([("Order", False, "defaultLineClass")])
+    select_find_result(dialog, "Order class>>defaultLineClass")
     dialog.on_result_double_click(None)
     fixture.app.update()
 
@@ -6675,8 +6893,8 @@ def test_find_dialog_double_click_navigates_browser_to_selected_class(fixture):
     with patch.object(FindDialog, "wait_visibility"):
         dialog = FindDialog(fixture.app)
 
-    dialog.results_listbox.insert(tk.END, "OrderLine")
-    dialog.results_listbox.selection_set(0)
+    dialog.display_class_results(["OrderLine"])
+    select_find_result(dialog, "OrderLine")
     dialog.on_result_double_click(None)
     fixture.app.update()
 
@@ -6712,8 +6930,8 @@ def test_find_dialog_double_click_in_dictionary_mode_updates_dictionary_and_clas
     with patch.object(FindDialog, "wait_visibility"):
         dialog = FindDialog(fixture.app)
 
-    dialog.results_listbox.insert(tk.END, "OrderLine")
-    dialog.results_listbox.selection_set(0)
+    dialog.display_class_results(["OrderLine"])
+    select_find_result(dialog, "OrderLine")
     dialog.on_result_double_click(None)
     fixture.app.update()
 
@@ -6760,8 +6978,8 @@ def test_find_dialog_double_click_in_dictionary_mode_uses_class_membership_not_s
     with patch.object(FindDialog, "wait_visibility"):
         dialog = FindDialog(fixture.app)
 
-    dialog.results_listbox.insert(tk.END, "OrderLine")
-    dialog.results_listbox.selection_set(0)
+    dialog.display_class_results(["OrderLine"])
+    select_find_result(dialog, "OrderLine")
     dialog.on_result_double_click(None)
     fixture.app.update()
 
@@ -6806,7 +7024,7 @@ def test_senders_dialog_method_search_populates_result_list(fixture):
             reference_target="method",
         )
 
-    results = list(dialog.results_listbox.get(0, "end"))
+    results = find_result_labels(dialog)
     assert results == ["Order class>>default", "OrderLine>>recalculateTotal"]
     dialog.destroy()
 
@@ -6841,7 +7059,7 @@ def test_senders_dialog_double_click_navigates_browser_to_selected_sender(fixtur
             reference_target="method",
         )
 
-    dialog.results_listbox.selection_set(0)
+    select_find_result(dialog, "OrderLine>>recalculateTotal")
     dialog.on_result_double_click(None)
     fixture.app.update()
 
@@ -6946,7 +7164,7 @@ def test_senders_dialog_narrow_with_tracing_filters_to_observed_senders(fixture)
                 )
                 dialog.narrow_senders_with_tracing()
 
-    results = list(dialog.results_listbox.get(0, "end"))
+    results = find_result_labels(dialog)
     assert results == ["OrderLine>>recalculateTotal"]
     fixture.mock_browser.sender_test_plan_for_selector.assert_called_once_with(
         "total",
@@ -7390,12 +7608,12 @@ def test_senders_dialog_narrow_with_tracing_reloads_static_senders_after_selecto
                 reference_target="method",
             )
             dialog.narrow_senders_with_tracing()
-            first_results = list(dialog.results_listbox.get(0, "end"))
+            first_results = find_result_labels(dialog)
 
             dialog.find_entry.delete(0, tk.END)
             dialog.find_entry.insert(0, "subtotal")
             dialog.narrow_senders_with_tracing()
-            second_results = list(dialog.results_listbox.get(0, "end"))
+            second_results = find_result_labels(dialog)
 
     assert first_results == ["OrderLine>>recalculateTotal"]
     assert second_results == ["Invoice>>recalculateSubtotal"]


### PR DESCRIPTION
Find dialog results move from a single-column Listbox to a Treeview with columns chosen per search type (Class/Class Category for class search; +Method/Method Category for implementor/sender/class-reference searches; a single Method column for selector 'contains' searches). Method and class results nest an override directly under the nearest ancestor that is also in the result set, indented via the tree column.

The Debugger frame list keeps call-stack order and gains Class Category and Method Category columns, with per-class lookups cached.

Factor the superclass-walk into GemstoneSessionRecord.class_definition_map, which ClassSelection now delegates to.