### PR TITLE
  Appearance settings: tab spacing, auto-format on save

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -147,6 +147,7 @@ alongside `appearance.theme`. Current keys:
 |---|---|---|---|
 | `appearance.theme` | `"light"` / `"dark"` | OS preference, then light | Colour palette for the session |
 | `appearance.tab_spacing` | positive integer | `4` | Editor tab stop width in spaces |
+| `appearance.auto_format` | `true` / `false` | `false` | Whether the editor auto-formats methods on save |
 
 The `appearance` section is preserved verbatim on every config save (it is not in the `known_keys`
 set in `McpConfigurationStore.save()`), so adding a new key here never requires changes to the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,6 +140,18 @@ departing theme (dark) restyles, via `ThemeApplication` — the Tk **option data
 widgets plus a `clam`-based `ttk.Style` for ttk widgets (the two families don't share a styling
 mechanism). New colour sites read a role; new screens get themed for free.
 
+**User editor preferences** live under the top-level `appearance` key in the JSON config file,
+alongside `appearance.theme`. Current keys:
+
+| Key | Values | Default | Effect |
+|---|---|---|---|
+| `appearance.theme` | `"light"` / `"dark"` | OS preference, then light | Colour palette for the session |
+| `appearance.tab_spacing` | positive integer | `4` | Editor tab stop width in spaces |
+
+The `appearance` section is preserved verbatim on every config save (it is not in the `known_keys`
+set in `McpConfigurationStore.save()`), so adding a new key here never requires changes to the
+save path — just a `load_*` reader method on `McpConfigurationStore`.
+
 ---
 
 ## Architectural constraints

--- a/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
+++ b/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
@@ -783,3 +783,295 @@ def apply_source_edits(source, source_edits):
             + edited_source[edit.end_offset :]
         )
     return edited_source
