### PR TITLE
Made tabs pinnable

### DIFF
--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -2452,6 +2452,25 @@ class MethodEditor(FramedWidget):
         for tab_path in tab_paths[after_index + 1:]:
             self.close_tab(self.editor_notebook.nametowidget(tab_path))
 
+    def close_tabs_in_same_class(self, reference_tab):
+        # AI: Close every open method that belongs to the same class as
+        # reference_tab (including reference_tab itself). tab_key[0] is the
+        # class name. Iterate a snapshot because close_tab mutates the tab set.
+        reference_class = reference_tab.tab_key[0]
+        for tab_path in list(self.editor_notebook.tabs()):
+            tab_widget = self.editor_notebook.nametowidget(tab_path)
+            if tab_widget.tab_key[0] == reference_class:
+                self.close_tab(tab_widget)
+
+    def close_tabs_in_other_classes(self, reference_tab):
+        # AI: Close every open method that belongs to a different class than
+        # reference_tab, leaving the tabs for reference_tab's class open.
+        reference_class = reference_tab.tab_key[0]
+        for tab_path in list(self.editor_notebook.tabs()):
+            tab_widget = self.editor_notebook.nametowidget(tab_path)
+            if tab_widget.tab_key[0] != reference_class:
+                self.close_tab(tab_widget)
+
     def close_editor_tab_at_index(self, notebook, tab_index):
         # AI: Adapter that the closable_notebook helper calls when the user
         # clicks the 'x' on a tab. Routes through the existing close_tab to

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -1729,6 +1729,11 @@ class MethodSelection(FramedWidget):
         self.event_queue.subscribe('Aborted', self.repopulate)
 
         self.selection_list.selection_listbox.bind('<Button-3>', self.show_context_menu)
+        # AI: A single click opens the method in a transient preview tab; a
+        # double click pins that tab so it is no longer recycled.
+        self.selection_list.selection_listbox.bind(
+            '<Double-Button-1>', self.pin_selected_method_tab
+        )
 
     def populate_text_editor(self, event):
         selected_listbox = event.widget
@@ -1815,6 +1820,13 @@ class MethodSelection(FramedWidget):
         self.event_queue.publish(
             'MethodSelected', origin=self, log_context={'method': selected_method}
         )
+
+    def pin_selected_method_tab(self, event=None):
+        # AI: Double-clicking a method promotes its preview editor tab to a
+        # permanent one (mirrors VS Code's double-click-to-keep behaviour).
+        # The preceding single click already opened the preview tab, so the
+        # MethodEditor just needs to pin the current selection.
+        self.event_queue.publish('MethodTabPinRequested', origin=self)
 
     def select_inherited_method(self, selected_method, owner_class_name):
         show_instance_side = self.gemstone_session_record.show_instance_side
@@ -2374,8 +2386,12 @@ class MethodEditor(FramedWidget):
 
         self.open_tab_registry = DeduplicatedTabRegistry(self.editor_notebook)
         self.open_tabs = self.open_tab_registry.tabs_by_key
+        # AI: Key of the single transient "preview" tab, or None. Opening a
+        # method in preview mode recycles this tab instead of adding a new one.
+        self.preview_tab_key = None
 
         self.event_queue.subscribe('MethodSelected', self.open_method)
