### PR TITLE
Add --theme command-line flag to override the configured appearance t…

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -130,8 +130,9 @@ fully themeable in either — add a role to *both* or to neither. When a colour 
 (direct vs inferred inheritance, safe vs unsafe risk), give each side its own role rather than
 inverting lightness, so the meaning survives in both palettes.
 
-The theme is **resolved once at startup** (configured `appearance.theme` → OS preference via
-`OperatingSystemAppearance` → light default) and **fixed for the session** — changing it means
+The theme is **resolved once at startup** (the `--theme` command-line flag overrides the
+configured `appearance.theme`, which overrides the OS preference via `OperatingSystemAppearance`,
+falling through to a light default) and **fixed for the session** — changing it means
 restarting. There is deliberately no on-the-fly switch: that would need a re-apply path through
 every open tool and the diagrams' canvas redraw. Light is the host's **native** look and applies
 no global styling (its per-site colours equal the original appearance, so zero regression); only a

--- a/README.md
+++ b/README.md
@@ -76,7 +76,16 @@ swordfish
 
 # Or if installed from source
 python -m swordfish
+
+# Force the appearance theme for this run, overriding the saved config
+swordfish --theme dark
+swordfish --theme light
 ```
+
+The colour theme is resolved at startup and fixed for the session. `--theme`
+overrides the configured `appearance.theme`; without it the saved config is
+used, falling through to the operating system's light/dark preference and then
+a light default.
 
 ## MCP
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,8 @@
+
+Do something re config - split it into site-wide/user? Add a config window that can save the editable parts?
+
+More than one instance of Find/Diagrams with a way to hide the unnecessary parts
+
+Bug: what happens to breakpoints when:
+ - you compile a method that has a breakoint in it
+ - when you continue

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -5318,6 +5318,15 @@ class Swordfish(tk.Tk):
             help='GemStone stone name to prefill in login form.',
         )
         argument_parser.add_argument(
+            '--theme',
+            default=None,
+            choices=['light', 'dark'],
+            help=(
+                'Override the configured appearance theme for this run '
+                '(otherwise appearance.theme, then the OS preference, then light).'
+            ),
+        )
+        argument_parser.add_argument(
             '--headless-mcp',
             action='store_true',
             default=default_headless_mcp,
@@ -5468,6 +5477,7 @@ class Swordfish(tk.Tk):
             mcp_configuration_store=configuration_store,
             experimental=arguments.experimental,
             activity_log=activity_log,
+            theme_override=arguments.theme,
         )
         app.mainloop()
 
@@ -5479,6 +5489,7 @@ class Swordfish(tk.Tk):
         mcp_configuration_store=None,
         experimental=False,
         activity_log=None,
+        theme_override=None,
     ):
         super().__init__()
         self.action_gate = ActionGate()
@@ -5555,9 +5566,13 @@ class Swordfish(tk.Tk):
         self.session_only_mcp_runtime_config_active = False
 
         # AI: Resolve and apply the colour theme once, before any widgets are built, so every
-        # widget reads the right colours as it constructs itself. Fixed for the session.
+        # widget reads the right colours as it constructs itself. Fixed for the session. A
+        # --theme on the command line overrides the configured appearance.theme; otherwise the
+        # saved config name is used (and the resolver falls through to OS preference, then light).
         self.apply_theme(
-            self.mcp_server_controller.configuration_store.load_theme_name()
+            theme_override
+            if theme_override is not None
+            else self.mcp_server_controller.configuration_store.load_theme_name()
         )
 
         self.event_queue.subscribe('LoggedInSuccessfully', self.show_main_app)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2681,6 +2681,39 @@ def test_run_application_uses_cli_stone_name_when_given():
     swordfish_mainloop.assert_called_once()
 
 
+def test_run_application_passes_theme_override_from_command_line():
+    """AI: A --theme on the command line overrides the configured appearance.theme: it reaches
+    Swordfish as theme_override, the higher-priority source of the 'configured theme name' that
+    the one theme resolver then honours over the saved config."""
+    with patch.object(Swordfish, "__init__", return_value=None) as init_swordfish:
+        with patch.object(Swordfish, "mainloop"):
+            with patch.object(
+                McpConfigurationStore,
+                "merged_config_from_arguments",
+                return_value=McpRuntimeConfig(),
+            ):
+                with patch("sys.argv", ["swordfish", "--theme", "dark"]):
+                    Swordfish.run()
+    swordfish_call_arguments = init_swordfish.call_args.kwargs
+    assert swordfish_call_arguments["theme_override"] == "dark"
+
+
+def test_run_application_has_no_theme_override_without_the_command_line_flag():
+    """AI: Without --theme there is no override, so the configured appearance.theme (then OS, then
+    light) is left to decide; the absence is signalled as None, not a guessed default."""
+    with patch.object(Swordfish, "__init__", return_value=None) as init_swordfish:
+        with patch.object(Swordfish, "mainloop"):
+            with patch.object(
+                McpConfigurationStore,
+                "merged_config_from_arguments",
+                return_value=McpRuntimeConfig(),
+            ):
+                with patch("sys.argv", ["swordfish"]):
+                    Swordfish.run()
+    swordfish_call_arguments = init_swordfish.call_args.kwargs
+    assert swordfish_call_arguments["theme_override"] is None
+
+
 def test_run_application_uses_saved_mcp_config_when_no_cli_runtime_overrides():
     """AI: run_application should load saved MCP runtime settings when no explicit MCP CLI overrides are supplied."""
     saved_runtime_config = McpRuntimeConfig(


### PR DESCRIPTION
…heme

The flag is the highest-priority source of the configured theme name: when present it overrides appearance.theme; absent (None) it leaves the saved config -> OS preference -> light chain to decide. It flows through the one ThemeSelection resolver unchanged, threaded via Swordfish.__init__'s new theme_override keyword. Documents the precedence in DESIGN.md and README.md.