### PR TITLE
Consolidated text-ish panes everywhere and add a scalar display pane to inspctor

### DIFF
--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -14,12 +14,14 @@ from reahl.swordfish.text_editing import (
     CodePanel,
     EditableText,
     TextCursorPositionIndicator,
+    Workspace,
     configure_widget_if_alive,
 )
 from reahl.swordfish.ui_context import UiContext
 from reahl.swordfish.ui_support import (
     add_source_code_commands,
     class_name_at_widget_cursor,
+    class_name_for_class_diagram,
     is_compile_error,
     popup_menu,
     selector_at_widget_cursor,
@@ -122,9 +124,16 @@ class RunTab(ttk.Frame):
         self.result_label = ttk.Label(self, text='Result:')
         self.result_label.grid(row=4, column=0, sticky='nw', padx=10, pady=(10, 0))
 
-        self.result_text = tk.Text(self, height=7, state='disabled')
-        self.editable_result = EditableText(self.result_text, self)
-        self.result_text.grid(row=5, column=0, sticky='nsew', padx=10, pady=(0, 10))
+        # AI: The result pane is a Workspace too: an editable, evaluable scratch
+        # pane so a run's printString can itself be selected and re-run/inspected/
+        # browsed. result_text/editable_result alias its internals so the existing
+        # result-writing and clipboard code keeps working unchanged.
+        self.result_workspace = Workspace(self, application=self.application)
+        self.result_workspace.grid(
+            row=5, column=0, sticky='nsew', padx=10, pady=(0, 10)
+        )
+        self.result_text = self.result_workspace.text
+        self.editable_result = self.result_workspace.editable
         self.configure_text_actions()
         self.source_cursor_position_indicator = TextCursorPositionIndicator(
             self.source_text,
@@ -151,14 +160,7 @@ class RunTab(ttk.Frame):
         )
         self.source_text.bind('<Button-3>', self.open_source_text_menu)
 
-        self.result_text.bind('<Control-a>', self.select_all_result_text)
-        self.result_text.bind('<Control-A>', self.select_all_result_text)
-        self.result_text.bind('<Control-c>', self.copy_result_selection)
-        self.result_text.bind('<Control-C>', self.copy_result_selection)
-        self.result_text.bind('<Button-3>', self.open_result_text_menu)
-
         self.source_text.bind('<Button-1>', self.close_text_menu, add='+')
-        self.result_text.bind('<Button-1>', self.close_text_menu, add='+')
 
     def is_read_only(self):
         is_busy = self.application.integrated_session_state.is_mcp_busy()
@@ -210,14 +212,6 @@ class RunTab(ttk.Frame):
     def replace_selected_source_text_before_typing(self, event):
         self.editable_source.delete_selection_before_typing(event)
 
-    def select_all_result_text(self, event=None):
-        self.editable_result.select_all()
-        return 'break'
-
-    def copy_result_selection(self, event=None):
-        self.editable_result.copy_selection()
-        return 'break'
-
     def open_source_text_menu(self, event):
         self.source_text.mark_set(tk.INSERT, f'@{event.x},{event.y}')
         self.show_text_menu_for_widget(
@@ -226,16 +220,6 @@ class RunTab(ttk.Frame):
             allow_paste=True,
             allow_undo=True,
             include_run_actions=True,
-        )
-
-    def open_result_text_menu(self, event):
-        self.result_text.mark_set(tk.INSERT, f'@{event.x},{event.y}')
-        self.show_text_menu_for_widget(
-            event,
-            self.result_text,
-            allow_paste=False,
-            allow_undo=False,
-            include_run_actions=False,
         )
 
     def selected_source_text(self):
@@ -268,6 +252,28 @@ class RunTab(ttk.Frame):
             )
             return
         self.application.browse_class(class_name, show_instance_side=True)
+
+    def add_class_to_class_diagram_from_source(self):
+        # AI: The class-name sibling of Browse Class: add the class named under the
+        # cursor (or the selection) straight to the Class Diagram, no evaluation.
+        class_name = class_name_at_widget_cursor(
+            self.source_text, self.selected_source_text()
+        )
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        if not class_name[0].isupper():
+            messagebox.showwarning(
+                'Not a Class Name',
+                f'{class_name!r} does not look like a class name. '
+                'Class names start with a capital letter.',
+            )
+            return
+        self.application.open_class_diagram_for_class(class_name)
 
     def open_implementors_from_source(self):
         # AI: Implementors from the Run tab's source editor. Mirrors the CodePanel
@@ -325,8 +331,6 @@ class RunTab(ttk.Frame):
     def editable_text_for_widget(self, text_widget):
         if text_widget is self.source_text:
             return self.editable_source
-        if text_widget is self.result_text:
-            return self.editable_result
         return EditableText(text_widget, self)
 
     def run_selected_source(self, selected_text):
@@ -476,6 +480,60 @@ class RunTab(ttk.Frame):
         finally:
             self.application.end_foreground_activity()
 