+
+
+class SmalltalkMethodFormat:
+    """AI: AST-based Smalltalk method formatter producing canonical GemStone 1-tab style.
+
+    Rules derived from analysis of Wonka- codebase:
+    - 1 tab per nesting level; method body at depth 1.
+    - Keyword sends with 2+ keywords OR a long block arg → multi-line:
+      receiver on opener line, each keyword:arg at depth+1.
+    - Cascade: receiver at depth, each message at depth+1, ';' on all but last.
+    - Multi-keyword cascade messages: first keyword at cascade depth, continuations at depth+1.
+    - Short block (≤1 stmt, no temps, expr not itself multi-line) → inline [ expr ].
+    - Long block: '[ :args |' on opener line, body at +1 depth, ']' on last body line.
+    - No trailing '.' on the last statement of any scope.
+    - Leading method comment → blank line → (temps) → statements.
+    - On parse error: return source unchanged."""
+
+    INDENT = '\t'
+
+    def format_method(self, source):
+        try:
+            method_node = SmalltalkMethodParser().parse_method(source)
+        except SmalltalkSyntaxError:
+            return source
+        comments = self.scan_body_comments(source)
+        return self.render_method(source, method_node, comments)
+
+    def scan_body_comments(self, source):
+        header_end = source.find('\n')
+        if header_end == -1:
+            return []
+        result = []
+        for token in SmalltalkSourceScanner().scan_tokens(source):
+            if token.kind == SmalltalkTokenKind.comment and token.start_offset > header_end:
+                result.append((token.start_offset, source[token.start_offset:token.end_offset]))
+        return result
+
+    def render_method(self, source, method_node, comments):
+        parts = [self.format_header(method_node.selector, method_node.argument_names)]
+        for pragma in method_node.pragmas:
+            parts.append(self.INDENT + source[pragma.start_offset:pragma.end_offset])
+        first_stmt_offset = method_node.statements[0].start_offset if method_node.statements else float('inf')
+        leading_comments = [(off, text) for off, text in comments if off < first_stmt_offset]
+        body_comments = [(off, text) for off, text in comments if off >= first_stmt_offset]
+        if leading_comments:
+            for _off, text in leading_comments:
+                parts.append(self.INDENT + text)
+            parts.append('')
+        if method_node.temporaries:
+            parts.append(self.INDENT + '| ' + ' '.join(method_node.temporaries) + ' |')
+        items = [(s.start_offset, 'stmt', s) for s in method_node.statements]
+        items += [(off, 'comment', text) for off, text in body_comments]
+        items.sort(key=lambda t: t[0])
+        stmt_total = len(method_node.statements)
+        stmt_index = 0
+        prev_comment = False
+        for item_index, (_offset, kind, item) in enumerate(items):
+            is_last_item = (item_index == len(items) - 1)
+            if kind == 'comment':
+                if not prev_comment and parts and not is_last_item:
+                    parts.append('')
+                parts.append(self.INDENT + item)
+                prev_comment = True
+            else:
+                if prev_comment:
+                    parts.append('')
+                stmt_index += 1
+                lines = self.node_lines(item, 1)
+                if stmt_index < stmt_total:
+                    lines[-1] += '.'
+                parts.extend(lines)
+                prev_comment = False
+        return '\n'.join(parts)
+
+    def format_header(self, selector, argument_names):
+        if not argument_names:
+            return selector
+        if ':' not in selector:
+            return selector + ' ' + argument_names[0]
+        keywords = [k + ':' for k in selector.split(':') if k]
+        return ' '.join(kw + ' ' + arg for kw, arg in zip(keywords, argument_names))
+
+    def node_lines(self, node, depth):
+        """AI: Returns a list of fully-indented strings for this node at depth."""
+        tab = self.INDENT * depth
+        if isinstance(node, ReturnNode):
+            inner = self.node_lines(node.expression, depth)
+            inner[0] = tab + '^ ' + inner[0][len(tab):]
+            return inner
+        if isinstance(node, AssignmentNode):
+            inner = self.node_lines(node.value, depth)
+            inner[0] = tab + node.variable_name + ' := ' + inner[0][len(tab):]
+            return inner
+        if isinstance(node, MessageSendNode):
+            return self.message_lines(node, depth)
+        if isinstance(node, CascadeNode):
+            return self.cascade_lines(node, depth)
+        if isinstance(node, BlockNode):
+            header, body = self.long_block(node, depth)
+            return [tab + header] + body
+        if isinstance(node, DynamicArrayNode):
+            return self.dynamic_array_lines(node, depth)
+        return [tab + self.inline(node, 'none')]
+
+    def message_lines(self, node, depth):
+        tab = self.INDENT * depth
+        if node.send_kind == 'unary':
+            return [tab + self.inline(node.receiver, 'unary_receiver') + ' ' + node.selector]
+        if node.send_kind == 'binary':
+            recv = self.inline(node.receiver, 'binary_receiver')
+            arg = self.inline(node.arguments[0], 'binary_arg')
+            return [tab + recv + ' ' + node.selector + ' ' + arg]
+        keywords = [k + ':' for k in node.selector.split(':') if k]
+        if not self.send_is_multiline(node):
+            recv = self.inline(node.receiver, 'binary_receiver')
+            kw_args = ' '.join(kw + ' ' + self.inline(a, 'keyword_arg')
+                               for kw, a in zip(keywords, node.arguments))
+            return [tab + recv + ' ' + kw_args]
+        recv = self.inline(node.receiver, 'binary_receiver')
+        result = [tab + recv]
+        kd = depth + 1
+        for kw, arg in zip(keywords, node.arguments):
+            result.extend(self.keyword_arg_lines(kw, arg, kd))
+        return result
+
+    def keyword_arg_lines(self, keyword, arg, depth):
+        """AI: Lines for 'keyword: arg' at depth, expanding long blocks inline."""
+        tab = self.INDENT * depth
+        if isinstance(arg, BlockNode) and self.is_long_block(arg):
+            header, body = self.long_block(arg, depth)
+            return [tab + keyword + ' ' + header] + body
+        return [tab + keyword + ' ' + self.inline(arg, 'keyword_arg')]
+
+    def cascade_lines(self, node, depth):
+        recv = self.inline(node.receiver, 'binary_receiver')
+        result = [self.INDENT * depth + recv]
+        for i, msg in enumerate(node.messages):
+            is_last = (i == len(node.messages) - 1)
+            lines = self.cascade_message_lines(msg, depth + 1)
+            if not is_last:
+                lines[-1] += ';'
+            result.extend(lines)
+        return result
+
+    def cascade_message_lines(self, msg, depth):
+        tab = self.INDENT * depth
+        if msg.send_kind == 'unary':
+            return [tab + msg.selector]
+        if msg.send_kind == 'binary':
+            return [tab + msg.selector + ' ' + self.inline(msg.arguments[0], 'binary_arg')]
+        keywords = [k + ':' for k in msg.selector.split(':') if k]
+        if len(keywords) == 1 and not any(
+            isinstance(a, BlockNode) and self.is_long_block(a) for a in msg.arguments
+        ):
+            return [tab + keywords[0] + ' ' + self.inline(msg.arguments[0], 'keyword_arg')]
+        result = []
+        kd = depth + 1
+        for i, (kw, arg) in enumerate(zip(keywords, msg.arguments)):
+            result.extend(self.keyword_arg_lines(kw, arg, depth if i == 0 else kd))
+        return result
+
+    def long_block(self, block, opener_depth):
+        """AI: Returns (header_text, body_lines).
+        header_text goes on the same line as the keyword/opener.
+        body_lines are at opener_depth+1; ']' is appended to the last body line."""
+        header_parts = []
+        if block.argument_names:
+            header_parts.append(' '.join(':' + a for a in block.argument_names) + ' |')
+        if block.temporaries and not block.argument_names:
+            header_parts.append('| ' + ' '.join(block.temporaries) + ' |')
+        header = ('[ ' + ' '.join(header_parts)) if header_parts else '['
+        body_depth = opener_depth + 1
+        body = []
+        if block.temporaries and block.argument_names:
+            body.append(self.INDENT * body_depth + '| ' + ' '.join(block.temporaries) + ' |')
+        stmts = block.statements
+        for i, stmt in enumerate(stmts):
+            lines = self.node_lines(stmt, body_depth)
+            if i < len(stmts) - 1:
+                lines[-1] += '.'
+            body.extend(lines)
+        if body:
+            body[-1] += ' ]'
+        else:
+            header += ' ]'
+        return header, body
+
+    def dynamic_array_lines(self, node, depth):
+        tab = self.INDENT * depth
+        if not node.elements:
+            return [tab + '{}']
+        elems = '. '.join(self.inline(e, 'none') for e in node.elements)
+        return [tab + '{' + elems + '}']
+
+    def send_is_multiline(self, node):
+        if node.send_kind in ('unary', 'binary'):
+            return False
+        if node.selector.count(':') >= 2:
+            return True
+        if isinstance(node.receiver, MessageSendNode) and node.receiver.send_kind == 'keyword':
+            return True
+        return any(isinstance(a, BlockNode) and self.is_long_block(a) for a in node.arguments)
+
+    def is_long_block(self, block):
+        if block.temporaries or len(block.statements) > 1:
+            return True
+        if len(block.statements) == 1:
+            return self.node_is_multiline(block.statements[0])
+        return False
+
+    def node_is_multiline(self, node):
+        if isinstance(node, ReturnNode):
+            return self.node_is_multiline(node.expression)
+        if isinstance(node, AssignmentNode):
+            return self.node_is_multiline(node.value)
+        if isinstance(node, CascadeNode):
+            return True
+        if isinstance(node, MessageSendNode):
+            return self.send_is_multiline(node)
+        if isinstance(node, BlockNode):
+            return self.is_long_block(node)
+        return False
+
+    def inline(self, node, context):
+        """AI: Single-line string, adding parentheses where Smalltalk precedence requires."""
+        text = self.inline_raw(node)
+        if self.needs_parens(node, context):
+            return '(' + text + ')'
+        return text
+
+    def inline_raw(self, node):
+        if isinstance(node, VariableNode):
+            return node.name
+        if isinstance(node, LiteralNode):
+            return node.text
+        if isinstance(node, BlockNode):
+            parts = []
+            if node.argument_names:
+                parts.append(' '.join(':' + a for a in node.argument_names) + ' |')
+            if node.temporaries:
+                parts.append('| ' + ' '.join(node.temporaries) + ' |')
+            stmt_texts = []
+            for i, s in enumerate(node.statements):
+                t = self.inline(s, 'none')
+                stmt_texts.append(t + '.' if i < len(node.statements) - 1 else t)
+            body = ' '.join(parts + stmt_texts)
+            return ('[ ' + body + ' ]') if body else '[]'
+        if isinstance(node, ReturnNode):
+            return '^ ' + self.inline(node.expression, 'none')
+        if isinstance(node, AssignmentNode):
+            return node.variable_name + ' := ' + self.inline(node.value, 'none')
+        if isinstance(node, MessageSendNode):
+            if node.send_kind == 'unary':
+                return self.inline(node.receiver, 'unary_receiver') + ' ' + node.selector
+            if node.send_kind == 'binary':
+                recv = self.inline(node.receiver, 'binary_receiver')
+                arg = self.inline(node.arguments[0], 'binary_arg')
+                return recv + ' ' + node.selector + ' ' + arg
+            recv = self.inline(node.receiver, 'binary_receiver')
+            keywords = [k + ':' for k in node.selector.split(':') if k]
+            kw_args = ' '.join(kw + ' ' + self.inline(a, 'keyword_arg')
+                               for kw, a in zip(keywords, node.arguments))
+            return recv + ' ' + kw_args
+        if isinstance(node, CascadeNode):
+            recv = self.inline(node.receiver, 'binary_receiver')
+            msgs = '; '.join(self.inline_cascade_msg(m) for m in node.messages)
+            return recv + ' ' + msgs
+        if isinstance(node, DynamicArrayNode):
+            return '{' + '. '.join(self.inline(e, 'none') for e in node.elements) + '}'
+        return '???'
+
+    def inline_cascade_msg(self, msg):
+        if msg.send_kind == 'unary':
+            return msg.selector
+        if msg.send_kind == 'binary':
+            return msg.selector + ' ' + self.inline(msg.arguments[0], 'binary_arg')
+        keywords = [k + ':' for k in msg.selector.split(':') if k]
+        return ' '.join(kw + ' ' + self.inline(a, 'keyword_arg')
+                        for kw, a in zip(keywords, msg.arguments))
+
+    def needs_parens(self, node, context):
+        if not isinstance(node, MessageSendNode):
+            return False
+        if context == 'unary_receiver':
+            return node.send_kind in ('binary', 'keyword')
+        if context == 'binary_receiver':
+            return node.send_kind == 'keyword'
+        if context == 'binary_arg':
+            return node.send_kind in ('binary', 'keyword')
+        if context == 'keyword_arg':
+            return node.send_kind == 'keyword'
+        return False

