### PR TITLE
Keep breakpoints effective across edits and show them in debugger frames

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,6 +152,14 @@ change events; snapshot views (diagrams, inspector) opt into a generic `RefreshF
 adding behaviour that several components care about, **add an event**, don't wire direct
 cross-references. See `EventQueue` in `main.py` and `reference_mcp_ide_refresh_bridge`.
 
+Breakpoints follow this rule concretely. A breakpoint binds to a `CompiledMethod`, which a
+recompile replaces — so a recompile **re-applies** the method's breakpoints onto the new method
+(remapping each to the step point nearest its stored source offset): an edit never silently
+disarms a breakpoint the user can still see. Every view that shows them re-reads on the typed
+events — the editor gutter and the **debugger frame pane** (the same `CodePanel`, so it marks the
+displayed frame's method) on method display, and the **Breakpoints pane** on
+`MethodsChanged`/`BreakpointsChanged`.
+
 ### One shared GemStone session; gem work off the UI thread
 There is one `ide-session` and it runs **one GCI call at a time**. Long gem work runs on a
 **worker thread** (never the Tk UI thread); results are marshalled back and all widget updates

--- a/src/reahl/swordfish/__init__.py
+++ b/src/reahl/swordfish/__init__.py
@@ -5,4 +5,4 @@ This package provides a Python-based IDE that offers a classic Smalltalk develop
 experience for GemStone/Smalltalk systems.
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/src/reahl/swordfish/execution.py
+++ b/src/reahl/swordfish/execution.py
@@ -1034,10 +1034,7 @@ class DebuggerWindow(ttk.PanedWindow):
             first_iid = str(first_frame.level)
             self.listbox.selection_set(first_iid)
             self.listbox.focus(first_iid)
-            self.code_panel.refresh(
-                first_frame.method_source,
-                mark=first_frame.step_point_offset,
-            )
+            self.present_frame_source(first_frame)
             self.refresh_explorer(first_frame)
 
     def refresh_explorer(self, frame):
@@ -1063,7 +1060,7 @@ class DebuggerWindow(ttk.PanedWindow):
                 'DebuggerFrameSelected',
                 log_context={'frame_level': self.selected_frame_level()},
             )
-            self.code_panel.refresh(frame.method_source, mark=frame.step_point_offset)
+            self.present_frame_source(frame)
             self.refresh_explorer(frame)
 
     def open_method_from_selected_frame(self, event):
@@ -1281,6 +1278,14 @@ class DebuggerWindow(ttk.PanedWindow):
             return None
         return class_name, show_instance_side, frame.method_name
 
+    def present_frame_source(self, frame):
+        # AI: Show a frame's source in the debugger pane AND adopt the frame's method identity,
+        # so the shared CodePanel paints breakpoint markers for that method (it keys markers off
+        # its method context). Non-method activations (executed doIts, blocks) have no identity,
+        # so frame_method_context returns None and any stale context is cleared.
+        self.code_panel.tab_key = self.frame_method_context(frame)
+        self.code_panel.refresh(frame.method_source, mark=frame.step_point_offset)
+
     def frame_categories(self, frame, class_category_by_name):
         # AI: Resolve the class category (package_name) and method category for a
         # AI: stack frame, mirroring frame_method_context's handling of the
@@ -1448,7 +1453,7 @@ class DebuggerWindow(ttk.PanedWindow):
         # frame's method source (with its step-point highlight).
         frame = self.get_selected_stack_frame()
         if frame is not None:
-            self.code_panel.refresh(frame.method_source, mark=frame.step_point_offset)
+            self.present_frame_source(frame)
         return 'break'
 
     def level_of_frame_running(self, method_context):

--- a/src/reahl/swordfish/gemstone/breakpoint_registry.py
+++ b/src/reahl/swordfish/gemstone/breakpoint_registry.py
@@ -117,6 +117,25 @@ def remove_breakpoint_for_session(gemstone_session, breakpoint_id):
     return dict(breakpoint_entry)
 
 
+def update_breakpoint_location(
+    gemstone_session, breakpoint_id, source_offset, step_point
+):
+    # AI: Move an existing breakpoint to a new source offset / step point while keeping its
+    # identity. Used when a method is recompiled: the step points of the new CompiledMethod
+    # may have shifted, so the recorded location is remapped without minting a new breakpoint.
+    selected_session_key = session_key_for(gemstone_session)
+    session_breakpoints = breakpoints_by_session_key.get(
+        selected_session_key,
+        {},
+    )
+    breakpoint_entry = session_breakpoints.get(breakpoint_id)
+    if breakpoint_entry is None:
+        return None
+    breakpoint_entry["source_offset"] = source_offset
+    breakpoint_entry["step_point"] = step_point
+    return dict(breakpoint_entry)
+
+
 def clear_breakpoints_for_session(gemstone_session):
     selected_session_key = session_key_for(gemstone_session)
     session_breakpoints = breakpoints_by_session_key.pop(

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -12,6 +12,7 @@ from reahl.swordfish.gemstone.breakpoint_registry import (
     list_breakpoints_for_session,
     record_breakpoint_for_session,
     remove_breakpoint_for_session,
+    update_breakpoint_location,
 )
 from reahl.swordfish.gemstone.session import DomainException, render_result
 from reahl.swordfish.gemstone.smalltalk_method_parser import (
@@ -1967,6 +1968,14 @@ class GemstoneBrowserSession:
             self.mirror_compiled_method(
                 class_name, show_instance_side, source, method_category, selector, previous_source
             )
+        # AI: A recompile installs a new CompiledMethod, so re-apply any breakpoints the user
+        # set on this method - otherwise the edit leaves them shown-but-dead (orphaned on the
+        # old method). Covers every edit that routes through compile_method (IDE save, MCP).
+        recompiled_selector = self.mirrored_selector(source)
+        if recompiled_selector is not None:
+            self.reapply_breakpoints_for_method(
+                class_name, show_instance_side, recompiled_selector
+            )
         return compile_result
 
     def effective_method_category(
@@ -2501,6 +2510,47 @@ class GemstoneBrowserSession:
             selected_source_offset,
             step_point,
         )
+
+    def reapply_breakpoints_for_method(
+        self, class_name, show_instance_side, method_selector
+    ):
+        # AI: A recompile installs a NEW CompiledMethod, orphaning any in-image break set on
+        # the old one - the image stops honouring it while the IDE still shows it as set.
+        # Re-install each registered breakpoint for this method on the new CompiledMethod,
+        # remapping its stored source offset to a step point of the new method, so an edit
+        # never silently disarms a breakpoint that the user can still see.
+        matching_breakpoints = [
+            breakpoint_entry
+            for breakpoint_entry in self.list_breakpoints()
+            if breakpoint_entry["class_name"] == class_name
+            and breakpoint_entry["show_instance_side"] == show_instance_side
+            and breakpoint_entry["method_selector"] == method_selector
+        ]
+        if not matching_breakpoints:
+            return []
+        compiled_method = self.get_compiled_method(
+            class_name,
+            method_selector,
+            show_instance_side,
+        )
+        offsets = self.source_offsets_for_compiled_method(compiled_method)
+        reapplied_breakpoints = []
+        for breakpoint_entry in matching_breakpoints:
+            step_point = self.step_point_for_source_offset(
+                offsets, breakpoint_entry["source_offset"]
+            )
+            compiled_method.perform(
+                "setBreakAtStepPoint:",
+                self.gemstone_session.from_py(step_point),
+            )
+            updated_breakpoint = update_breakpoint_location(
+                self.gemstone_session,
+                breakpoint_entry["breakpoint_id"],
+                offsets[step_point - 1],
+                step_point,
+            )
+            reapplied_breakpoints.append(updated_breakpoint)
+        return reapplied_breakpoints
 
     def clear_breakpoint(self, breakpoint_id):
         breakpoint_entry = breakpoint_for_session(

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -5202,6 +5202,11 @@ class BreakpointsPane(Pane):
         # refresh bridge's 'breakpoints' kind -> BreakpointsChanged (the MCP
         # doesn't publish the per-action BreakpointSet/BreakpointCleared events).
         self.event_queue.subscribe('BreakpointsChanged', self.refresh_breakpoints)
+        # AI: A recompile re-applies a method's breakpoints onto the new CompiledMethod,
+        # remapping their offset/step point. MethodsChanged is published by every edit path
+        # (editor save and MCP compile alike), so re-read on it to keep the Offset/Step Point
+        # columns true rather than showing pre-edit values.
+        self.event_queue.subscribe('MethodsChanged', self.refresh_breakpoints)
         self.refresh_breakpoints()
 
     def refresh_breakpoints(self, origin=None):

--- a/tests/test_debugger_frame_breakpoint_markers.py
+++ b/tests/test_debugger_frame_breakpoint_markers.py
@@ -1,0 +1,71 @@
+from reahl.swordfish.execution import DebuggerWindow
+
+
+class RecordingCodePanel:
+    """AI: Stands in for the debugger's CodePanel, recording the method context it adopts
+    and the source it is asked to show, without any Tk construction."""
+
+    def __init__(self):
+        self.tab_key = None
+        self.refreshed = []
+
+    def refresh(self, source, mark=None):
+        self.refreshed.append((source, mark))
+
+
+class FakeStackFrame:
+    def __init__(self, class_name, method_name, method_source, step_point_offset):
+        self.class_name = class_name
+        self.method_name = method_name
+        self.method_source = method_source
+        self.step_point_offset = step_point_offset
+
+
+class FramePresentingDebugger:
+    """AI: A DebuggerWindow stripped of Tk, reusing the real frame-presentation methods so a
+    test can prove what method identity the source pane adopts for a given frame."""
+
+    present_frame_source = DebuggerWindow.present_frame_source
+    frame_method_context = DebuggerWindow.frame_method_context
+
+    def __init__(self):
+        self.code_panel = RecordingCodePanel()
+
+
+def test_debugger_pane_adopts_the_frames_method_identity_so_breakpoint_markers_show():
+    """AI: The debugger source pane is the shared CodePanel, which paints breakpoint markers
+    only for the method named by its method context. So presenting a frame must make the pane
+    adopt that frame's (class, instance-side, selector) identity - otherwise a method you set
+    a breakpoint in shows none of its markers while you debug it."""
+    debugger = FramePresentingDebugger()
+    frame = FakeStackFrame('Account', 'deposit:', 'deposit: anAmount\n\t^anAmount', 12)
+
+    debugger.present_frame_source(frame)
+
+    assert debugger.code_panel.tab_key == ('Account', True, 'deposit:')
+    assert debugger.code_panel.refreshed == [('deposit: anAmount\n\t^anAmount', 12)]
+
+
+def test_class_side_frame_is_presented_on_the_class_side():
+    """AI: A class-side activation shows up as 'Account class' in the stack; the pane must
+    adopt the class side so a breakpoint set on the class-side method is the one whose markers
+    appear, not an instance-side namesake."""
+    debugger = FramePresentingDebugger()
+    frame = FakeStackFrame('Account class', 'new', 'new\n\t^super new init', 5)
+
+    debugger.present_frame_source(frame)
+
+    assert debugger.code_panel.tab_key == ('Account', False, 'new')
+
+
+def test_a_non_method_frame_clears_the_method_context():
+    """AI: Executed code (a doIt) and other non-method activations have no method identity, so
+    the pane must drop any context left from the previous frame - otherwise stale markers from
+    an unrelated method would bleed onto code that has none."""
+    debugger = FramePresentingDebugger()
+    debugger.code_panel.tab_key = ('Account', True, 'deposit:')
+    frame = FakeStackFrame('nil', None, '| x | x := 1', 3)
+
+    debugger.present_frame_source(frame)
+
+    assert debugger.code_panel.tab_key is None

--- a/tests/test_gemstone_browser_breakpoints.py
+++ b/tests/test_gemstone_browser_breakpoints.py
@@ -104,6 +104,33 @@ def test_setting_same_breakpoint_twice_reuses_existing_entry():
     assert compiled_method.breakpoints_set == [2]
 
 
+def test_recompiling_a_method_reapplies_its_breakpoint_to_the_new_method():
+    """AI: A recompile installs a brand-new CompiledMethod, so a breakpoint set on the old
+    one is orphaned - the image stops honouring it while the IDE still shows it as set.
+    Re-applying maps the breakpoint's stored source offset onto the NEW method's step points
+    and re-installs the break there, so editing a method never silently disarms its
+    breakpoint."""
+    clear_all_breakpoints()
+    original_method = FakeCompiledMethod([5, 14, 30])
+    gemstone_class = FakeGemstoneClass(original_method)
+    gemstone_session = FakeGemstoneSession({"ExampleClass": gemstone_class})
+    browser_session = GemstoneBrowserSession(gemstone_session)
+    browser_session.set_breakpoint("ExampleClass", "exampleMethod", True, 14)
+    assert original_method.breakpoints_set == [2]
+
+    # AI: The recompile: a new CompiledMethod whose step-point offsets have shifted.
+    new_method = FakeCompiledMethod([5, 20, 36])
+    gemstone_class.compiled_method = new_method
+    browser_session.reapply_breakpoints_for_method("ExampleClass", True, "exampleMethod")
+
+    # AI: The break is re-installed on the NEW method at the step point nearest the stored
+    # AI: offset, and the registry entry tracks the new step point so the marker stays true.
+    assert new_method.breakpoints_set == [2]
+    reapplied_breakpoint = browser_session.list_breakpoints()[0]
+    assert reapplied_breakpoint["step_point"] == 2
+    assert reapplied_breakpoint["source_offset"] == 20
+
+
 def test_clear_breakpoint_at_cursor_offset_removes_matching_breakpoint():
     clear_all_breakpoints()
     compiled_method = FakeCompiledMethod([5, 14, 30])

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3921,6 +3921,55 @@ def test_breakpoints_pane_refreshes_on_breakpoints_changed(fixture):
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_breakpoints_pane_refreshes_when_a_method_is_recompiled(fixture):
+    """AI: Recompiling a method re-applies its breakpoint onto the new CompiledMethod,
+    remapping its offset/step point. The pane re-reads on the method-change event (published
+    by both editor saves and MCP compiles) so its Offset/Step Point columns track the edit
+    rather than showing pre-edit values for a breakpoint that is in fact still effective."""
+    fixture.simulate_login()
+    fixture.session_record.list_breakpoints = Mock(
+        return_value=[
+            {
+                "breakpoint_id": "bp-1",
+                "class_name": "OrderLine",
+                "show_instance_side": True,
+                "method_selector": "total",
+                "source_offset": 42,
+                "step_point": 3,
+            }
+        ]
+    )
+    breakpoints_pane = fixture.app.open_breakpoints_dialog()
+    fixture.app.update()
+    original_values = breakpoints_pane.breakpoint_list.item(
+        breakpoints_pane.breakpoint_list.get_children()[0], "values"
+    )
+    assert original_values[3] == "42"
+
+    # AI: The recompile re-applied the breakpoint at a shifted offset / step point.
+    fixture.session_record.list_breakpoints = Mock(
+        return_value=[
+            {
+                "breakpoint_id": "bp-1",
+                "class_name": "OrderLine",
+                "show_instance_side": True,
+                "method_selector": "total",
+                "source_offset": 58,
+                "step_point": 4,
+            }
+        ]
+    )
+    fixture.app.event_queue.publish("MethodsChanged")
+    fixture.app.update()
+
+    refreshed_values = breakpoints_pane.breakpoint_list.item(
+        breakpoints_pane.breakpoint_list.get_children()[0], "values"
+    )
+    assert refreshed_values[3] == "58"
+    assert refreshed_values[4] == "4"
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_breakpoints_model_change_kind_publishes_breakpoints_changed(fixture):
     """AI: The 'breakpoints' model-change kind (requested by the MCP breakpoint
     tools through the refresh bridge) publishes BreakpointsChanged, so the IDE's


### PR DESCRIPTION
Two related breakpoint fixes (issues diagnosed and verified on a live gem):

#1 A recompile installs a new CompiledMethod, orphaning any in-image break set on the old one, while the IDE still showed it as set. compile_method now re-applies each registered breakpoint onto the new method via reapply_breakpoints_for_method, remapping its stored source offset to the nearest step point of the new method; update_breakpoint_location moves the registry entry in place so the breakpoint keeps its identity. Covers every edit path that routes through compile_method (IDE save, MCP). The Breakpoints pane re-reads on MethodsChanged (published by editor saves and MCP compiles alike) so its Offset/Step Point columns track the edit.

#2 The debugger source pane is the shared CodePanel, which paints breakpoint markers only for the method named by its method context. DebuggerWindow now adopts each displayed frame's identity via present_frame_source before refreshing, so a method you set a breakpoint in shows its markers while you debug it; non-method frames clear the context to avoid stale markers.

DESIGN.md records the breakpoint convention. Version bumped to 0.16.0.

Note: a third issue (Resume past a trap ignores breakpoints) is a parseltongue GciContinueWith flags=0 bug, deferred to that project.