+    def show_selected_source_in_class_diagram(self, selected_text):
+        if self.is_read_only():
+            self.status_label.config(text='MCP is busy. Class diagram is disabled.')
+            return
+        if not selected_text.strip():
+            self.status_label.config(
+                text='Select source text to show in Class Diagram'
+            )
+            return
+        self.application.event_queue.publish(
+            'ClassDiagramSelectionRun', log_context={'code': selected_text}
+        )
+        self.status_label.config(text='Showing selection in Class Diagram...')
+        self.last_exception = None
+        self.clear_source_error_highlight()
+        self.application.begin_foreground_activity(
+            'Showing selected source in Class Diagram...'
+        )
+        try:
+            try:
+                result = self.gemstone_session_record.run_code(selected_text)
+                self.on_run_complete(result)
+                self.application.open_class_diagram_for_class(
+                    class_name_for_class_diagram(result)
+                )
+                self.application.event_queue.publish(
+                    'ClassDiagramSelectionSucceeded',
+                    log_context={
+                        'code': selected_text,
+                        'result': result.asString().to_py,
+                    },
+                )
+            except (DomainException, GemstoneDomainException) as domain_exception:
+                self.status_label.config(text=str(domain_exception))
+                self.show_error_in_result_panel(str(domain_exception), None, None)
+                self.application.event_queue.publish(
+                    'ClassDiagramSelectionFailed',
+                    log_context={
+                        'code': selected_text,
+                        'error': str(domain_exception),
+                    },
+                )
+            except GemstoneError as gemstone_exception:
+                self.on_run_error(gemstone_exception)
+                self.application.event_queue.publish(
+                    'ClassDiagramSelectionFailed',
+                    log_context={
+                        'code': selected_text,
+                        'error': str(gemstone_exception),
+                    },
+                )
+        finally:
+            self.application.end_foreground_activity()
+
     def show_text_menu_for_widget(
         self,
         event,
@@ -539,6 +597,10 @@ class RunTab(ttk.Frame):
             self.current_text_menu.add_command(
                 label='Browse Class',
                 command=self.browse_class_from_source,
+            )
+            self.current_text_menu.add_command(
+                label='Add to Class Diagram',
+                command=self.add_class_to_class_diagram_from_source,
             )
         self.current_text_menu.bind(
             '<Escape>',
@@ -668,10 +730,11 @@ class RunTab(ttk.Frame):
     def on_run_complete(self, result):
         self.status_label.config(text='Completed successfully')
         self.clear_source_error_highlight()
+        # AI: Leave the result pane editable (it is a Workspace scratch buffer);
+        # only refresh its content with the run's printString.
         self.result_text.config(state='normal')
         self.result_text.delete('1.0', tk.END)
         self.result_text.insert(tk.END, result.asString().to_py)
-        self.result_text.config(state='disabled')
 
     def on_run_error(self, exception):
         self.last_exception = exception
@@ -741,7 +804,6 @@ class RunTab(ttk.Frame):
             )
             self.result_text.insert(tk.END, f'{source_line}\n')
             self.result_text.insert(tk.END, f'{caret_padding}^\n')
-        self.result_text.config(state='disabled')
 
     def error_status_text(self, error_text, line_number, column_number):
         if line_number is not None and column_number is not None:
@@ -1111,6 +1173,7 @@ class DebuggerWindow(ttk.PanedWindow):
             root_tab_label='Context',
             external_inspect_action=self.application.open_inspector_for_object,
             graph_inspect_action=self.application.open_object_diagram_for_object,
+            application=self.application,
         )
         self.explorer = explorer
         explorer.grid(row=0, column=0, sticky='nsew')

--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -19,7 +19,9 @@ from reahl.swordfish.text_editing import (
 )
 from reahl.swordfish.ui_context import UiContext
 from reahl.swordfish.ui_support import (
-    add_source_code_commands,
+    add_diagram_commands,
+    add_navigation_commands,
+    add_run_commands,
     class_name_at_widget_cursor,
     class_name_for_class_diagram,
     is_compile_error,
@@ -575,32 +577,14 @@ class RunTab(ttk.Frame):
             )
         if include_run_actions:
             selected_text = self.selected_source_text()
+            enabled = not self.is_read_only()
             self.current_text_menu.add_separator()
-            add_source_code_commands(
-                self.current_text_menu,
-                self,
-                selected_text,
-                enabled=not self.is_read_only(),
-            )
-            self.current_text_menu.add_command(
-                label='Implementors',
-                command=self.open_implementors_from_source,
-            )
-            self.current_text_menu.add_command(
-                label='Senders',
-                command=self.open_senders_from_source,
-            )
-            self.current_text_menu.add_command(
-                label='References',
-                command=self.find_references_from_source,
-            )
-            self.current_text_menu.add_command(
-                label='Browse Class',
-                command=self.browse_class_from_source,
-            )
-            self.current_text_menu.add_command(
-                label='Add to Class Diagram',
-                command=self.add_class_to_class_diagram_from_source,
+            add_run_commands(self.current_text_menu, self, selected_text, enabled)
+            self.current_text_menu.add_separator()
+            add_navigation_commands(self.current_text_menu, self)
+            self.current_text_menu.add_separator()
+            add_diagram_commands(
+                self.current_text_menu, self, selected_text, enabled
             )
         self.current_text_menu.bind(
             '<Escape>',

--- a/src/reahl/swordfish/inspector.py
+++ b/src/reahl/swordfish/inspector.py
@@ -7,6 +7,7 @@ from reahl.ptongue import GemstoneError
 from reahl.swordfish.closable_notebook import install_close_buttons
 from reahl.swordfish.navigation import NavigationHistory
 from reahl.swordfish.tab_registry import DeduplicatedTabRegistry
+from reahl.swordfish.text_editing import Workspace
 from reahl.swordfish.ui_support import popup_menu
 
 
@@ -20,9 +21,11 @@ class ObjectInspector(ttk.Frame):
         graph_inspect_action=None,
         browse_class_action=None,
         event_queue=None,
+        application=None,
     ):
         super().__init__(parent)
         self.inspected_object = an_object
+        self.application = application
         self.external_inspect_action = external_inspect_action
         self.graph_inspect_action = graph_inspect_action
         self.browse_class_action = browse_class_action
@@ -44,6 +47,15 @@ class ObjectInspector(ttk.Frame):
         self.treeview.heading('Class', text='Class')
         self.treeview.heading('Value', text='Value')
         self.treeview.grid(row=0, column=0, sticky='nsew')
+
+        # AI: Scalar objects with no inspectable attributes are shown in this
+        # Workspace as their printString rather than an empty row list: an
+        # editable, evaluable scratch pane with the same context menu as every
+        # other source pane. It shares the treeview's grid cell; only one of the
+        # two is mapped.
+        self.value_workspace = Workspace(self, application=self.application)
+        self.value_workspace.grid(row=0, column=0, sticky='nsew')
+        self.value_workspace.grid_remove()
 
         self.footer = ttk.Frame(self)
         self.footer.grid(row=1, column=0, sticky='ew', pady=(4, 0))
@@ -114,6 +126,35 @@ class ObjectInspector(ttk.Frame):
             return self.normalized_text(an_object.printString().to_py)
         except GemstoneError:
             return ''
+
+    def print_string_text(self, an_object):
+        # AI: Unlike value_label this keeps the printString verbatim (including
+        # newlines), since the text view has room to show a faithful representation.
+        if an_object is None:
+            return ''
+        try:
+            return an_object.printString().to_py
+        except GemstoneError:
+            return ''
+
+    def show_attribute_rows(self):
+        # AI: Reveal the attribute treeview and hide the scalar value workspace.
+        self.value_workspace.grid_remove()
+        self.treeview.grid()
+
+    def show_value_text(self, an_object):
+        # AI: Reveal the scalar value workspace, seeded with the object's
+        # printString, and hide the attribute treeview.
+        self.pagination_mode = None
+        self.total_items = 0
+        self.treeview.grid_remove()
+        self.value_workspace.grid()
+        self.value_workspace.set_text(self.print_string_text(an_object))
+        # AI: A scalar has no rows to page through, so the pagination footer
+        # is cleared rather than reporting a misleading "0 items".
+        self.status_label.configure(text='')
+        self.previous_button.configure(state=tk.DISABLED)
+        self.next_button.configure(state=tk.DISABLED)
 
     def oop_label_of(self, an_object):
         if an_object is None:
@@ -253,7 +294,14 @@ class ObjectInspector(ttk.Frame):
 
         self.pagination_mode = None
         inspected_values = self.inspect_instance(an_object)
-        self.load_rows(list(inspected_values.items()), 'Name', len(inspected_values))
+        if inspected_values:
+            self.load_rows(
+                list(inspected_values.items()), 'Name', len(inspected_values)
+            )
+        else:
+            # AI: No inspectable attributes means a scalar value (Integer, String,
+            # Symbol, ...); show its printString as text rather than an empty list.
+            self.show_value_text(an_object)
 
     def configure_dictionary_rows(self, an_object):
         try:
@@ -381,6 +429,7 @@ class ObjectInspector(ttk.Frame):
         return values
 
     def load_rows(self, rows, first_column_title, total_items):
+        self.show_attribute_rows()
         self.treeview_heading = first_column_title
         self.total_items = total_items
         self.treeview.heading('Name', text=self.treeview_heading)
@@ -573,8 +622,10 @@ class Explorer(ttk.Notebook):
         graph_inspect_action=None,
         browse_class_action=None,
         event_queue=None,
+        application=None,
     ):
         super().__init__(parent)