--- a/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
+++ b/src/reahl/swordfish/gemstone/smalltalk_method_parser.py
@@ -788,7 +788,7 @@ def apply_source_edits(source, source_edits):
 class SmalltalkMethodFormat:
     """AI: AST-based Smalltalk method formatter producing canonical GemStone 1-tab style.
 
-    Rules derived from analysis of Wonka- codebase:
+    Rules derived from analysis of the target codebase:
     - 1 tab per nesting level; method body at depth 1.
     - Keyword sends with 2+ keywords OR a long block arg → multi-line:
       receiver on opener line, each keyword:arg at depth+1.

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -1810,6 +1810,29 @@ class McpConfigurationStore:
             return auto_format
         return False
 
+    def save_auto_format(self, value):
+        existing_payload = self.config_payload() or {}
+        existing_payload.setdefault('appearance', {})['auto_format'] = value
+        config_file_path = self.config_file_path()
+        config_directory = os.path.dirname(config_file_path)
+        temporary_file_path = config_file_path + '.tmp'
+        try:
+            os.makedirs(config_directory, exist_ok=True)
+            with open(temporary_file_path, 'w', encoding='utf-8') as config_file:
+                json.dump(existing_payload, config_file, indent=2, sort_keys=True)
+                config_file.write('\n')
+            os.replace(temporary_file_path, config_file_path)
+            os.chmod(config_file_path, 0o600)
+        except OSError as error:
+            try:
+                os.remove(temporary_file_path)
+            except OSError:
+                pass
+            raise DomainException(
+                'Unable to save Swordfish configuration to %s: %s'
+                % (config_file_path, error)
+            )
+
     def load_login_gemstone_script_source(self):
         payload = self.config_payload()
         if payload is None:
@@ -5715,6 +5738,10 @@ class Swordfish(tk.Tk):
         ).chosen_theme()
         active_theme.activate(theme)
         ThemeApplication(self).apply(theme)
+
+    def set_auto_format(self, value):
+        self.auto_format = value
+        self.mcp_server_controller.configuration_store.save_auto_format(value)
 
     def mcp_configuration_access(self):
         can_write_config = (

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -1780,6 +1780,21 @@ class McpConfigurationStore:
         else:
             return None
 
+    def load_tab_spacing(self):
+        # AI: The configured editor tab stop width in spaces. Read from appearance.tab_spacing.
+        # Accepts any positive integer; defaults to 4 when absent or invalid.
+        payload = self.config_payload()
+        if payload is None:
+            return 4
+        appearance = payload.get('appearance')
+        if isinstance(appearance, dict):
+            tab_spacing = appearance.get('tab_spacing')
+        else:
+            tab_spacing = None
+        if isinstance(tab_spacing, int) and not isinstance(tab_spacing, bool) and tab_spacing > 0:
+            return tab_spacing
+        return 4
+
     def load_login_gemstone_script_source(self):
         payload = self.config_payload()
         if payload is None:
@@ -5602,6 +5617,9 @@ class Swordfish(tk.Tk):
             theme_override
             if theme_override is not None
             else self.mcp_server_controller.configuration_store.load_theme_name()
+        )
+        self.tab_spacing = (
+            self.mcp_server_controller.configuration_store.load_tab_spacing()
         )
 
         self.event_queue.subscribe('LoggedInSuccessfully', self.show_main_app)

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -1795,6 +1795,21 @@ class McpConfigurationStore:
             return tab_spacing
         return 4
 
+    def load_auto_format(self):
+        # AI: Whether the editor auto-formats methods on save. Read from appearance.auto_format.
+        # Only a strict Python bool (true/false in JSON) is accepted; anything else defaults to False.
+        payload = self.config_payload()
+        if payload is None:
+            return False
+        appearance = payload.get('appearance')
+        if isinstance(appearance, dict):
+            auto_format = appearance.get('auto_format')
+        else:
+            auto_format = None
+        if isinstance(auto_format, bool):
+            return auto_format
+        return False
+
     def load_login_gemstone_script_source(self):
         payload = self.config_payload()
         if payload is None:
@@ -5620,6 +5635,9 @@ class Swordfish(tk.Tk):
         )
         self.tab_spacing = (
             self.mcp_server_controller.configuration_store.load_tab_spacing()
+        )
+        self.auto_format = (
+            self.mcp_server_controller.configuration_store.load_auto_format()
         )
 
         self.event_queue.subscribe('LoggedInSuccessfully', self.show_main_app)

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -2352,7 +2352,8 @@ class EditorTab(tk.Frame):
 
         self.auto_format_var = tk.BooleanVar(value=application.auto_format)
         auto_format_control = ttk.Checkbutton(
-            self, text='Auto format', variable=self.auto_format_var
+            self, text='Auto format', variable=self.auto_format_var,
+            command=lambda: application.set_auto_format(self.auto_format_var.get())
         )
         auto_format_control.grid(row=1, column=0, sticky='w', padx=4, pady=(0, 2))
 

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -10,6 +10,7 @@ from reahl.ptongue import GemstoneError
 
 from reahl.swordfish.exceptions import DomainException
 from reahl.swordfish.gemstone.session import DomainException as GemstoneDomainException
+from reahl.swordfish.gemstone.smalltalk_method_parser import SmalltalkMethodFormat
 from reahl.swordfish.gemstone.smalltalk_source_scanner import (
     SmalltalkSourceScanner,
     SmalltalkTokenKind,
@@ -2349,6 +2350,12 @@ class EditorTab(tk.Frame):
         )
         self.code_panel.grid(row=0, column=0, sticky='nsew')
 
+        self.auto_format_var = tk.BooleanVar(value=application.auto_format)
+        auto_format_control = ttk.Checkbutton(
+            self, text='Auto format', variable=self.auto_format_var
+        )
+        auto_format_control.grid(row=1, column=0, sticky='w', padx=4, pady=(0, 2))
+
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
@@ -2446,11 +2453,14 @@ class EditorTab(tk.Frame):
 
     def save(self):
         selected_class, show_instance_side, method_symbol = self.tab_key
+        source = self.code_panel.text_editor.get('1.0', 'end-1c')
+        if self.auto_format_var.get():
+            source = SmalltalkMethodFormat().format_method(source)
         self.application.gemstone_session_record.update_method_source(
             selected_class,
             show_instance_side,
             method_symbol,
-            self.code_panel.text_editor.get('1.0', 'end-1c'),
+            source,
         )
         self.application.event_queue.publish('MethodsChanged')
         self.application.event_queue.publish('MethodDisplayRequested', origin=self)

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -1,6 +1,7 @@
 import json
 import re
 import tkinter as tk
+import tkinter.font as tkfont
 import tkinter.messagebox as messagebox
 import tkinter.simpledialog as simpledialog
 from tkinter import ttk
@@ -638,7 +639,9 @@ class CodePanel(tk.Frame):
         self.is_refreshing = False
         self.chord_pending = False
 
-        self.text_editor = tk.Text(self, tabs=('4',), wrap='none', undo=True)
+        self.text_editor = tk.Text(self, wrap='none', undo=True)
+        _tab_font = tkfont.Font(font=self.text_editor.cget('font'))
+        self.text_editor.configure(tabs=(_tab_font.measure(' ' * application.tab_spacing),))
         self.text_editor.bind('<<Modified>>', self.notify_text_changed)
         self.editable_text = EditableText(self.text_editor, self)
 

--- a/tests/test_auto_format.py
+++ b/tests/test_auto_format.py
@@ -1,3 +1,6 @@
+import json
+import os
+import tempfile
 import types
 from unittest.mock import Mock, patch
 
@@ -5,7 +8,7 @@ import tkinter as tk
 from reahl.tofu import Fixture, NoException, expected, scenario, with_fixtures
 
 from reahl.swordfish.gemstone.smalltalk_method_parser import SmalltalkMethodFormat
-from reahl.swordfish.main import McpConfigurationStore
+from reahl.swordfish.main import MCP_RUNTIME_CONFIG_SCHEMA_VERSION, McpConfigurationStore
 from reahl.swordfish.text_editing import EditorTab
 
 
@@ -13,7 +16,7 @@ class FormatterScenarios(Fixture):
     """AI: Each scenario maps a method source to the expected canonical AST-formatted output.
 
     The formatter is AST-based: it parses the method to a full recursive AST and