+        self.event_queue.subscribe('MethodTabPinRequested', self.pin_current_method_tab)
         self.event_queue.subscribe(
             'MethodSelected',
             self.record_method_navigation,
@@ -2420,6 +2436,8 @@ class MethodEditor(FramedWidget):
             return
         self.editor_notebook.forget(self.open_tabs[tab.tab_key])
         self.open_tab_registry.remove_key(tab.tab_key)
+        if self.preview_tab_key == tab.tab_key:
+            self.preview_tab_key = None
 
     def close_other_tabs(self, except_tab):
         # AI: Iterate a snapshot of tab paths because close_tab mutates the set.
@@ -2540,6 +2558,13 @@ class MethodEditor(FramedWidget):
         if self.open_tab_registry.select_key(method_context):
             return
 
+        # AI: A method opened from the list starts life as a transient "preview"
+        # tab. At most one preview tab exists at a time, so opening another
+        # method recycles this slot instead of accumulating tabs. The tab
+        # becomes permanent ("pinned") when the user edits it, pins it from the
+        # tab menu, or double-clicks the method in the list (see pin_tab).
+        self.discard_preview_tab()
+
         new_tab = EditorTab(
             self.editor_notebook,
             self.browser_window,
@@ -2553,9 +2578,42 @@ class MethodEditor(FramedWidget):
             new_tab,
             selected_method_symbol,
         )
+        self.preview_tab_key = method_context
+        new_tab.update_tab_label()
         new_tab.code_panel.set_read_only(
             self.browser_window.application.integrated_session_state.is_mcp_busy()
         )
+
+    def discard_preview_tab(self):
+        # AI: Close the current preview (unpinned) tab, if any. A preview tab
+        # never holds unsaved edits because the first edit pins it, so closing
+        # it here is always safe.
+        if self.preview_tab_key is None:
+            return
+        if self.preview_tab_key in self.open_tabs:
+            self.editor_notebook.forget(self.open_tabs[self.preview_tab_key])
+            self.open_tab_registry.remove_key(self.preview_tab_key)
+        self.preview_tab_key = None
+
+    def tab_is_pinned(self, tab):
+        # AI: A tab is pinned (permanent) unless it is the single preview tab.
+        return tab.tab_key != self.preview_tab_key
+
+    def pin_tab(self, tab):
+        # AI: Promote the preview tab to a permanent one so it survives opening
+        # other methods. Already-pinned tabs are left untouched.
+        if self.preview_tab_key == tab.tab_key:
+            self.preview_tab_key = None
+            tab.update_tab_label()
+
+    def pin_current_method_tab(self, origin=None):
+        # AI: Driven by MethodTabPinRequested (a double-click in the method
+        # list). Pins the tab for the currently selected method.
+        method_context = self.current_method_context()
+        if method_context is None:
+            return
+        if method_context in self.open_tabs:
+            self.pin_tab(self.open_tabs[method_context])
 
     def set_read_only(self, read_only):
         for open_tab in self.open_tabs.values():

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -2017,6 +2017,17 @@ class EditorTab(tk.Frame):
             label='Close All to the Right',
             command=lambda: self.method_editor.close_tabs_to_right(self),
         )
+        # AI: tab_key is (class_name, instance_side, selector); name the actual
+        # class in the labels so the scope of each bulk close is unambiguous.
+        tab_class_name = self.tab_key[0]
+        menu.add_command(
+            label=f'Close All in {tab_class_name}',
+            command=lambda: self.method_editor.close_tabs_in_same_class(self),
+        )
+        menu.add_command(
+            label=f'Close All not in {tab_class_name}',
+            command=lambda: self.method_editor.close_tabs_in_other_classes(self),
+        )
         menu.bind(
             '<Escape>',
             lambda popup_event: close_popup_menu(menu),

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -1941,6 +1941,11 @@ class CodePanel(tk.Frame):
             self.is_refreshing = False
 
 
+# AI: Leading marker shown on a pinned (permanent) editor tab. Preview tabs
+# show the bare selector; this distinguishes the tab that will not be recycled.
+PINNED_TAB_MARKER = '★ '
+
+
 class EditorTab(tk.Frame):
     def __init__(self, parent, browser_window, method_editor, tab_key):
         super().__init__(parent)
@@ -1989,6 +1994,17 @@ class EditorTab(tk.Frame):
             state=write_command_state,
         )
         menu.add_separator()