+        self.application = application
         self.tab_registry = DeduplicatedTabRegistry(self)
         # AI: Each inspector tab gets an 'x' close affordance. Closing the
         # root tab is allowed — the surrounding InspectorTab manages whether
@@ -593,6 +644,7 @@ class Explorer(ttk.Notebook):
             graph_inspect_action=self.graph_inspect_action,
             browse_class_action=self.browse_class_action,
             event_queue=self.event_queue,
+            application=self.application,
         )
         tab_label = root_tab_label
         if tab_label is None:
@@ -641,6 +693,7 @@ class Explorer(ttk.Notebook):
                 external_inspect_action=self.external_inspect_action,
                 graph_inspect_action=self.graph_inspect_action,
                 browse_class_action=self.browse_class_action,
+                application=self.application,
             )
         except GemstoneError as e:
             messagebox.showerror('Inspector', f'Cannot inspect this object:\n{e}')
@@ -726,6 +779,7 @@ class InspectorTab(ttk.Frame):
             graph_inspect_action=graph_inspect_action,
             browse_class_action=self.application.browse_object_class,
             event_queue=self.application.event_queue,
+            application=self.application,
         )
         self.explorer.grid(row=1, column=0, sticky='nsew', padx=10, pady=(0, 10))
         self.explorer.bind(

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -2718,7 +2718,6 @@ class MainMenu(tk.Menu):
         super().__init__(parent, **kwargs)
         self.parent = parent
         self.event_queue = event_queue
-        self.file_menu = tk.Menu(self, tearoff=0)
         self.find_menu = tk.Menu(self, tearoff=0)
         self.debug_menu = tk.Menu(self, tearoff=0)
         self.session_menu = tk.Menu(self, tearoff=0)
@@ -2729,21 +2728,19 @@ class MainMenu(tk.Menu):
         self._subscribe_events()
 
     def _create_menus(self):
-        # File Menu
-        self.add_cascade(label="File", menu=self.file_menu)
-        self.update_file_menu()
+        # AI: Session comes first and now owns Exit (moved off the old File menu,
+        # which held nothing else and is gone).
+        self.add_cascade(label="Session", menu=self.session_menu)
+        self.update_session_menu()
 
         # Find Menu
         self.add_cascade(label="Find", menu=self.find_menu)
         self.update_find_menu()
 
-        # Debug Menu
-        self.add_cascade(label="Debug", menu=self.debug_menu)
+        # AI: The former Debug menu, renamed Code.
+        self.add_cascade(label="Code", menu=self.debug_menu)
         self.update_debug_menu()
 
-        # Session Menu
-        self.add_cascade(label="Session", menu=self.session_menu)
-        self.update_session_menu()
         self.add_cascade(label="MCP", menu=self.mcp_menu)
         self.update_mcp_menu()
         self.add_cascade(label="FileTree", menu=self.filetree_menu)
@@ -2757,7 +2754,6 @@ class MainMenu(tk.Menu):
 
     def update_menus(self, gemstone_session_record=None, **kwargs):
         self.update_session_menu()
-        self.update_file_menu()
         self.update_find_menu()
         self.update_debug_menu()
         self.update_mcp_menu()
@@ -2787,6 +2783,10 @@ class MainMenu(tk.Menu):
             self.session_menu.add_command(
                 label="Login", command=self.parent.show_login_screen
             )
+        # AI: Exit lives here now (it used to be the sole File-menu entry) and is
+        # always available, logged in or not.
+        self.session_menu.add_separator()
+        self.session_menu.add_command(label="Exit", command=self.parent.quit)
 
     def update_mcp_menu(self):
         self.mcp_menu.delete(0, tk.END)
@@ -2873,10 +2873,6 @@ class MainMenu(tk.Menu):
 
     def file_out_class_categories(self):
         self.parent.file_out_class_categories_from_menu()
-
-    def update_file_menu(self):
-        self.file_menu.delete(0, tk.END)
-        self.file_menu.add_command(label="Exit", command=self.parent.quit)
 
     def update_find_menu(self):
         self.find_menu.delete(0, tk.END)

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -15,8 +15,12 @@ from reahl.swordfish.gemstone.smalltalk_source_scanner import (
 )
 from reahl.swordfish.ui_support import (
     add_source_code_commands,
+    class_name_at_widget_cursor,
+    class_name_for_class_diagram,
     close_popup_menu,
     is_compile_error,
+    popup_menu,
+    selector_at_widget_cursor,
 )
 from reahl.swordfish.ui_support import selector_token as resolve_selector_token
 
@@ -234,6 +238,294 @@ class CodeLineNumberColumn:
         )
         self.line_numbers_text.configure(state='disabled')
         self.sync_scroll_position()