-    pretty-prints it in the canonical GemStone/Wonka tab style.  Hand-placed
+    pretty-prints it in the canonical GemStone 1-tab style.  Hand-placed
     alignment and blank lines are not preserved; the output is always the canonical form.
     Key rules: body at 1 tab; 2+ keyword sends always multi-line (receiver on opener
     line, each keyword:arg at depth+1); short blocks inline; ^ followed by a space."""
@@ -70,7 +73,7 @@ class FormatterScenarios(Fixture):
     @scenario
     def comment_at_method_top(self):
         """AI: A comment before the first statement is placed at 1 tab followed by a blank
-        separator line — matching the Wonka leading-comment convention."""
+        separator line — matching the canonical leading-comment convention."""
         self.source = 'getValue\n    "Returns the stored value."\n    ^value'
         self.expected = 'getValue\n\t"Returns the stored value."\n\n\t^ value'
 
@@ -83,7 +86,7 @@ class FormatterScenarios(Fixture):
     @scenario
     def multi_keyword_with_comment_and_temps(self):
         """AI: A method with a leading comment, temps, and 2-keyword sends is formatted
-        in canonical Wonka style: comment→blank→temps→receiver-at-L, keyword:arg-at-L+1."""
+        in canonical style: comment→blank→temps→receiver-at-L, keyword:arg-at-L+1."""
         self.source = (
             'add: newObject after: targetObject\n'
             '\n'
@@ -151,21 +154,21 @@ class FormatterScenarios(Fixture):
     def keyword_receiver_forces_multiline_for_single_keyword_send(self):
         """AI: A 1-keyword send whose receiver is itself a keyword send is always formatted
         multi-line (parenthesised receiver at depth, keyword at depth+1).