+        # AI: Pinning is only meaningful for the transient preview tab; an
+        # already-pinned tab disables the command rather than hiding it.
+        pin_command_state = (
+            tk.DISABLED if self.method_editor.tab_is_pinned(self) else tk.NORMAL
+        )
+        menu.add_command(
+            label='Pin Tab',
+            command=lambda: self.method_editor.pin_tab(self),
+            state=pin_command_state,
+        )
+        menu.add_separator()
         menu.add_command(
             label='Close',
             command=lambda: self.method_editor.close_tab(self),
@@ -2010,11 +2026,18 @@ class EditorTab(tk.Frame):
     def mark_dirty(self):
         if not self.is_dirty:
             self.is_dirty = True
+            # AI: Editing a preview tab makes it permanent so the user's work
+            # is never silently discarded when another method is opened.
+            self.method_editor.pin_tab(self)
             self.update_tab_label()
 
     def update_tab_label(self):
         _, _, method_symbol = self.tab_key
-        label = ('*' + method_symbol) if self.is_dirty else method_symbol
+        label = method_symbol
+        if self.method_editor.tab_is_pinned(self):
+            label = PINNED_TAB_MARKER + label
+        if self.is_dirty:
+            label = '*' + label
         try:
             self.method_editor.editor_notebook.tab(self, text=label)
         except tk.TclError:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1030,6 +1030,9 @@ def test_tab_context_menu_lists_expected_tab_actions(fixture):
     assert "Close" in command_labels
     assert "Close Others" in command_labels
     assert "Close All to the Right" in command_labels
+    # AI: The class-scoped bulk closes name the actual class (tab_key[0]).
+    assert "Close All in OrderLine" in command_labels
+    assert "Close All not in OrderLine" in command_labels
 
 
 @with_fixtures(SwordfishGuiFixture)
@@ -1066,6 +1069,47 @@ def test_close_tabs_to_right_preserves_left_of_clicked_tab(fixture):
 
     menu = fixture.open_tab_context_menu_for_tab(middle_tab)
     fixture.invoke_menu_command(menu, "Close All to the Right")
+
+    assert list(editor.open_tabs.keys()) == [
+        ("OrderLine", True, "total"),
+        ("OrderLine", True, "description"),
+    ]
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_close_all_in_same_class_closes_only_that_classes_tabs(fixture):
+    """AI: 'Close All in <class>' closes every open method of the clicked tab's
+    class and leaves methods of other classes open."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
+    fixture.select_down_to_method("Kernel", "Order", "accessing", "total", pin=True)
+
+    editor = fixture.browser_window.editor_area_widget
+    order_line_tab = editor.open_tabs[("OrderLine", True, "total")]
+
+    menu = fixture.open_tab_context_menu_for_tab(order_line_tab)
+    fixture.invoke_menu_command(menu, "Close All in OrderLine")
+
+    assert list(editor.open_tabs.keys()) == [("Order", True, "total")]
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_close_all_not_in_class_keeps_only_that_classes_tabs(fixture):
+    """AI: 'Close All not in <class>' closes methods of every other class and
+    keeps the clicked tab's class open."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
+    fixture.select_down_to_method("Kernel", "Order", "accessing", "total", pin=True)
+
+    editor = fixture.browser_window.editor_area_widget
+    order_line_tab = editor.open_tabs[("OrderLine", True, "total")]
+
+    menu = fixture.open_tab_context_menu_for_tab(order_line_tab)
+    fixture.invoke_menu_command(menu, "Close All not in OrderLine")
 
     assert list(editor.open_tabs.keys()) == [
         ("OrderLine", True, "total"),

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -52,6 +52,7 @@ from reahl.swordfish.main import (
 )
 from reahl.swordfish.mcp.integration_state import IntegratedSessionState
 from reahl.swordfish.object_diagram import UmlObjectDiagramNodeDetailDialog
+from reahl.swordfish.text_editing import PINNED_TAB_MARKER
 
 
 class FakeApplication:
@@ -310,8 +311,13 @@ class SwordfishGuiFixture(Fixture):
         selection_list.handle_selection(types.SimpleNamespace(widget=listbox))
         self.root.update()
 
-    def select_down_to_method(self, package, class_name, category, method):
-        """AI: Navigate all four selection columns to open an editor tab for a method."""
+    def select_down_to_method(self, package, class_name, category, method, pin=False):
+        """AI: Navigate all four selection columns to open an editor tab for a method.
+
+        A single selection opens the method in a transient *preview* tab; pass
+        pin=True to also pin it (as a user would by double-clicking), so it
+        survives opening other methods.
+        """
         self.select_in_listbox(
             self.browser_window.packages_widget.selection_list.selection_listbox,
             package,
@@ -328,6 +334,9 @@ class SwordfishGuiFixture(Fixture):
             self.browser_window.methods_widget.selection_list.selection_listbox,
             method,
         )
+        if pin:
+            self.browser_window.methods_widget.pin_selected_method_tab()
+            self.root.update()
 
     def open_text_context_menu_for_tab(self, tab):
         menu_event = types.SimpleNamespace(
@@ -816,14 +825,86 @@ def test_method_editor_source_shows_line_numbers(fixture):
 def test_selecting_already_open_method_brings_its_tab_to_fore(fixture):
     """Re-selecting a method that already has an open tab switches to that
     tab rather than opening a duplicate."""
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
     fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
 
     notebook = fixture.browser_window.editor_area_widget.editor_notebook
     assert len(notebook.tabs()) == 2
     selected_tab = notebook.select()
-    assert notebook.tab(selected_tab, "text") == "total"
+    assert notebook.tab(selected_tab, "text") == PINNED_TAB_MARKER + "total"
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_selecting_another_method_recycles_the_preview_tab(fixture):
+    """AI: A method opened from the list lives in a single transient preview
+    tab. Selecting a different method reuses that one tab rather than piling
+    up tabs, so an unpinned tab is never left behind."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+
+    editor = fixture.browser_window.editor_area_widget
+    assert list(editor.open_tabs.keys()) == [("OrderLine", True, "description")]
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_double_clicking_a_method_pins_its_tab(fixture):
+    """AI: Double-clicking a method pins its tab, so it is no longer the
+    recyclable preview tab and survives opening another method."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+
+    editor = fixture.browser_window.editor_area_widget
+    assert ("OrderLine", True, "total") in editor.open_tabs
+    assert ("OrderLine", True, "description") in editor.open_tabs
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_pinned_tab_label_carries_the_pin_marker(fixture):
+    """AI: A pinned tab is distinguished from a preview tab by a marker on its
+    label; the preview tab shows the bare selector."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    editor = fixture.browser_window.editor_area_widget
+    preview_tab = editor.open_tabs[("OrderLine", True, "total")]
+    assert editor.editor_notebook.tab(preview_tab, "text") == "total"
+
+    fixture.browser_window.methods_widget.pin_selected_method_tab()
+    fixture.root.update()
+    assert (
+        editor.editor_notebook.tab(preview_tab, "text") == PINNED_TAB_MARKER + "total"
+    )
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_pin_tab_command_keeps_the_tab_when_another_method_opens(fixture):
+    """AI: The 'Pin Tab' action on the tab menu promotes the preview tab to a
+    permanent one, exactly like double-clicking the method."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    editor = fixture.browser_window.editor_area_widget
+    tab = editor.open_tabs[("OrderLine", True, "total")]
+
+    menu = fixture.open_tab_context_menu_for_tab(tab)
+    fixture.invoke_menu_command(menu, "Pin Tab")
+
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+    assert ("OrderLine", True, "total") in editor.open_tabs
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_editing_a_preview_tab_pins_it(fixture):
+    """AI: Starting to edit a preview tab pins it, so a user's unsaved work is
+    never silently discarded when the next method is opened."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    editor = fixture.browser_window.editor_area_widget
+    tab = editor.open_tabs[("OrderLine", True, "total")]
+
+    tab.code_panel.text_editor.insert("end", "\n    ^42")
+    fixture.root.update()
+
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+    assert ("OrderLine", True, "total") in editor.open_tabs
 
 
 @with_fixtures(SwordfishGuiFixture)
@@ -955,9 +1036,11 @@ def test_tab_context_menu_lists_expected_tab_actions(fixture):
 def test_close_others_closes_only_other_tabs(fixture):
     """AI: Invoking 'Close Others' from a tab keeps that one tab open and
     closes every other tab in the editor notebook."""
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
-    fixture.select_down_to_method("Kernel", "Order", "accessing", "total")
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
+    fixture.select_down_to_method("Kernel", "Order", "accessing", "total", pin=True)
 
     editor = fixture.browser_window.editor_area_widget
     middle_tab = editor.open_tabs[("OrderLine", True, "description")]
@@ -972,9 +1055,11 @@ def test_close_others_closes_only_other_tabs(fixture):
 def test_close_tabs_to_right_preserves_left_of_clicked_tab(fixture):
     """AI: 'Close All to the Right' closes only the tabs positioned after the
     clicked tab, leaving the clicked tab and everything left of it open."""
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
-    fixture.select_down_to_method("Kernel", "Order", "accessing", "total")
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
+    fixture.select_down_to_method("Kernel", "Order", "accessing", "total", pin=True)
 
     editor = fixture.browser_window.editor_area_widget
     middle_tab = editor.open_tabs[("OrderLine", True, "description")]
@@ -1404,8 +1489,10 @@ def test_editor_notebook_uses_closable_style(fixture):
 def test_close_editor_tab_at_index_removes_that_tab(fixture):
     """AI: Closing a tab via the close-button dispatch removes that tab from
     the editor's open_tabs registry (and only that one)."""
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
-    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "description")
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total", pin=True)
+    fixture.select_down_to_method(
+        "Kernel", "OrderLine", "accessing", "description", pin=True
+    )
 
     editor = fixture.browser_window.editor_area_widget
     editor.editor_notebook.close_tab_at_index(0)


### PR DESCRIPTION
This is a small step towards #17 

When browsing methods, just review in a single tab unless open it pinned (double click) or choose to pin it on the tab's context menu. Also added more close methods on the right click menu.