+
+
+class Workspace(ttk.Frame):
+    """AI: An editable, evaluable scratch pane. It is seeded with text (a doit, or
+    the printString of an inspected object) and offers the same Run / Inspect /
+    Debug / Show in Object Diagram / Implementors / Senders / References / Browse
+    Class context menu as the method editor and the run window's source pane, acting
+    on whatever the reader selects. Edits are a scratch buffer: they never write back
+    to whatever seeded the text. When no application is supplied (e.g. the object
+    diagram's embedded inspector) it degrades to a plain editable text pane without
+    the live-evaluation menu."""
+
+    def __init__(self, parent, application=None, initial_text=''):
+        super().__init__(parent)
+        self.application = application
+        self.current_context_menu = None
+
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+
+        self.text = tk.Text(self, undo=True, wrap='word')
+        self.editable = EditableText(self.text, self)
+        self.line_number_column = CodeLineNumberColumn(self, self.text)
+        self.line_number_column.line_numbers_text.grid(row=0, column=0, sticky='ns')
+        self.text.grid(row=0, column=1, sticky='nsew')
+
+        if initial_text:
+            self.set_text(initial_text)
+
+        self.text.bind('<Control-a>', self.select_all)
+        self.text.bind('<Control-A>', self.select_all)
+        self.text.bind('<Control-c>', self.copy_selection)
+        self.text.bind('<Control-C>', self.copy_selection)
+        self.text.bind('<Control-v>', self.paste)
+        self.text.bind('<Control-V>', self.paste)
+        self.text.bind('<Control-z>', self.undo)
+        self.text.bind('<Control-Z>', self.undo)
+        self.text.bind('<KeyPress>', self.replace_selection_before_typing, add='+')
+        self.text.bind('<Button-3>', self.open_context_menu)
+        self.text.bind('<Button-1>', self.close_context_menu, add='+')
+
+    @property
+    def gemstone_session_record(self):
+        return self.application.gemstone_session_record
+
+    def set_text(self, content):
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete('1.0', tk.END)
+        self.text.insert('1.0', content)
+
+    def selected_text(self):
+        start_index, end_index = self.editable.selected_range()
+        if start_index is None:
+            return ''
+        return self.text.get(start_index, end_index)
+
+    def is_read_only(self):
+        if self.application is None:
+            return False
+        return self.application.integrated_session_state.is_mcp_busy()
+
+    def select_all(self, event=None):
+        self.editable.select_all()
+        return 'break'
+
+    def copy_selection(self, event=None):
+        self.editable.copy_selection()
+        return 'break'
+
+    def paste(self, event=None):
+        self.editable.paste()
+        return 'break'
+
+    def undo(self, event=None):
+        self.editable.undo()
+        return 'break'
+
+    def replace_selection_before_typing(self, event):
+        self.editable.delete_selection_before_typing(event)
+
+    def run_selected_source(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only', 'MCP is busy. Run is disabled until MCP finishes.'
+            )
+            return
+        self.application.event_queue.publish(
+            'SourceTextRun', log_context={'code': selected_text}
+        )
+        self.application.run_code(selected_text)
+
+    def inspect_selected_source(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only', 'MCP is busy. Inspect is disabled until MCP finishes.'
+            )
+            return
+        self.application.event_queue.publish(
+            'SourceTextInspected', log_context={'code': selected_text}
+        )
+        try:
+            inspected_object = self.gemstone_session_record.run_code(selected_text)
+        except (DomainException, GemstoneDomainException) as domain_exception:
+            messagebox.showerror('Inspect Selection', str(domain_exception))
+            return
+        except GemstoneError as gemstone_exception:
+            messagebox.showerror('Inspect Selection', str(gemstone_exception))
+            return
+        self.application.open_inspector_for_object(inspected_object)
+
+    def show_selected_source_in_object_diagram(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only',
+                'MCP is busy. Object diagram is disabled until MCP finishes.',
+            )
+            return
+        try:
+            inspected_object = self.gemstone_session_record.run_code(selected_text)
+        except (DomainException, GemstoneDomainException) as domain_exception:
+            messagebox.showerror('Show in Object Diagram', str(domain_exception))
+            return
+        except GemstoneError as gemstone_exception:
+            messagebox.showerror('Show in Object Diagram', str(gemstone_exception))
+            return
+        self.application.open_object_diagram_for_object(inspected_object)
+
+    def show_selected_source_in_class_diagram(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only',
+                'MCP is busy. Class diagram is disabled until MCP finishes.',
+            )
+            return
+        try:
+            evaluated_object = self.gemstone_session_record.run_code(selected_text)
+        except (DomainException, GemstoneDomainException) as domain_exception:
+            messagebox.showerror('Show in Class Diagram', str(domain_exception))
+            return
+        except GemstoneError as gemstone_exception:
+            messagebox.showerror('Show in Class Diagram', str(gemstone_exception))
+            return
+        self.application.open_class_diagram_for_class(
+            class_name_for_class_diagram(evaluated_object)
+        )
+
+    def debug_selected_source(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only', 'MCP is busy. Debug is disabled until MCP finishes.'
+            )
+            return
+        self.application.event_queue.publish(
+            'SourceTextDebug', log_context={'code': selected_text}
+        )
+        try:
+            self.gemstone_session_record.debug_source(selected_text)
+        except (DomainException, GemstoneDomainException) as domain_exception:
+            messagebox.showerror('Debug Selection', str(domain_exception))
+            return
+        except GemstoneError as gemstone_exception:
+            if is_compile_error(gemstone_exception):
+                messagebox.showerror('Debug Selection', str(gemstone_exception))
+                return
+            self.application.open_debugger(gemstone_exception)
+
+    def open_implementors_from_source(self):
+        selector = selector_at_widget_cursor(self.text, self.selected_text())
+        if selector is None:
+            messagebox.showwarning(
+                'No Selector',
+                'Place the cursor on a selector or select one before running this.',
+            )
+            return
+        self.application.event_queue.publish(
+            'ImplementorsOpened', log_context={'selector': selector}
+        )
+        self.application.open_implementors_dialog(method_symbol=selector)
+
+    def open_senders_from_source(self):
+        selector = selector_at_widget_cursor(self.text, self.selected_text())
+        if selector is None:
+            messagebox.showwarning(
+                'No Selector',
+                'Place the cursor on a selector or select one before running this.',
+            )
+            return
+        self.application.event_queue.publish(
+            'SendersOpened', log_context={'selector': selector}
+        )
+        self.application.open_senders_dialog(method_symbol=selector)
+
+    def find_references_from_source(self):
+        class_name = class_name_at_widget_cursor(self.text, self.selected_text())
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        self.application.open_find_dialog_for_class(class_name)
+
+    def browse_class_from_source(self):
+        class_name = class_name_at_widget_cursor(self.text, self.selected_text())
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        if not class_name[0].isupper():
+            messagebox.showwarning(
+                'Not a Class Name',
+                f'{class_name!r} does not look like a class name. '
+                'Class names start with a capital letter.',
+            )
+            return
+        self.application.browse_class(class_name, show_instance_side=True)
+
+    def add_class_to_class_diagram_from_source(self):
+        # AI: The class-name sibling of Browse Class: add the class named under the
+        # cursor (or the selection) straight to the Class Diagram, no evaluation.
+        class_name = class_name_at_widget_cursor(self.text, self.selected_text())
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        if not class_name[0].isupper():
+            messagebox.showwarning(
+                'Not a Class Name',
+                f'{class_name!r} does not look like a class name. '
+                'Class names start with a capital letter.',
+            )
+            return
+        self.application.open_class_diagram_for_class(class_name)
+
+    def open_context_menu(self, event):
+        self.text.mark_set(tk.INSERT, f'@{event.x},{event.y}')
+        self.close_context_menu()
+        self.current_context_menu = tk.Menu(self, tearoff=0)
+        self.current_context_menu.add_command(
+            label='Select All', command=self.editable.select_all
+        )
+        self.current_context_menu.add_command(
+            label='Copy', command=self.editable.copy_selection
+        )
+        self.current_context_menu.add_command(
+            label='Paste', command=self.editable.paste
+        )
+        self.current_context_menu.add_command(
+            label='Undo', command=self.editable.undo
+        )
+        if self.application is not None:
+            selected_text = self.selected_text()
+            self.current_context_menu.add_separator()
+            add_source_code_commands(
+                self.current_context_menu,
+                self,
+                selected_text,
+                enabled=not self.is_read_only(),
+            )
+            self.current_context_menu.add_command(
+                label='Implementors', command=self.open_implementors_from_source
+            )
+            self.current_context_menu.add_command(
+                label='Senders', command=self.open_senders_from_source
+            )
+            self.current_context_menu.add_command(
+                label='References', command=self.find_references_from_source
+            )
+            self.current_context_menu.add_command(
+                label='Browse Class', command=self.browse_class_from_source
+            )
+            self.current_context_menu.add_command(
+                label='Add to Class Diagram',
+                command=self.add_class_to_class_diagram_from_source,
+            )
+        popup_menu(self.current_context_menu, event)
+
+    def close_context_menu(self, event=None):
+        if self.current_context_menu is not None:
+            close_popup_menu(self.current_context_menu)
+            self.current_context_menu = None
 
 
 class TextCursorPositionIndicator:
@@ -616,6 +908,10 @@ class CodePanel(tk.Frame):
             label='Browse Class',
             command=self.browse_class_from_source,
         )
+        self.current_context_menu.add_command(
+            label='Add to Class Diagram',
+            command=self.add_class_to_class_diagram_from_source,
+        )
         if self.application.experimental_features_enabled:
             self.current_context_menu.add_separator()
             self.current_context_menu.add_command(
@@ -945,6 +1241,26 @@ class CodePanel(tk.Frame):
         if hasattr(self.application, 'open_object_diagram_for_object'):
             self.application.open_object_diagram_for_object(inspected_object)
 
+    def show_selected_source_in_class_diagram(self, selected_text):
+        if self.is_read_only():
+            messagebox.showwarning(
+                'Read Only',
+                'MCP is busy. Class diagram is disabled until MCP finishes.',
+            )
+            return
+        try:
+            evaluated_object = self.gemstone_session_record.run_code(selected_text)
+        except (DomainException, GemstoneDomainException) as domain_exception:
+            messagebox.showerror('Show in Class Diagram', str(domain_exception))
+            return
+        except GemstoneError as gemstone_exception:
+            messagebox.showerror('Show in Class Diagram', str(gemstone_exception))
+            return
+        if hasattr(self.application, 'open_class_diagram_for_class'):
+            self.application.open_class_diagram_for_class(
+                class_name_for_class_diagram(evaluated_object)
+            )
+
     def debug_selected_source(self, selected_text):
         if self.is_read_only():
             messagebox.showwarning(
@@ -1039,6 +1355,27 @@ class CodePanel(tk.Frame):
             )
             return
         self.application.browse_class(class_name, show_instance_side=True)
+
+    def add_class_to_class_diagram_from_source(self):
+        # AI: The class-name sibling of Browse Class: add the class named under the
+        # cursor (or the selection) straight to the Class Diagram, no evaluation.
+        class_name = self.class_name_for_reference_lookup()
+        if class_name is None:
+            messagebox.showwarning(
+                'No Class Name',
+                'Place the cursor on a class name or select one before '
+                'running this.',
+            )
+            return
+        if not class_name[0].isupper():
+            messagebox.showwarning(
+                'Not a Class Name',
+                f'{class_name!r} does not look like a class name. '
+                'Class names start with a capital letter.',
+            )
+            return
+        if hasattr(self.application, 'open_class_diagram_for_class'):
+            self.application.open_class_diagram_for_class(class_name)
 
     def run_method_analysis(self, analysis_function, title):
         method_context = self.method_context()

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -14,7 +14,9 @@ from reahl.swordfish.gemstone.smalltalk_source_scanner import (
     SmalltalkTokenKind,
 )
 from reahl.swordfish.ui_support import (
-    add_source_code_commands,
+    add_diagram_commands,
+    add_navigation_commands,
+    add_run_commands,
     class_name_at_widget_cursor,
     class_name_for_class_diagram,
     close_popup_menu,
@@ -497,28 +499,14 @@ class Workspace(ttk.Frame):
         )
         if self.application is not None:
             selected_text = self.selected_text()
+            enabled = not self.is_read_only()
             self.current_context_menu.add_separator()
-            add_source_code_commands(
-                self.current_context_menu,
-                self,
-                selected_text,
-                enabled=not self.is_read_only(),
-            )
-            self.current_context_menu.add_command(
-                label='Implementors', command=self.open_implementors_from_source
-            )
-            self.current_context_menu.add_command(
-                label='Senders', command=self.open_senders_from_source
-            )
-            self.current_context_menu.add_command(
-                label='References', command=self.find_references_from_source
-            )
-            self.current_context_menu.add_command(
-                label='Browse Class', command=self.browse_class_from_source
-            )
-            self.current_context_menu.add_command(
-                label='Add to Class Diagram',
-                command=self.add_class_to_class_diagram_from_source,
+            add_run_commands(self.current_context_menu, self, selected_text, enabled)
+            self.current_context_menu.add_separator()
+            add_navigation_commands(self.current_context_menu, self)
+            self.current_context_menu.add_separator()
+            add_diagram_commands(
+                self.current_context_menu, self, selected_text, enabled
             )
         popup_menu(self.current_context_menu, event)
 
@@ -884,33 +872,15 @@ class CodePanel(tk.Frame):
             )
             self.current_context_menu.add_separator()
         selected_text = self.selected_text()
-        if selected_text:
-            add_source_code_commands(
-                self.current_context_menu,
-                self,
-                selected_text,
-                enabled=run_command_state == tk.NORMAL,
-            )
-            self.current_context_menu.add_separator()
-        self.current_context_menu.add_command(
-            label='Implementors',
-            command=self.open_implementors_from_source,
+        run_enabled = run_command_state == tk.NORMAL
+        add_run_commands(
+            self.current_context_menu, self, selected_text, run_enabled
         )
-        self.current_context_menu.add_command(
-            label='Senders',
-            command=self.open_senders_from_source,
-        )
-        self.current_context_menu.add_command(
-            label='References',
-            command=self.find_references_from_source,
-        )
-        self.current_context_menu.add_command(
-            label='Browse Class',
-            command=self.browse_class_from_source,
-        )
-        self.current_context_menu.add_command(
-            label='Add to Class Diagram',
-            command=self.add_class_to_class_diagram_from_source,
+        self.current_context_menu.add_separator()
+        add_navigation_commands(self.current_context_menu, self)
+        self.current_context_menu.add_separator()
+        add_diagram_commands(
+            self.current_context_menu, self, selected_text, run_enabled
         )
         if self.application.experimental_features_enabled:
             self.current_context_menu.add_separator()

--- a/src/reahl/swordfish/ui_support.py
+++ b/src/reahl/swordfish/ui_support.py
@@ -60,9 +60,10 @@ def is_compile_error(exception):
     return 'compileerror' in error_text or 'compile error' in error_text
 
 
-def add_source_code_commands(menu, source_code_editor, selected_text, enabled):
-    # AI: Shared Run/Inspect/Debug/Show in Object Diagram group for every live code
-    # AI: editor, so the action set stays identical wherever code is selected.
+def add_run_commands(menu, source_code_editor, selected_text, enabled):
+    # AI: The 'evaluate the selection' group - Run / Inspect / Debug - shared by
+    # every live code editor so the action set stays identical wherever code is
+    # selected. Disabled when there is nothing to evaluate.
     command_state = tk.NORMAL if enabled and selected_text.strip() else tk.DISABLED
 
     def add_command(label, action):
@@ -75,13 +76,56 @@ def add_source_code_commands(menu, source_code_editor, selected_text, enabled):
     add_command('Run', source_code_editor.run_selected_source)
     add_command('Inspect', source_code_editor.inspect_selected_source)
     add_command('Debug', source_code_editor.debug_selected_source)
-    add_command(
-        'Show in Object Diagram',
-        source_code_editor.show_selected_source_in_object_diagram,
+
+
+def add_navigation_commands(menu, source_code_editor):
+    # AI: The 'find the code behind a name' group - Implementors / Senders /
+    # References / Browse Class - which act on the selector or class name under the
+    # cursor, so they need no selection and are always enabled.
+    menu.add_command(
+        label='Implementors',
+        command=source_code_editor.open_implementors_from_source,
     )
-    add_command(
-        'Show in Class Diagram',
-        source_code_editor.show_selected_source_in_class_diagram,
+    menu.add_command(
+        label='Senders',
+        command=source_code_editor.open_senders_from_source,
+    )
+    menu.add_command(
+        label='References',
+        command=source_code_editor.find_references_from_source,
+    )
+    menu.add_command(
+        label='Browse Class',
+        command=source_code_editor.browse_class_from_source,
+    )
+
+
+def add_diagram_commands(menu, source_code_editor, selected_text, enabled):
+    # AI: The diagram group. The two 'Show in ...' entries evaluate the selection
+    # (so share its enablement); 'Add to Class Diagram' acts on the class name under
+    # the cursor, paired directly under 'Show in Class Diagram'.
+    eval_state = tk.NORMAL if enabled and selected_text.strip() else tk.DISABLED
+    menu.add_command(
+        label='Show in Object Diagram',
+        command=(
+            lambda code=selected_text: (
+                source_code_editor.show_selected_source_in_object_diagram(code)
+            )
+        ),
+        state=eval_state,
+    )
+    menu.add_command(
+        label='Show in Class Diagram',
+        command=(
+            lambda code=selected_text: (
+                source_code_editor.show_selected_source_in_class_diagram(code)
+            )
+        ),
+        state=eval_state,
+    )
+    menu.add_command(
+        label='Add to Class Diagram',
+        command=source_code_editor.add_class_to_class_diagram_from_source,
     )
 
 

--- a/src/reahl/swordfish/ui_support.py
+++ b/src/reahl/swordfish/ui_support.py
@@ -79,6 +79,24 @@ def add_source_code_commands(menu, source_code_editor, selected_text, enabled):
         'Show in Object Diagram',
         source_code_editor.show_selected_source_in_object_diagram,
     )
+    add_command(
+        'Show in Class Diagram',
+        source_code_editor.show_selected_source_in_class_diagram,
+    )
+
+
+def class_name_for_class_diagram(gem_object):
+    # AI: The class to diagram for an evaluated result: the object's class, or the
+    # object itself when it already is a class/metaclass (a Behavior). Mirrors how
+    # 'Show in Object Diagram' graphs the live result, but at the class level.
+    target = gem_object
+    try:
+        is_class = gem_object.isBehavior().to_py
+    except GemstoneError:
+        is_class = False
+    if not is_class:
+        target = gem_object.gemstone_class()
+    return target.name().to_py
 
 
 def word_under_text_cursor(text_widget):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3862,6 +3862,94 @@ def test_run_context_menu_graph_inspect_opens_graph_for_selected_result(fixture)
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_show_in_class_diagram_opens_class_diagram(fixture):
+    """AI: 'Show in Class Diagram' is part of the shared source-panel protocol, so
+    the workspace source menu evaluates the selection and opens the Class Diagram tab
+    on the class of the resulting object (here the selected class itself)."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "OrderLine")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.9")
+
+    evaluated_class = make_mock_gemstone_object("OrderLine class", "OrderLine")
+    evaluated_class.isBehavior.return_value.to_py = True
+    evaluated_class.name.return_value.to_py = "OrderLine"
+    fixture.mock_browser.run_code.return_value = evaluated_class
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    assert "Show in Class Diagram" in menu_command_labels(run_tab.current_text_menu)
+    invoke_menu_command_by_label(run_tab.current_text_menu, "Show in Class Diagram")
+    fixture.app.update()
+
+    fixture.mock_browser.run_code.assert_called_with("OrderLine")
+    assert fixture.app.class_diagram_tab is not None
+    selected_tab_text = fixture.app.notebook.tab(fixture.app.notebook.select(), "text")
+    assert selected_tab_text == "Class Diagram"
+    assert fixture.app.class_diagram_tab.uml_canvas.registry.class_node_for("OrderLine")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_add_to_class_diagram_uses_class_name_without_eval(
+    fixture,
+):
+    """AI: 'Add to Class Diagram' is the class-name sibling of Browse Class: it adds
+    the class named under the cursor/selection to the Class Diagram WITHOUT evaluating
+    anything, so it works on a bare class name in a larger expression."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "OrderLine new foo")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.9")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    assert "Add to Class Diagram" in menu_command_labels(run_tab.current_text_menu)
+    invoke_menu_command_by_label(run_tab.current_text_menu, "Add to Class Diagram")
+    fixture.app.update()
+
+    fixture.mock_browser.run_code.assert_not_called()
+    assert fixture.app.class_diagram_tab is not None
+    assert fixture.app.class_diagram_tab.uml_canvas.registry.class_node_for("OrderLine")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_inspector_scalar_value_pane_is_an_evaluable_workspace(fixture):
+    """AI: The scalar inspector pane is a Workspace seeded with the printString and
+    carrying the full evaluable context menu (Run / Inspect / Object & Class Diagram /
+    References / Browse Class), so an attribute-less value is no dead end."""
+    fixture.simulate_login()
+    scalar = make_mock_gemstone_object("Integer", "42")
+    fixture.app.open_inspector_for_object(scalar)
+    fixture.app.update()
+
+    explorer = fixture.app.inspector_tab.explorer
+    context_inspector = fixture.app.nametowidget(explorer.tabs()[0])
+    value_workspace = context_inspector.value_workspace
+
+    assert value_workspace.grid_info() != {}
+    assert value_workspace.text.get("1.0", "end-1c") == "42"
+
+    value_workspace.open_context_menu(
+        types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1)
+    )
+    labels = menu_command_labels(value_workspace.current_context_menu)
+    for expected_label in (
+        "Run",
+        "Inspect",
+        "Show in Object Diagram",
+        "Show in Class Diagram",
+        "References",
+        "Browse Class",
+        "Add to Class Diagram",
+    ):
+        assert expected_label in labels
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_run_source_context_menu_includes_implementors_senders_and_references(fixture):
     """AI: The workspace source menu should expose the same navigation group
     (Implementors, Senders, References) as the method editor, so a selector or
@@ -5691,7 +5779,9 @@ def test_global_back_skips_replaced_debugger_session_entries(fixture):
 
 @with_fixtures(SwordfishAppFixture)
 def test_run_result_text_supports_copy_and_has_result_context_menu(fixture):
-    """Run result text supports selecting/copying output via shortcuts and context menu actions."""
+    """The run result pane is now a Workspace: an editable scratch pane whose
+    context menu offers the full evaluable action set (Select All / Copy / Paste /
+    Undo plus Run), so a run's output can itself be copied, edited and re-run."""
     fixture.simulate_login()
     mock_result = Mock()
     mock_result.asString.return_value.to_py = "42"
@@ -5704,16 +5794,19 @@ def test_run_result_text_supports_copy_and_has_result_context_menu(fixture):
     assert run_tab.result_text.bind("<Control-a>")
     assert run_tab.result_text.bind("<Control-c>")
 
-    run_tab.select_all_result_text()
-    run_tab.copy_result_selection()
+    run_tab.result_workspace.select_all()
+    run_tab.result_workspace.copy_selection()
     assert fixture.app.clipboard_get() == "42"
 
-    run_tab.open_result_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
-    labels = menu_command_labels(run_tab.current_text_menu)
+    run_tab.result_workspace.open_context_menu(
+        types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1)
+    )
+    labels = menu_command_labels(run_tab.result_workspace.current_context_menu)
     assert "Select All" in labels
     assert "Copy" in labels
-    assert "Paste" not in labels
-    assert "Undo" not in labels
+    assert "Paste" in labels
+    assert "Undo" in labels
+    assert "Run" in labels
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -8227,6 +8320,38 @@ def test_array_inspector_shows_size_and_pages_through_values(fixture):
     assert len(next_rows) == 5
     assert array_inspector.status_label.cget("text") == "Items 101-105 of 105"
     assert array_inspector.treeview.item(next_rows[0], "values")[0] == "[101]"
+
+
+@with_fixtures(ObjectInspectorFixture)
+def test_attribute_less_object_shows_print_string_as_text(fixture):
+    """An object with no inspectable attributes (a scalar such as an Integer or
+    String) is best understood by its printed form, so the inspector replaces the
+    empty attribute list with a read-only text view of its printString."""
+    integer = make_mock_gemstone_object("Integer", "42")
+    scalar_inspector = ObjectInspector(fixture.root, an_object=integer)
+    scalar_inspector.pack()
+    fixture.root.update()
+
+    assert scalar_inspector.treeview.grid_info() == {}
+    assert scalar_inspector.value_workspace.grid_info() != {}
+    assert scalar_inspector.value_workspace.text.get("1.0", "end-1c") == "42"
+
+
+@with_fixtures(ObjectInspectorFixture)
+def test_object_with_attributes_keeps_the_attribute_list(fixture):
+    """An object that does expose instance variables still shows the attribute
+    treeview, never the scalar text view, so structured objects are unaffected."""
+    instance = make_mock_instance_with_inst_vars(
+        "OrderLine", "anOrderLine", {"quantity": fixture.mock_x}
+    )
+    instance_inspector = ObjectInspector(fixture.root, an_object=instance)
+    instance_inspector.pack()
+    fixture.root.update()
+
+    assert instance_inspector.treeview.grid_info() != {}
+    assert instance_inspector.value_workspace.grid_info() == {}
+    rows = instance_inspector.treeview.get_children()
+    assert instance_inspector.treeview.item(rows[0], "values")[0] == "quantity"
 
 
 @with_fixtures(SwordfishGuiFixture)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3268,17 +3268,25 @@ def test_find_menu_contains_find_implementors_senders_and_references_shortcuts(
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_file_menu_no_longer_carries_find_or_debug_shortcuts(fixture):
-    """AI: The File menu sheds the search and debug actions once they move to dedicated menus."""
+def test_session_menu_owns_exit_and_leads_the_menubar_with_a_code_menu(fixture):
+    """AI: Exit now lives on the Session menu (the File menu, which held nothing
+    else, is gone), Session leads the menubar, and the former Debug menu is Code."""
     fixture.simulate_login()
     fixture.app.menu_bar.update_menus()
+    menu_bar = fixture.app.menu_bar
 
-    file_menu_labels = menu_command_labels(fixture.app.menu_bar.file_menu)
-    assert "Find" not in file_menu_labels
-    assert "Implementors" not in file_menu_labels
-    assert "Senders" not in file_menu_labels
-    assert "Breakpoints" not in file_menu_labels
-    assert "Workspace" not in file_menu_labels
+    assert "Exit" in menu_command_labels(menu_bar.session_menu)
+
+    cascade_labels = []
+    entry_count = int(menu_bar.index("end")) + 1
+    for entry_index in range(entry_count):
+        if menu_bar.type(entry_index) == "cascade":
+            cascade_labels.append(menu_bar.entrycget(entry_index, "label"))
+
+    assert cascade_labels[0] == "Session"
+    assert "Code" in cascade_labels
+    assert "File" not in cascade_labels
+    assert "Debug" not in cascade_labels
 
 
 @with_fixtures(SwordfishAppFixture)
@@ -3914,6 +3922,51 @@ def test_run_source_context_menu_add_to_class_diagram_uses_class_name_without_ev
     fixture.mock_browser.run_code.assert_not_called()
     assert fixture.app.class_diagram_tab is not None
     assert fixture.app.class_diagram_tab.uml_canvas.registry.class_node_for("OrderLine")
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_run_source_context_menu_groups_actions_with_dividers(fixture):
+    """AI: The source menu groups its actions - evaluate (Run/Inspect/Debug),
+    navigate (Implementors/Senders/References/Browse Class) and diagram (Show in
+    Object/Class Diagram, Add to Class Diagram) - in that order, with Add to Class
+    Diagram stacked directly under Show in Class Diagram and separators dividing the
+    groups."""
+    fixture.simulate_login()
+    fixture.app.run_code()
+    fixture.app.update()
+    run_tab = fixture.app.run_tab
+    run_tab.source_text.delete("1.0", "end")
+    run_tab.source_text.insert("1.0", "OrderLine new")
+    run_tab.source_text.tag_add(tk.SEL, "1.0", "1.9")
+
+    run_tab.open_source_text_menu(types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1))
+    menu = run_tab.current_text_menu
+    labels = menu_command_labels(menu)
+    expected_order = [
+        "Run",
+        "Inspect",
+        "Debug",
+        "Implementors",
+        "Senders",
+        "References",
+        "Browse Class",
+        "Show in Object Diagram",
+        "Show in Class Diagram",
+        "Add to Class Diagram",
+    ]
+    positions = [labels.index(label) for label in expected_order]
+    assert positions == sorted(positions)
+    assert (
+        labels.index("Add to Class Diagram")
+        == labels.index("Show in Class Diagram") + 1
+    )
+
+    separator_count = sum(
+        1
+        for entry_index in range(int(menu.index("end")) + 1)
+        if menu.type(entry_index) == "separator"
+    )
+    assert separator_count >= 3
 
 
 @with_fixtures(SwordfishAppFixture)


### PR DESCRIPTION
  Source-pane context menus — grouped with dividers

  Split the old add_source_code_commands into three shared ui_support helpers, used identically by CodePanel, RunTab, and Workspace, each separated by a divider and in this order:

  Select All / Copy / Paste / Undo
  ──────────────
  Run / Inspect / Debug                              (add_run_commands)
  ──────────────
  Implementors / Senders / References / Browse Class  (add_navigation_commands)
  ──────────────
  Show in Object Diagram
  Show in Class Diagram
  Add to Class Diagram                               (add_diagram_commands)

  "Add to Class Diagram" now sits directly under "Show in Class Diagram", as you asked. The run/diagram groups are always present (disabled when nothing is selected), so the layout is
  consistent everywhere — that also fixed a small inconsistency where CodePanel previously hid the run group entirely until you selected text.

  Menubar

  - Session is now the first menu and owns Exit (always available, logged in or not).
  - The File menu is gone — it contained nothing but Exit, so leaving it empty would have been the opposite of neat.
  - Debug → Code (display label only; the internal debug_menu/update_debug_menu names are unchanged, so nothing else had to move).