-        This is the canonical Wonka pattern for guard conditions: (a or: [b]) ifTrue: [c]."""
+        This is the canonical pattern for guard conditions: (a or: [b]) ifTrue: [c]."""
         self.source = (
             'guarded\n'
-            '    (fromAccount isSupplierAccount or: [ toAccount isSupplierAccount ]) ifTrue: [ self signalError ]'
+            '    (sourceItem isComplete or: [ targetItem isComplete ]) ifTrue: [ self proceed ]'
         )
         self.expected = (
             'guarded\n'
-            '\t(fromAccount isSupplierAccount or: [ toAccount isSupplierAccount ])\n'
-            '\t\tifTrue: [ self signalError ]'
+            '\t(sourceItem isComplete or: [ targetItem isComplete ])\n'
+            '\t\tifTrue: [ self proceed ]'
         )
 
 
 @with_fixtures(FormatterScenarios)
 def test_formatter_normalises_body_indentation(scenario):
-    """AI: The formatter normalises all source to canonical GemStone/Wonka 1-tab style,
+    """AI: The formatter normalises all source to canonical GemStone 1-tab style,
     splitting multi-keyword sends, inlining short blocks, and placing ^ with a space."""
     result = SmalltalkMethodFormat().format_method(scenario.source)
     assert result == scenario.expected
@@ -189,13 +192,13 @@ def test_formatter_is_idempotent():
 
 
 def test_formatter_is_idempotent_on_canonical_source():
-    """AI: A method already written in canonical Wonka style — cascade with mixed
+    """AI: A method already written in canonical style — cascade with mixed
     unary/keyword messages, receiver on opener line — passes through the formatter unchanged."""
     source = (
-        'checkHistoricalInvariantsWithCurrent: current\n'
+        'validateStateWithPrevious: previous\n'
         '\tself\n'
-        '\t\tassert: self class == current class;\n'
-        '\t\tcheckReferencedObject.\n'
+        '\t\tassert: self class == previous class;\n'
+        '\t\tverifyLinks.\n'
         '\t^ self isValid'
     )
     result = SmalltalkMethodFormat().format_method(source)
@@ -310,3 +313,37 @@ def test_save_with_auto_format_off_passes_source_unchanged():
         assert source_saved == unformatted_source
     finally:
         root.destroy()
+
+
+def test_save_auto_format_writes_value_to_config_file():
+    """AI: save_auto_format writes appearance.auto_format into the JSON config file
+    so the checkbox state survives an application restart."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = McpConfigurationStore()
+        with patch.object(McpConfigurationStore, 'config_home_directory', return_value=tmpdir):
+            store.save_auto_format(True)
+            store.save_auto_format(False)
+            store.save_auto_format(True)
+            payload = store.config_payload()
+            assert payload['appearance']['auto_format'] is True
+
+
+def test_save_auto_format_preserves_other_config_keys():
+    """AI: save_auto_format updates only appearance.auto_format; all other top-level
+    keys in the config survive the write so existing MCP settings are not lost."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = McpConfigurationStore()
+        with patch.object(McpConfigurationStore, 'config_home_directory', return_value=tmpdir):
+            config_path = store.config_file_path()
+            os.makedirs(os.path.dirname(config_path), exist_ok=True)
+            with open(config_path, 'w') as f:
+                json.dump(
+                    {'schema_version': MCP_RUNTIME_CONFIG_SCHEMA_VERSION,
+                     'appearance': {'theme': 'dark'}},
+                    f,
+                )
+            store.save_auto_format(True)
+            payload = store.config_payload()
+            assert payload['schema_version'] == MCP_RUNTIME_CONFIG_SCHEMA_VERSION
+            assert payload['appearance']['theme'] == 'dark'
+            assert payload['appearance']['auto_format'] is True

