### PR TITLE
Make Debug stop on the first statement of tests and selected source

### DIFF
--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -929,10 +929,10 @@ class RunTab(ttk.Frame):
         self.application.begin_foreground_activity('Debugging source...')
         try:
             try:
-                result = self.gemstone_session_record.run_code(selected_text)
+                result = self.gemstone_session_record.debug_source(selected_text)
                 self.on_run_complete(result)
                 self.status_label.config(
-                    text='Completed successfully; no debugger context',
+                    text='Completed; no step point to stop at',
                 )
                 self.application.event_queue.publish(
                     'RunTabDebugSucceeded',

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -2619,14 +2619,70 @@ class GemstoneBrowserSession:
         return self.summarized_test_result(test_result)
 
     def debug_test_method(self, test_case_class_name, test_method_selector):
+        # AI: Debugging a test stops at the first step point of the test method itself,
+        # AI: as if an implicit breakpoint sat there: we install a transient break at
+        # AI: step point 1 of the instance-side test method, then run the test via runCase
+        # AI: so setUp has happened and the trap lands in the test body.
         selector_literal = self.smalltalk_string_literal(test_method_selector)
-        self.run_code(
-            (
-                "| testCase |\n"
-                "testCase := %s selector: (%s asSymbol).\n"
-                "testCase runCase"
-            )
-            % (test_case_class_name, selector_literal)
+        compiled_method = self.get_compiled_method(
+            test_case_class_name,
+            test_method_selector,
+            True,
+        )
+        source = (
+            "| testCase |\n"
+            "testCase := %s selector: (%s asSymbol).\n"
+            "testCase runCase"
+        ) % (test_case_class_name, selector_literal)
+        return self.run_stopping_at_first_statement(compiled_method, source)
+
+    def debug_source(self, source):
+        # AI: Selected source has no named method to break on. Wrapping it in a block and
+        # AI: breaking would put the marker ahead of execution (a block's prologue - its first
+        # AI: two step points - has no breakable IP). A METHOD maps its entry to step point 1,
+        # AI: so we compile the selection as an UNINSTALLED doit-method (self is nil) via
+        # AI: _compileMethod:symbolList: and break at the FIRST STATEMENT - step point 2, since
+        # AI: step point 1 is the synthetic "doIt" header - guarding selections too small to
+        # AI: have a second step point. It is run through _executeInContext: inside a single
+        # AI: run_code execute (a step-point break only traps during an execute, not a perform).
+        # AI: The method is never installed in any dictionary, so there is nothing to clean up;
+        # AI: the debugger shows it as a "doIt" header over the selection.
+        doit_method_source = self.smalltalk_string_literal("doIt\n" + source)
+        return self.run_code(
+            "| swordfishDebugMethod |\n"
+            "swordfishDebugMethod := UndefinedObject\n"
+            "  _compileMethod: %s\n"
+            "  symbolList: System myUserProfile symbolList.\n"
+            "swordfishDebugMethod setBreakAtStepPoint: "
+            "(swordfishDebugMethod _sourceOffsets size min: 2).\n"
+            "swordfishDebugMethod _executeInContext: nil" % doit_method_source
+        )
+
+    def run_stopping_at_first_statement(self, compiled_method, source):
+        step_point = self.first_statement_step_point(compiled_method)
+        self.set_step_point_break(compiled_method, step_point)
+        try:
+            return self.run_code(source)
+        finally:
+            self.clear_step_point_break(compiled_method, step_point)
+
+    def first_statement_step_point(self, compiled_method):
+        # AI: Step point 1 of a method is its entry (the header line); step point 2 is the
+        # AI: first real statement - the first place worth stopping. Methods without a second
+        # AI: step point fall back to the one they have.
+        step_point_count = compiled_method.perform("_sourceOffsets").size().to_py
+        return min(2, step_point_count)
+
+    def set_step_point_break(self, compiled_method, step_point):
+        compiled_method.perform(
+            "setBreakAtStepPoint:",
+            self.gemstone_session.from_py(step_point),
+        )
+
+    def clear_step_point_break(self, compiled_method, step_point):
+        compiled_method.perform(
+            "disableBreakAtStepPoint:",
+            self.gemstone_session.from_py(step_point),
         )
 
     def summarized_test_result(self, test_result):

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -1027,6 +1027,10 @@ class GemstoneSessionRecord:
             class_name, method_selector
         )
 
+    def debug_source(self, source):
+        self.require_write_access("debug_source")
+        return self.gemstone_browser_session.debug_source(source)
+
     def set_breakpoint(
         self,
         class_name,

--- a/src/reahl/swordfish/mcp/tools.py
+++ b/src/reahl/swordfish/mcp/tools.py
@@ -5206,8 +5206,12 @@ def register_tools(
         test_case_class_name,
         test_method_selector,
     ):
-        """Like gs_run_test_method but pauses on first error and returns a debug_id
-        you can step through with gs_debug_step_*. Requires --allow-test-execution."""
+        """Like gs_run_test_method but stops in the debugger on the first statement of the
+        test method - as if an implicit breakpoint sat there - and returns a debug_id you
+        can step through with gs_debug_step_*. It no longer waits for the test to fail: a
+        passing test still pauses on its first statement (after setUp). tests_passed is only
+        reported for the rare method with no statement to stop at. The implicit break is
+        transient and leaves nothing behind in the image. Requires --allow-test-execution."""
         test_exec_error = require_test_execution_enabled(
             connection_id, 'gs_debug_test_method'
         )

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -956,7 +956,7 @@ class CodePanel(tk.Frame):
             'SourceTextDebug', log_context={'code': selected_text}
         )
         try:
-            self.gemstone_session_record.run_code(selected_text)
+            self.gemstone_session_record.debug_source(selected_text)
         except (DomainException, GemstoneDomainException) as domain_exception:
             messagebox.showerror('Debug Selection', str(domain_exception))
             return

--- a/tests/test_gemstone_browser_debug_first_step_point.py
+++ b/tests/test_gemstone_browser_debug_first_step_point.py
@@ -1,0 +1,163 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, expected, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+# AI: "Debug" should always drop you into the debugger on the FIRST STATEMENT of the code you
+# AI: asked to debug - as if an implicit breakpoint sat there - rather than only stopping when
+# AI: the code happens to raise. The mechanism (verified against a live gem) is a transient
+# AI: break at step point 2 (step point 1 is the method entry / header), which traps to the
+# AI: client exactly like the existing debugger expects. A step-point break only traps during
+# AI: an EXECUTE, so the code under debug is always run through run_code, never invoked via
+# AI: gem_proxy.perform. For selected text we compile a doit-METHOD (whose entry maps cleanly
+# AI: to step points) rather than a block (whose prologue would put the marker ahead of
+# AI: execution).
+
+
+class WrappedInteger:
+    """AI: parseltongue's from_py wraps a Python int as a gem object whose .to_py reads
+    it back. The break-installing code converts the step point through from_py, so the
+    recorded argument arrives wrapped - this satisfies just that contract."""
+
+    def __init__(self, value):
+        self.to_py = value
+
+
+class RecordingSession:
+    def from_py(self, value):
+        return WrappedInteger(value)
+
+
+class FakeStepPointOffsets:
+    def __init__(self, count):
+        self.count = count
+
+    def size(self):
+        return WrappedInteger(self.count)
+
+
+class RecordingCompiledMethod:
+    """AI: Records the step-point break protocol (setBreakAtStepPoint: /
+    disableBreakAtStepPoint:) so a test can prove a break was both installed and removed,
+    and reports a step-point count via _sourceOffsets so the first-statement (step point 2)
+    choice can be exercised."""
+
+    def __init__(self, step_point_count=5):
+        self.step_point_count = step_point_count
+        self.step_points_broken = []
+        self.step_points_cleared = []
+
+    def perform(self, selector, *args):
+        if selector == '_sourceOffsets':
+            return FakeStepPointOffsets(self.step_point_count)
+        if selector == 'setBreakAtStepPoint:':
+            self.step_points_broken.append(args[0].to_py)
+            return None
+        if selector == 'disableBreakAtStepPoint:':
+            self.step_points_cleared.append(args[0].to_py)
+            return None
+        raise AssertionError('AI: Unexpected selector: %s' % selector)
+
+
+class SimulatedBreakpointTrap(Exception):
+    """AI: Stands in for the ptongue GemstoneError raised when the implicit step-point
+    break traps. The session layer must let it propagate so the debugger can open on it."""
+
+
+@stubclass(GemstoneBrowserSession)
+class RecordingDebugSession(GemstoneBrowserSession):
+    requested_method = None
+    run_outcome = None
+    canned_run_result = None
+    compiled_method = None
+
+    def get_compiled_method(self, class_name, method_selector, show_instance_side):
+        self.requested_method = (class_name, method_selector, show_instance_side)
+        return self.compiled_method
+
+    def run_code(self, source):
+        self.run_code_sources.append(source)
+        if self.run_outcome is not None:
+            raise self.run_outcome
+        return self.canned_run_result
+
+
+class DebugFirstStepPointFixture(Fixture):
+    def new_compiled_method(self):
+        return RecordingCompiledMethod()
+
+    def new_browser_session(self):
+        session = RecordingDebugSession(RecordingSession())
+        session.compiled_method = self.compiled_method
+        session.run_code_sources = []
+        return session
+
+
+@with_fixtures(DebugFirstStepPointFixture)
+def test_debugging_a_test_breaks_at_its_first_statement(fixture):
+    """AI: Debugging a test method should stop on its first real statement, not its header:
+    the session installs a break at step point 2 (step point 1 is the method entry) of the
+    instance-side test method and runs the test via runCase, so the trap lands on the first
+    statement of the test body (after setUp)."""
+    session = fixture.browser_session
+    session.run_outcome = SimulatedBreakpointTrap()
+
+    with expected(SimulatedBreakpointTrap):
+        session.debug_test_method('AccountTest', 'testDeposit')
+
+    assert session.requested_method == ('AccountTest', 'testDeposit', True)
+    executed_source = session.run_code_sources[-1]
+    assert "AccountTest selector: ('testDeposit' asSymbol)" in executed_source
+    assert 'runCase' in executed_source
+    assert fixture.compiled_method.step_points_broken == [2]
+
+
+@with_fixtures(DebugFirstStepPointFixture)
+def test_implicit_test_break_is_removed_even_when_it_traps(fixture):
+    """AI: The implicit break is transient - it must be removed once the run is under way,
+    even though hitting it raises the trap that opens the debugger - so debugging a test
+    never leaves breakpoints lying around in the image."""
+    session = fixture.browser_session
+    session.run_outcome = SimulatedBreakpointTrap()
+
+    with expected(SimulatedBreakpointTrap):
+        session.debug_test_method('AccountTest', 'testDeposit')
+
+    assert fixture.compiled_method.step_points_cleared == [2]
+
+
+@with_fixtures(DebugFirstStepPointFixture)
+def test_debugging_selected_source_compiles_it_as_a_doit_method_run_via_execute(fixture):
+    """AI: Selected text is compiled into a doit-METHOD (not a block, whose prologue would
+    put the marker two step points ahead of execution), broken at its first statement (step
+    point 2, since step point 1 is the synthetic doIt header), and run through
+    _executeInContext: in a single execute - so the break traps on the selection's first
+    statement with the marker where execution actually is."""
+    session = fixture.browser_session
+    session.run_outcome = SimulatedBreakpointTrap()
+
+    with expected(SimulatedBreakpointTrap):
+        session.debug_source('account deposit: 10')
+
+    executed_source = session.run_code_sources[-1]
+    assert '_compileMethod:' in executed_source
+    assert "'doIt\naccount deposit: 10'" in executed_source
+    assert 'setBreakAtStepPoint: (swordfishDebugMethod _sourceOffsets size min: 2)' in executed_source
+    assert '_executeInContext: nil' in executed_source
+
+
+@with_fixtures(DebugFirstStepPointFixture)
+def test_debug_doit_method_is_compiled_uninstalled_so_nothing_persists(fixture):
+    """AI: The doit-method is compiled with UndefinedObject _compileMethod:symbolList:, which
+    returns an uninstalled GsNMethod - never added to any class's method dictionary - so
+    debugging arbitrary source leaves nothing behind in the image to clean up."""
+    session = fixture.browser_session
+    session.run_outcome = SimulatedBreakpointTrap()
+
+    with expected(SimulatedBreakpointTrap):
+        session.debug_source('account deposit: 10')
+
+    executed_source = session.run_code_sources[-1]
+    assert 'UndefinedObject' in executed_source
+    assert 'compileMethod:dictionaries:' not in executed_source

--- a/tests/test_gemstone_browser_debug_first_step_point.py
+++ b/tests/test_gemstone_browser_debug_first_step_point.py
@@ -3,7 +3,6 @@ from reahl.tofu import Fixture, expected, with_fixtures
 
 from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
 
-
 # AI: "Debug" should always drop you into the debugger on the FIRST STATEMENT of the code you
 # AI: asked to debug - as if an implicit breakpoint sat there - rather than only stopping when
 # AI: the code happens to raise. The mechanism (verified against a live gem) is a transient

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -21,6 +21,7 @@ from reahl.tofu import (
 from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
 from reahl.swordfish.gemstone.session import DomainException as GemstoneDomainException
 from reahl.swordfish.main import (
+    GEMSTONE_EXE_CONF_CONFIG_NAME,
     BreakpointsDialog,
     BrowserWindow,
     CoveringTestsBrowseDialog,
@@ -29,7 +30,6 @@ from reahl.swordfish.main import (
     EventQueue,
     Explorer,
     FindDialog,
-    GEMSTONE_EXE_CONF_CONFIG_NAME,
     GemstoneSessionRecord,
     GlobalNavigationEntry,
     GlobalNavigationHistory,

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -169,6 +169,18 @@ def select_find_result(dialog, label):
     dialog.results_tree.selection_set(find_result_iid_for_label(dialog, label))
 
 
+def route_debug_source_through_real_session(mock_browser):
+    # AI: The Debug button/menu calls debug_source, which (see its own unit tests) wraps the
+    # selection in a block and runs it through run_code, stopping at its first step point.
+    # GUI tests only need the debugger-opening flow, so route debug_source to a single
+    # run_code: that lets tests arming run_code (the GemStone leaf) drive the debugger while
+    # debug_source still records the unwrapped selection it was asked to debug.
+    def debug_selection(source):
+        return mock_browser.run_code(source)
+
+    mock_browser.debug_source.side_effect = debug_selection
+
+
 class SwordfishGuiFixture(Fixture):
     @set_up
     def create_app(self):
@@ -176,6 +188,7 @@ class SwordfishGuiFixture(Fixture):
         self.root.withdraw()
 
         self.mock_browser = Mock(spec=GemstoneBrowserSession)
+        route_debug_source_through_real_session(self.mock_browser)
         self.mock_browser.list_categories.return_value = ["Kernel", "Collections"]
         self.mock_browser.list_dictionaries.return_value = [
             "Kernel",
@@ -1224,7 +1237,7 @@ def test_debug_command_from_method_source_context_menu_opens_debugger_for_runtim
     menu = fixture.open_text_context_menu_for_tab(tab)
     fixture.invoke_menu_command(menu, "Debug")
 
-    fixture.mock_browser.run_code.assert_called_with("1/0")
+    fixture.mock_browser.debug_source.assert_called_with("1/0")
     tab.code_panel.application.open_debugger.assert_called_once_with(runtime_error)
 
 
@@ -2036,6 +2049,7 @@ class SwordfishAppFixture(Fixture):
     def create_app(self):
         self.mock_gemstone_session = Mock()
         self.mock_browser = Mock(spec=GemstoneBrowserSession)
+        route_debug_source_through_real_session(self.mock_browser)
         self.mock_browser.list_categories.return_value = ["Kernel", "Collections"]
         self.mock_browser.list_dictionaries.return_value = [
             "Kernel",
@@ -3828,7 +3842,7 @@ def test_run_context_menu_debug_opens_debugger_for_selected_text_only(fixture):
     invoke_menu_command_by_label(run_tab.current_text_menu, "Debug")
     fixture.app.update()
 
-    fixture.mock_browser.run_code.assert_called_with("1/0")
+    fixture.mock_browser.debug_source.assert_called_with("1/0")
     tab_labels = [
         fixture.app.notebook.tab(t, "text") for t in fixture.app.notebook.tabs()
     ]
@@ -5677,11 +5691,10 @@ def test_debug_button_uses_current_source_text_not_stale_prior_error(fixture):
     run_tab.debug_button.invoke()
     fixture.app.update()
 
-    assert fixture.mock_browser.run_code.call_args_list[-1] == call("2 + 2")
+    assert fixture.mock_browser.debug_source.call_args_list[-1] == call("2 + 2")
     assert fixture.app.debugger_tab is None
     assert (
-        run_tab.status_label.cget("text")
-        == "Completed successfully; no debugger context"
+        run_tab.status_label.cget("text") == "Completed; no step point to stop at"
     )
 
 
@@ -5713,7 +5726,7 @@ def test_debug_button_does_not_open_debugger_for_compile_error(fixture):
     ]
     assert "Debugger" not in tab_labels
     expected_source = run_tab.source_text.get("1.0", "end-1c")
-    assert fixture.mock_browser.run_code.call_args_list[-1] == call(expected_source)
+    assert fixture.mock_browser.debug_source.call_args_list[-1] == call(expected_source)
     assert "line 2, column 40" in run_tab.status_label.cget("text")
 
 


### PR DESCRIPTION
  Makes the Debug action always drop you straight into the debugger on the first statement of whatever you asked to debug — a test method or a selected expression — as if an implicit
  breakpoint sat there. Previously Debug only opened the debugger if the code happened to raise an unhandled error; a passing test or clean expression just ran to completion with
  nothing to inspect.

The mechanism is a transient breakpoint that traps to the client exactly like the existing debugger expects, then disappears — no breakpoints are left lying around in the image.

  - Debug a test (debug_test_method): install a break at the test method's first statement (step point 2 — step point 1 is the method entry/header), run it via runCase so setUp has
  happened, and clear the break in a finally. You land on the first real statement of the test body.
  - Debug selected source (debug_source): a selection has no named method to break on, so it's compiled into an uninstalled doit-method via UndefinedObject _compileMethod:symbolList:
  (a method's entry maps cleanly to step points, unlike a block, whose prologue would put the marker ahead of execution), broken at its first statement, and run via _executeInContext:
  inside a single run_code execute. The method is never installed in any dictionary, so there's nothing to clean up.

  A key constraint drove the design: a GemStone step-point break only traps back to the client during an execute, not when code is invoked via gem_proxy.perform. That's why the
  selection is run through run_code rather than a direct perform. (Filed a parseltongue follow-up to make perform trap breakpoints; when that lands this can be simplified.)

  Contract change (advertised)

  The MCP tool gs_debug_test_method no longer waits for a failure: a passing test now pauses on its first statement and returns a debug_id to step through, instead of reporting
  tests_passed. Its docstring is updated accordingly