--- a/tests/test_auto_format.py
+++ b/tests/test_auto_format.py
@@ -1,0 +1,312 @@
+import types
+from unittest.mock import Mock, patch
+
+import tkinter as tk
+from reahl.tofu import Fixture, NoException, expected, scenario, with_fixtures
+
+from reahl.swordfish.gemstone.smalltalk_method_parser import SmalltalkMethodFormat
+from reahl.swordfish.main import McpConfigurationStore
+from reahl.swordfish.text_editing import EditorTab
+
+
+class FormatterScenarios(Fixture):
+    """AI: Each scenario maps a method source to the expected canonical AST-formatted output.
+
+    The formatter is AST-based: it parses the method to a full recursive AST and
+    pretty-prints it in the canonical GemStone/Wonka tab style.  Hand-placed
+    alignment and blank lines are not preserved; the output is always the canonical form.
+    Key rules: body at 1 tab; 2+ keyword sends always multi-line (receiver on opener
+    line, each keyword:arg at depth+1); short blocks inline; ^ followed by a space."""
+
+    @scenario
+    def unary_method(self):
+        """AI: A unary method body is formatted to 1 tab with a space after ^."""
+        self.source = 'myMethod\n    ^42'
+        self.expected = 'myMethod\n\t^ 42'
+
+    @scenario
+    def binary_method(self):
+        """AI: A binary method header is normalised; body uses ^ with a space."""
+        self.source = '+  aValue\n    ^self total + aValue'
+        self.expected = '+ aValue\n\t^ self total + aValue'
+
+    @scenario
+    def keyword_method_single(self):
+        """AI: A 1-keyword body send with no long-block arg stays on one line."""
+        self.source = 'addValue: aValue\n    total := total + aValue.\n    ^self'
+        self.expected = 'addValue: aValue\n\ttotal := total + aValue.\n\t^ self'
+
+    @scenario
+    def keyword_method_multi(self):
+        """AI: A 2-keyword body send is always multi-line: receiver on opener line,
+        each keyword:arg on the next line at depth+1."""
+        self.source = 'at:   key   put: aValue\n    dict at: key put: aValue'
+        self.expected = 'at: key put: aValue\n\tdict\n\t\tat: key\n\t\tput: aValue'
+
+    @scenario
+    def method_with_temporaries(self):
+        """AI: Temp declaration at 1 tab; each statement at 1 tab."""
+        self.source = 'compute\n    | x y |\n    x := 3.\n    y := 4.\n    ^x + y'
+        self.expected = 'compute\n\t| x y |\n\tx := 3.\n\ty := 4.\n\t^ x + y'
+
+    @scenario
+    def tabs_replace_spaces(self):
+        """AI: Space-indented body is normalised to 1 tab."""
+        self.source = 'getValue\n    ^value'
+        self.expected = 'getValue\n\t^ value'
+
+    @scenario
+    def zero_indent_normalised_to_one_tab(self):
+        """AI: Source with no body indentation gets 1 tab regardless of what was present."""
+        self.source = 'getValue\n^value'
+        self.expected = 'getValue\n\t^ value'
+
+    @scenario
+    def already_canonical(self):
+        """AI: A method already in canonical 1-tab style with spaced ^ passes through unchanged."""
+        self.source = 'getValue\n\t^ value'
+        self.expected = 'getValue\n\t^ value'
+
+    @scenario
+    def comment_at_method_top(self):
+        """AI: A comment before the first statement is placed at 1 tab followed by a blank
+        separator line — matching the Wonka leading-comment convention."""
+        self.source = 'getValue\n    "Returns the stored value."\n    ^value'
+        self.expected = 'getValue\n\t"Returns the stored value."\n\n\t^ value'
+
+    @scenario
+    def dot_terminated_statements(self):
+        """AI: All statements except the last carry a period separator."""
+        self.source = 'run\n    self prepare.\n    ^self'
+        self.expected = 'run\n\tself prepare.\n\t^ self'
+
+    @scenario
+    def multi_keyword_with_comment_and_temps(self):
+        """AI: A method with a leading comment, temps, and 2-keyword sends is formatted
+        in canonical Wonka style: comment→blank→temps→receiver-at-L, keyword:arg-at-L+1."""
+        self.source = (
+            'add: newObject after: targetObject\n'
+            '\n'
+            '"Adds newObject after targetObject."\n'
+            '\n'
+            '| index |\n'
+            '\n'
+            "index := self indexOf: targetObject\n"
+            "             ifAbsent: [^ self error: 'not found'].\n"
+            '\n'
+            "^ self insertObject: newObject at: (index + 1).\n"
+        )
+        self.expected = (
+            'add: newObject after: targetObject\n'
+            '\t"Adds newObject after targetObject."\n'
+            '\n'
+            '\t| index |\n'
+            '\tindex := self\n'
+            '\t\tindexOf: targetObject\n'
+            "\t\tifAbsent: [ ^ self error: 'not found' ].\n"
+            '\t^ self\n'
+            '\t\tinsertObject: newObject\n'
+            '\t\tat: index + 1'
+        )
+
+    @scenario
+    def hand_placed_alignment_normalised(self):
+        """AI: Hand-placed continuation alignment is not preserved — the formatter
+        re-indents to canonical receiver-at-L, keywords-at-L+1 style."""
+        self.source = (
+            'findPattern: aPattern startingAt: anIndex\n'
+            '\n'
+            '"Searches the receiver."\n'
+            '\n'
+            '^self\n'
+            '    indexOf: aPattern\n'
+            '    matchCase: true\n'
+            '    startingAt: anIndex\n'
+        )
+        self.expected = (
+            'findPattern: aPattern startingAt: anIndex\n'
+            '\t"Searches the receiver."\n'
+            '\n'
+            '\t^ self\n'
+            '\t\tindexOf: aPattern\n'
+            '\t\tmatchCase: true\n'
+            '\t\tstartingAt: anIndex'
+        )
+
+    @scenario
+    def block_with_arg_is_inline_when_short(self):
+        """AI: A block with one argument and one simple unary statement is short and
+        is formatted inline as [ :arg | body ] on the keyword send line."""
+        self.source = 'doAll\n    aCollection do: [:each |\n        each process].\n    ^self'
+        self.expected = 'doAll\n\taCollection do: [ :each | each process ].\n\t^ self'
+
+    @scenario
+    def trailing_comment_has_no_blank_line_before_it(self):
+        """AI: A comment after the last statement (trailing, e.g. commented-out code)
+        sits flush against that statement — no blank line is inserted before it."""
+        self.source = 'checkValue\n\tself validate.\n\t^ self isValid\n\t"TODO: verify invariants"'
+        self.expected = 'checkValue\n\tself validate.\n\t^ self isValid\n\t"TODO: verify invariants"'
+
+    @scenario
+    def keyword_receiver_forces_multiline_for_single_keyword_send(self):
+        """AI: A 1-keyword send whose receiver is itself a keyword send is always formatted
+        multi-line (parenthesised receiver at depth, keyword at depth+1).
+        This is the canonical Wonka pattern for guard conditions: (a or: [b]) ifTrue: [c]."""
+        self.source = (
+            'guarded\n'
+            '    (fromAccount isSupplierAccount or: [ toAccount isSupplierAccount ]) ifTrue: [ self signalError ]'
+        )
+        self.expected = (
+            'guarded\n'
+            '\t(fromAccount isSupplierAccount or: [ toAccount isSupplierAccount ])\n'
+            '\t\tifTrue: [ self signalError ]'
+        )
+
+
+@with_fixtures(FormatterScenarios)
+def test_formatter_normalises_body_indentation(scenario):
+    """AI: The formatter normalises all source to canonical GemStone/Wonka 1-tab style,
+    splitting multi-keyword sends, inlining short blocks, and placing ^ with a space."""
+    result = SmalltalkMethodFormat().format_method(scenario.source)
+    assert result == scenario.expected
+
+
+def test_formatter_returns_original_source_on_parse_error():
+    """AI: If the source does not parse as a valid method, the formatter returns it unchanged
+    so that a save with auto_format on does not destroy content the user is still editing."""
+    invalid_source = 'not valid smalltalk ??? [['
+    result = SmalltalkMethodFormat().format_method(invalid_source)
+    assert result == invalid_source
+
+
+def test_formatter_is_idempotent():
+    """AI: Running the formatter twice produces the same result — a user who saves
+    repeatedly does not accumulate more whitespace changes on each save."""
+    source = 'compute\n    | x |\n    x := 3.\n    ^x + 1'
+    first_pass = SmalltalkMethodFormat().format_method(source)
+    second_pass = SmalltalkMethodFormat().format_method(first_pass)
+    assert first_pass == second_pass
+
+
+def test_formatter_is_idempotent_on_canonical_source():
+    """AI: A method already written in canonical Wonka style — cascade with mixed
+    unary/keyword messages, receiver on opener line — passes through the formatter unchanged."""
+    source = (
+        'checkHistoricalInvariantsWithCurrent: current\n'
+        '\tself\n'
+        '\t\tassert: self class == current class;\n'
+        '\t\tcheckReferencedObject.\n'
+        '\t^ self isValid'
+    )
+    result = SmalltalkMethodFormat().format_method(source)
+    assert result == source
+
+
+class AutoFormatConfigScenarios(Fixture):
+    """AI: Maps config payloads to the boolean the loader should produce."""
+
+    @scenario
+    def no_config(self):
+        """AI: When there is no config file, auto_format defaults to False — formatting is opt-in."""
+        self.config_payload = None
+        self.expected = False
+
+    @scenario
+    def enabled(self):
+        """AI: appearance.auto_format: true explicitly enables auto-formatting."""
+        self.config_payload = {'appearance': {'auto_format': True}}
+        self.expected = True
+
+    @scenario
+    def disabled(self):
+        """AI: appearance.auto_format: false keeps auto-formatting off (same as default)."""
+        self.config_payload = {'appearance': {'auto_format': False}}
+        self.expected = False
+
+    @scenario
+    def no_auto_format_key(self):
+        """AI: An appearance section without auto_format defaults to False."""
+        self.config_payload = {'appearance': {'theme': 'dark'}}
+        self.expected = False
+
+    @scenario
+    def invalid_integer(self):
+        """AI: A JSON integer (1 or 0) is not a Python bool and falls back to False."""
+        self.config_payload = {'appearance': {'auto_format': 1}}
+        self.expected = False
+
+    @scenario
+    def invalid_string(self):
+        """AI: A string like 'true' is not a bool and falls back to False."""
+        self.config_payload = {'appearance': {'auto_format': 'true'}}
+        self.expected = False
+
+
+@with_fixtures(AutoFormatConfigScenarios)
+def test_auto_format_loaded_from_appearance_config(scenario):
+    """AI: appearance.auto_format is read as a strict bool; any other type falls back to False
+    so a misconfigured value never silently forces auto-formatting on."""
+    store = McpConfigurationStore()
+    with patch.object(
+        McpConfigurationStore, 'config_payload', return_value=scenario.config_payload
+    ):
+        assert store.load_auto_format() == scenario.expected
+
+
+def test_save_with_auto_format_on_passes_formatted_source_to_gemstone():
+    """AI: When auto_format is enabled, EditorTab.save() formats the method source before
+    passing it to update_method_source, so GemStone stores the normalised version."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        session_record = Mock()
+        session_record.get_method.return_value = None
+        app = types.SimpleNamespace(
+            auto_format=True,
+            tab_spacing=4,
+            integrated_session_state=types.SimpleNamespace(is_mcp_busy=lambda: False),
+            debugger_tab=None,
+            experimental_features_enabled=False,
+            event_queue=Mock(),
+            gemstone_session_record=session_record,
+        )
+        tab_key = ('MyClass', True, 'myMethod')
+        editor_tab = EditorTab(root, app, Mock(), tab_key)
+        editor_tab.code_panel.text_editor.insert('1.0', 'myMethod\n    ^42')
+
+        editor_tab.save()
+
+        source_saved = session_record.update_method_source.call_args[0][3]
+        assert source_saved == 'myMethod\n\t^ 42'
+    finally:
+        root.destroy()
+
+
+def test_save_with_auto_format_off_passes_source_unchanged():
+    """AI: When auto_format is disabled, save() passes the source to GemStone exactly as typed —
+    the checkbox is purely opt-in and never silently modifies user input."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        session_record = Mock()
+        session_record.get_method.return_value = None
+        app = types.SimpleNamespace(
+            auto_format=False,
+            tab_spacing=4,
+            integrated_session_state=types.SimpleNamespace(is_mcp_busy=lambda: False),
+            debugger_tab=None,
+            experimental_features_enabled=False,
+            event_queue=Mock(),
+            gemstone_session_record=session_record,
+        )
+        tab_key = ('MyClass', True, 'myMethod')
+        unformatted_source = 'myMethod\n    ^42'
+        editor_tab = EditorTab(root, app, Mock(), tab_key)
+        editor_tab.code_panel.text_editor.insert('1.0', unformatted_source)
+
+        editor_tab.save()
+
+        source_saved = session_record.update_method_source.call_args[0][3]
+        assert source_saved == unformatted_source
+    finally:
+        root.destroy()

--- a/tests/test_debugger_breakpoint_menu.py
+++ b/tests/test_debugger_breakpoint_menu.py
@@ -13,6 +13,7 @@ def test_debugger_context_menu_includes_breakpoint_commands():
     root.withdraw()
     try:
         fake_app = types.SimpleNamespace(
+            tab_spacing=4,
             integrated_session_state=types.SimpleNamespace(is_mcp_busy=lambda: False),
             debugger_tab=None,
             experimental_features_enabled=False,

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -66,6 +66,7 @@ class FakeApplication:
         self.gemstone_session_record = gemstone_session_record
         self.integrated_session_state = IntegratedSessionState()
         self.experimental_features_enabled = True
+        self.tab_spacing = 4
 
     def handle_sender_selection(self, class_name, show_instance_side, method_symbol):
         if self.gemstone_session_record.gemstone_session is not None:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -67,6 +67,7 @@ class FakeApplication:
         self.integrated_session_state = IntegratedSessionState()
         self.experimental_features_enabled = True
         self.tab_spacing = 4
+        self.auto_format = False
 
     def handle_sender_selection(self, class_name, show_instance_side, method_symbol):
         if self.gemstone_session_record.gemstone_session is not None:

--- a/tests/test_tab_spacing.py
+++ b/tests/test_tab_spacing.py
@@ -1,0 +1,111 @@
+import tkinter as tk
+import tkinter.font as tkfont
+import types
+from unittest.mock import patch
+
+from reahl.tofu import Fixture, scenario, with_fixtures
+
+from reahl.swordfish.main import McpConfigurationStore
+from reahl.swordfish.text_editing import CodePanel
+
+
+class TabSpacingConfigScenarios(Fixture):
+    """AI: Maps each valid/invalid appearance.tab_spacing value to the integer the application
+    should use for tab stops."""
+
+    @scenario
+    def not_configured(self):
+        """AI: No config file at all — fall back to the 4-space default."""
+        self.config_payload = None
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def appearance_section_has_no_tab_spacing(self):
+        """AI: An appearance section that only sets theme should still default tab spacing to 4."""
+        self.config_payload = {'appearance': {'theme': 'dark'}}
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def two_spaces(self):
+        """AI: appearance.tab_spacing = 2 selects compact two-space indentation."""
+        self.config_payload = {'appearance': {'tab_spacing': 2}}
+        self.expected_tab_spacing = 2
+
+    @scenario
+    def four_spaces(self):
+        """AI: appearance.tab_spacing = 4 round-trips to the same value as the absent default."""
+        self.config_payload = {'appearance': {'tab_spacing': 4}}
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def eight_spaces(self):
+        """AI: Any positive integer is accepted; 8-space tabs should work for those who prefer them."""
+        self.config_payload = {'appearance': {'tab_spacing': 8}}
+        self.expected_tab_spacing = 8
+
+    @scenario
+    def invalid_string(self):
+        """AI: A string like '4' (easy JSON-editing mistake) is not an integer and falls back to 4."""
+        self.config_payload = {'appearance': {'tab_spacing': '4'}}
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def invalid_zero(self):
+        """AI: Zero-space tabs would render all indentation as invisible; treat as invalid."""
+        self.config_payload = {'appearance': {'tab_spacing': 0}}
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def invalid_negative(self):
+        """AI: A negative tab spacing is nonsensical and must not crash the editor."""
+        self.config_payload = {'appearance': {'tab_spacing': -2}}
+        self.expected_tab_spacing = 4
+
+    @scenario
+    def invalid_float(self):
+        """AI: A float like 4.0 is not an integer (JSON does not distinguish, but Python does not
+        accept floats as int tab counts) and falls back to 4."""
+        self.config_payload = {'appearance': {'tab_spacing': 4.0}}
+        self.expected_tab_spacing = 4
+
+
+@with_fixtures(TabSpacingConfigScenarios)
+def test_tab_spacing_loaded_from_appearance_config(scenario):
+    """AI: The editor tab stop width is read from appearance.tab_spacing in the config file.
+    Missing, non-integer, or non-positive values fall back to 4 so the editor is always usable."""
+    store = McpConfigurationStore()
+    with patch.object(
+        McpConfigurationStore, 'config_payload', return_value=scenario.config_payload
+    ):
+        assert store.load_tab_spacing() == scenario.expected_tab_spacing
+
+
+def test_code_panel_tab_width_scales_proportionally_with_configured_spaces():
+    """AI: The text editor must render a 4-space tab as exactly twice the width of a 2-space tab,
+    because the editor font is monospace. This invariant holds for any valid positive spacing and
+    confirms the implementation measures real character widths rather than hardcoding pixels."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        def make_panel(tab_spacing):
+            fake_app = types.SimpleNamespace(
+                tab_spacing=tab_spacing,
+                integrated_session_state=types.SimpleNamespace(is_mcp_busy=lambda: False),
+                debugger_tab=None,
+                experimental_features_enabled=False,
+            )
+            return CodePanel(root, application=fake_app)
+
+        panel_2 = make_panel(2)
+        panel_4 = make_panel(4)
+
+        assert _tab_pixels(panel_4.text_editor) == 2 * _tab_pixels(panel_2.text_editor)
+    finally:
+        root.destroy()
+
+
+def _tab_pixels(text_widget):
+    tabs = text_widget.cget('tabs')
+    if isinstance(tabs, (list, tuple)) and tabs:
+        return int(float(tabs[0]))
+    return int(float(str(tabs)))


### PR DESCRIPTION
  Adds two opt-in appearance settings, both controlled by appearance.* keys in the JSON config file.

  Configurable tab spacing (appearance.tab_spacing, closes #41 )
  The editor's tab stop width is now configurable. The default remains 4 spaces. Setting appearance.tab_spacing: 8 (or any integer) overrides it for the session.

  Auto-format on save (appearance.auto_format, Closes #37)
  A new "Auto format" checkbox in the editor toolbar formats the method source to canonical GemStone 1-tab style whenever the method is saved. The formatter is AST-based — it parses
  the method to a full recursive AST and pretty-prints it deterministically, rather than trying to reindent the existing text heuristically. This means hand-placed alignment is not
  preserved; the output is always canonical.

  Key formatting rules:
  - Body indented at 1 tab; ^ followed by a space
  - 2+ keyword sends always multi-line (receiver on opener line, each keyword:arg at depth+1)
  - A 1-keyword send whose receiver is itself a keyword send is also multi-line
  - Short blocks (no temps, ≤1 non-multiline statement) stay inline: [ :x | x doSomething ]
  - Leading comments (before first statement) get a blank separator line; trailing comments sit flush against the last statement

  The checkbox state is persisted to the config file immediately on toggle, so the preference survives a restart.
