### PR TITLE
Variable References + Find dialog overhaul (#43)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,14 +82,47 @@ columns, the filter boxes, and the filtered values together. All result paths fu
 one render path that keeps an unfiltered baseline, so filtering re-renders without re-querying
 the gem. See `FindPane` in `main.py`.
 
-### Find References: class, method, and inst var
-The "Reference" search type has three targets: **Class** (finds every method that mentions a
-class literal), **Method** (senders), and **Inst Var** (every instance-side method on a named
-class that reads or writes a named instance variable). The inst-var mode opens with both fields
-pre-filled when triggered from the right-click menu on the class-definition pane in the
-browser (`ClassSelection.show_class_definition_context_menu`). Double-clicking an inst-var
-result navigates to the method and highlights all occurrences of the variable name in the
-editor via the `InstVarHighlightRequested` event → `MethodEditor.apply_instvar_highlight_to_active_tab`
+### Find References: class, method, and variables
+The "Reference" search type has four targets: **Class** (every method that mentions a class
+literal), **Method** (senders), **Inst Var**, and **Class Var**. The two variable targets share
+the result shape (`class TAB side TAB selector`) and downstream navigation/highlight, but use
+**different gem queries** because the two variable kinds are found in fundamentally different ways:
+
+- **Inst Var** uses `GsNMethod>>instVarsAccessed`, searching the selected class + its subclasses
+  on **both the instance and class sides**. This also covers **class-instance variables**, which
+  are simply the metaclass's instance variables and so show up on the class side.
+- **Class Var** cannot use `instVarsAccessed` (it does not see class variables). A class-variable
+  reference compiles to a `SymbolAssociation` literal whose **key** is the variable name, so the
+  search walks up to the variable's **owner** (the highest ancestor declaring it) and scans that
+  whole subclass hierarchy's method `literals` for an `Association` with that key. Identity on the
+  association does **not** work (the compiler binds a different association object), so it matches
+  by key symbol. Portable selectors (`detect:ifNone:`, `isKindOf: Association`) are used so the
+  query also runs on GemStone 3.6.5. See `GemstoneBrowserSession.find_classvar_references`.
+
+The variable modes are reached by right-clicking a class — in **both** the class **list** and the
+**hierarchy tree** — which opens a **Variable References** cascade submenu of that class's
+*accessible* variables. The submenu groups them under three **underlined, normal-weight, inert
+heading rows** — *Instance*, *Class-instance*, *Class* — and a heading appears only when that kind
+has members. Headings carry no command (they are not selectable) but stay in the normal colour
+(**not** greyed) so they read as section titles, not disabled variables. Within each kind the
+class's **own** variables come first in normal colour, then **inherited** ones (defined on a
+superclass) in the muted `disabled_list_item` colour — the **same grey-means-inherited convention
+used for inherited methods in the method list** (`ClassSelection.style_method_entry`). Inherited
+entries stay **selectable** (greyed for emphasis only). Choosing a variable opens the Find dialog
+with both fields pre-filled — instance and class-instance entries route to the Inst Var search,
+class-variable entries to the Class Var search.
+
+The submenu is read **fresh from the gem each time the menu is posted** (no per-class cache) so
+right-clicking a class always lists that class's variables, even when a different class is
+currently selected. Both context menus build the submenu through the one shared
+`ClassSelection.add_instvar_references_cascade`; the per-kind own/inherited variable lists come
+from `GemstoneBrowserSession.accessible_var_names`, which derives "own vs inherited" from the
+GemStone invariant that `instVarNames`/`classVarNames`/`class instVarNames` are own-only while
+`allInstVarNames` is the full chain.
+
+Double-clicking an inst-var result navigates to the method and highlights all occurrences of the
+variable name in the editor via the `InstVarHighlightRequested` event →
+`MethodEditor.apply_instvar_highlight_to_active_tab`
 → `CodePanel.apply_instvar_highlight`. The highlight uses the `instvar_reference_background`
 theme role and the `instvar_highlight` text tag (applied after syntax tags so it wins
 background priority while syntax foreground colours remain active). Clearing the highlight is

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -154,17 +154,15 @@ GemStone invariant that `instVarNames`/`classVarNames`/`class instVarNames` are 
 so on **both peek (single click) and open (double click)**, so a glance shows the references in
 context. Each result row carries a `highlight_term`: the variable name for inst/class-var
 searches, the class name for class references, and the sent selector for senders. Selecting the
-row publishes the `InstVarHighlightRequested` event →
-`MethodEditor.apply_instvar_highlight_to_active_tab` → `CodePanel.apply_instvar_highlight`, which
-marks every matching token. Matching covers the token kinds a reference can take: identifiers
+row publishes the `OccurrenceHighlightRequested` event →
+`MethodEditor.apply_occurrence_highlight_to_active_tab` → `CodePanel.apply_occurrence_highlight`,
+which marks every matching token. Matching covers the token kinds a reference can take: identifiers
 (variables, class names, unary selectors), keyword-message parts (e.g. `printOn:`) and binary
 selectors; a multi-keyword selector such as `at:put:` is several tokens and is not highlighted as
 a unit (whole-token matching avoids false positives). The highlight uses the
-`instvar_reference_background` theme role and the `instvar_highlight` text tag (applied after
+`reference_highlight_background` theme role and the `occurrence_highlight` text tag (applied after
 syntax tags so it wins background priority while syntax foreground colours remain active).
 Clearing the highlight is implicit the next time a different method opens or it is re-applied.
-(The event/method keep their historical `instvar` names though they now serve all reference
-searches.)
 
 ### Anything that can run long is interruptible from the IDE
 If an operation can take a noticeable time (a search, a run/inspect/debug of user code, a test

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,9 +82,39 @@ columns, the filter boxes, and the filtered values together. All result paths fu
 one render path that keeps an unfiltered baseline, so filtering re-renders without re-querying
 the gem. See `FindPane` in `main.py`.
 
+### Find: one intent chosen via category tabs, not a grid of radio buttons
+The Find dialog presents **one choice — the search intent** — not a cross-product of "search
+type × match mode × reference target" radio groups. The intents are grouped into three
+**category tabs** and selected by a short **variant** row within the active tab:
+
+- **Class** — Containing · Exact · References
+- **Method** — Implementors · Containing · Senders
+- **Variable** — Inst var · Class var
+
+The chosen intent drives, *behind the scenes*, the engine's existing `search_type` /
+`match_mode` / `reference_target` model (`FindPane.SEARCH_INTENT_TO_CONFIG`); those are no longer
+user-facing controls. Switching to a category whose variants do not include the current intent
+falls back to that category's first variant (`default_intent_for_tab`).
+
+**The inputs live inside the tab body, not below the tab bar.** Each tab carries its variant row
+*and* the inputs that category needs: a query entry (labelled per category — "Class:" /
+"Selector:" / "Variable:") with an icon find button, plus the owning-class entry on the Variable
+tab and the receiver-class entry on the Method tab (shown only for Senders). The per-tab query
+entries share one `query_var`, so the typed text is the same whichever tab is shown.
+
+Programmatic openers (`open_find_dialog_for_class` / `_for_instvar` / `_for_classvar`, senders,
+implementors) still pass the legacy triple; `sync_intent_from_config` selects the matching
+tab/variant so the visible control reflects the search. Because `ttk.Notebook.select()` only
+sticks once the pane is mapped (an unmapped notebook snaps to tab 0 and fires
+`<<NotebookTabChanged>>` on realization), the tab-change handler stays inert until
+`activate_search_tabs` runs after the pane is shown — otherwise realization would overwrite a
+programmatically chosen intent. There is **no separate "search intent" sentence** — the selected
+tab + variant *is* the statement of intent; a short result-action hint remains. See `FindPane` in
+`main.py`.
+
 ### Find References: class, method, and variables
-The "Reference" search type has four targets: **Class** (every method that mentions a class
-literal), **Method** (senders), **Inst Var**, and **Class Var**. The two variable targets share
+Reference searches are the **References** (Class tab), **Senders** (Method tab), and **Inst var**
+/ **Class var** (Variable tab) intents. The two variable intents share
 the result shape (`class TAB side TAB selector`) and downstream navigation/highlight, but use
 **different gem queries** because the two variable kinds are found in fundamentally different ways:
 
@@ -120,13 +150,21 @@ from `GemstoneBrowserSession.accessible_var_names`, which derives "own vs inheri
 GemStone invariant that `instVarNames`/`classVarNames`/`class instVarNames` are own-only while
 `allInstVarNames` is the full chain.
 
-Double-clicking an inst-var result navigates to the method and highlights all occurrences of the
-variable name in the editor via the `InstVarHighlightRequested` event →
-`MethodEditor.apply_instvar_highlight_to_active_tab`
-→ `CodePanel.apply_instvar_highlight`. The highlight uses the `instvar_reference_background`
-theme role and the `instvar_highlight` text tag (applied after syntax tags so it wins
-background priority while syntax foreground colours remain active). Clearing the highlight is
-implicit the next time a different method opens or the highlight is re-applied.
+**Every reference search highlights its term where it occurs in the result method** — and it does
+so on **both peek (single click) and open (double click)**, so a glance shows the references in
+context. Each result row carries a `highlight_term`: the variable name for inst/class-var
+searches, the class name for class references, and the sent selector for senders. Selecting the
+row publishes the `InstVarHighlightRequested` event →
+`MethodEditor.apply_instvar_highlight_to_active_tab` → `CodePanel.apply_instvar_highlight`, which
+marks every matching token. Matching covers the token kinds a reference can take: identifiers
+(variables, class names, unary selectors), keyword-message parts (e.g. `printOn:`) and binary
+selectors; a multi-keyword selector such as `at:put:` is several tokens and is not highlighted as
+a unit (whole-token matching avoids false positives). The highlight uses the
+`instvar_reference_background` theme role and the `instvar_highlight` text tag (applied after
+syntax tags so it wins background priority while syntax foreground colours remain active).
+Clearing the highlight is implicit the next time a different method opens or it is re-applied.
+(The event/method keep their historical `instvar` names though they now serve all reference
+searches.)
 
 ### Anything that can run long is interruptible from the IDE
 If an operation can take a noticeable time (a search, a run/inspect/debug of user code, a test

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,6 +82,19 @@ columns, the filter boxes, and the filtered values together. All result paths fu
 one render path that keeps an unfiltered baseline, so filtering re-renders without re-querying
 the gem. See `FindPane` in `main.py`.
 
+### Find References: class, method, and inst var
+The "Reference" search type has three targets: **Class** (finds every method that mentions a
+class literal), **Method** (senders), and **Inst Var** (every instance-side method on a named
+class that reads or writes a named instance variable). The inst-var mode opens with both fields
+pre-filled when triggered from the right-click menu on the class-definition pane in the
+browser (`ClassSelection.show_class_definition_context_menu`). Double-clicking an inst-var
+result navigates to the method and highlights all occurrences of the variable name in the
+editor via the `InstVarHighlightRequested` event → `MethodEditor.apply_instvar_highlight_to_active_tab`
+→ `CodePanel.apply_instvar_highlight`. The highlight uses the `instvar_reference_background`
+theme role and the `instvar_highlight` text tag (applied after syntax tags so it wins
+background priority while syntax foreground colours remain active). Clearing the highlight is
+implicit the next time a different method opens or the highlight is re-applied.
+
 ### Anything that can run long is interruptible from the IDE
 If an operation can take a noticeable time (a search, a run/inspect/debug of user code, a test
 run, a debugger resume/step, an MCP tool's work), it must run as a **foreground activity** and

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -932,6 +932,8 @@ class ClassSelection(Pane):
         self.current_context_menu = None
         self.context_menu_class_name = None
 
+        self.class_definition_text.bind('<Button-3>', self.show_class_definition_context_menu)
+
     def switch_side(self):
         if self.syncing_side_selection:
             return
@@ -1183,6 +1185,33 @@ class ClassSelection(Pane):
             state=file_command_state,
         )
         popup_menu(menu, event)
+
+    def show_class_definition_context_menu(self, event):
+        word = self.instvar_name_at_definition_click(event)
+        if not word:
+            return
+        menu = tk.Menu(self, tearoff=0)
+        menu.add_command(
+            label='References to \'%s\'' % word,
+            command=lambda: self.find_instvar_references_from_definition(word),
+        )
+        popup_menu(menu, event)
+
+    def instvar_name_at_definition_click(self, event):
+        try:
+            index = self.class_definition_text.index('@%d,%d' % (event.x, event.y))
+            word_start = self.class_definition_text.index('%s wordstart' % index)
+            word_end = self.class_definition_text.index('%s wordend' % index)
+            word = self.class_definition_text.get(word_start, word_end).strip()
+            return word if word.isidentifier() else None
+        except tk.TclError:
+            return None
+
+    def find_instvar_references_from_definition(self, instvar_name):
+        class_name = self.gemstone_session_record.selected_class
+        if not class_name or not instvar_name:
+            return
+        self.application.open_find_dialog_for_instvar(class_name, instvar_name)
 
     def file_out_class(self):
         class_name = (
@@ -2426,6 +2455,10 @@ class MethodEditor(Pane):
         self.event_queue.subscribe('Committed', self.repopulate)
         self.event_queue.subscribe('Aborted', self.repopulate)
         self.event_queue.subscribe(
+            'InstVarHighlightRequested',
+            self.apply_instvar_highlight_to_active_tab,
+        )
+        self.event_queue.subscribe(
             'McpBusyStateChanged',
             self.handle_mcp_busy_state_changed,
             ui_context=self.ui_context,
@@ -2693,6 +2726,13 @@ class MethodEditor(Pane):
             return
         if method_context in self.open_tabs:
             self.pin_tab(self.open_tabs[method_context])
+
+    def apply_instvar_highlight_to_active_tab(self, instvar_name, origin=None):
+        selected_tab_path = self.editor_notebook.select()
+        if not selected_tab_path:
+            return
+        tab = self.editor_notebook.nametowidget(selected_tab_path)
+        tab.code_panel.apply_instvar_highlight(instvar_name)
 
     def set_read_only(self, read_only):
         for open_tab in self.open_tabs.values():

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -2,6 +2,7 @@ import queue
 import re
 import threading
 import tkinter as tk
+import tkinter.font as tkfont
 import tkinter.messagebox as messagebox
 import tkinter.simpledialog as simpledialog
 from tkinter import ttk
@@ -931,8 +932,18 @@ class ClassSelection(Pane):
         self.selection_list.selection_listbox.bind('<Button-3>', self.show_context_menu)
         self.current_context_menu = None
         self.context_menu_class_name = None
+        self.cached_class_definition = None
+        self.variable_heading_font = None
 
-        self.class_definition_text.bind('<Button-3>', self.show_class_definition_context_menu)
+    def variable_heading_font_for_menu(self):
+        # AI: An underlined (normal-weight) copy of the standard menu font, created once
+        # and reused, for the kind headings in the Variable References submenu. Headings
+        # carry no command so they are inert, but stay in the normal colour (not greyed)
+        # so they read as labels rather than disabled variables.
+        if self.variable_heading_font is None:
+            self.variable_heading_font = tkfont.nametofont('TkMenuFont').copy()
+            self.variable_heading_font.configure(underline=1)
+        return self.variable_heading_font
 
     def switch_side(self):
         if self.syncing_side_selection:
@@ -1162,6 +1173,7 @@ class ClassSelection(Pane):
             command=self.find_references_for_selected_class,
             state=tk.NORMAL if has_selection else tk.DISABLED,
         )
+        self.add_instvar_references_cascade(menu, selected_class_name)
         menu.add_command(
             label='Add to Class Diagram',
             command=self.add_selected_class_to_class_diagram,
@@ -1186,32 +1198,74 @@ class ClassSelection(Pane):
         )
         popup_menu(menu, event)
 
-    def show_class_definition_context_menu(self, event):
-        word = self.instvar_name_at_definition_click(event)
-        if not word:
-            return
-        menu = tk.Menu(self, tearoff=0)
-        menu.add_command(
-            label='References to \'%s\'' % word,
-            command=lambda: self.find_instvar_references_from_definition(word),
+    def add_instvar_references_cascade(self, menu, class_name):
+        # AI: Builds the 'Variable References' submenu for class_name and attaches it
+        # to menu. Each variable kind gets a non-clickable heading row; inherited
+        # variables are shown in the muted 'disabled_list_item' colour but stay
+        # selectable (the same convention used for inherited methods in the method
+        # list). Read fresh so the submenu always matches the class the user pointed
+        # at. Shared by the class list and hierarchy context menus.
+        variables_submenu = tk.Menu(menu, tearoff=0)
+        accessible_vars = self.fetch_accessible_vars(class_name)
+        has_any_vars = False
+        if accessible_vars is not None:
+            inherited_colour = active_theme.current().color_for('disabled_list_item')
+            # AI: Class-instance variables are found by the same instVarsAccessed search
+            # as instance variables (they are the metaclass's instance variables); only
+            # true class variables need the class-variable search, so they route to a
+            # different opener.
+            sections = [
+                (
+                    'Instance',
+                    accessible_vars.get('inst_var_names') or [],
+                    self.open_instvar_references,
+                ),
+                (
+                    'Class-instance',
+                    accessible_vars.get('class_inst_var_names') or [],
+                    self.open_instvar_references,
+                ),
+                (
+                    'Class',
+                    accessible_vars.get('class_var_names') or [],
+                    self.open_classvar_references,
+                ),
+            ]
+            heading_font = self.variable_heading_font_for_menu()
+            for heading, entries, open_references in sections:
+                if entries:
+                    has_any_vars = True
+                    variables_submenu.add_command(label=heading, font=heading_font)
+                    for entry in entries:
+                        variable_name = entry['name']
+                        if entry['inherited']:
+                            variables_submenu.add_command(
+                                label=variable_name,
+                                foreground=inherited_colour,
+                                command=lambda n=variable_name, o=open_references: o(n),
+                            )
+                        else:
+                            variables_submenu.add_command(
+                                label=variable_name,
+                                command=lambda n=variable_name, o=open_references: o(n),
+                            )
+        menu.add_cascade(
+            label='Variable References',
+            menu=variables_submenu,
+            state=tk.NORMAL if has_any_vars else tk.DISABLED,
         )
-        popup_menu(menu, event)
 
-    def instvar_name_at_definition_click(self, event):
-        try:
-            index = self.class_definition_text.index('@%d,%d' % (event.x, event.y))
-            word_start = self.class_definition_text.index('%s wordstart' % index)
-            word_end = self.class_definition_text.index('%s wordend' % index)
-            word = self.class_definition_text.get(word_start, word_end).strip()
-            return word if word.isidentifier() else None
-        except tk.TclError:
-            return None
-
-    def find_instvar_references_from_definition(self, instvar_name):
-        class_name = self.gemstone_session_record.selected_class
+    def open_instvar_references(self, instvar_name):
+        class_name = self.context_menu_class_name
         if not class_name or not instvar_name:
             return
         self.application.open_find_dialog_for_instvar(class_name, instvar_name)
+
+    def open_classvar_references(self, classvar_name):
+        class_name = self.context_menu_class_name
+        if not class_name or not classvar_name:
+            return
+        self.application.open_find_dialog_for_classvar(class_name, classvar_name)
 
     def file_out_class(self):
         class_name = (
@@ -1298,6 +1352,7 @@ class ClassSelection(Pane):
             command=self.find_references_for_selected_class,
             state=tk.NORMAL if selected_class_name is not None else tk.DISABLED,
         )
+        self.add_instvar_references_cascade(menu, selected_class_name)
         menu.add_command(
             label='Add to Class Diagram',
             command=self.add_selected_class_to_class_diagram,
@@ -1470,16 +1525,33 @@ class ClassSelection(Pane):
                 class_definition = self.gemstone_session_record.gemstone_browser_session.get_class_definition(
                     selected_class,
                 )
+                self.cached_class_definition = class_definition
                 class_definition_text = self.formatted_class_definition(
                     class_definition,
                 )
             except (GemstoneDomainException, GemstoneError):
+                self.cached_class_definition = None
                 class_definition_text = ''
+        else:
+            self.cached_class_definition = None
         self.class_definition_text.config(state='normal')
         self.class_definition_text.delete('1.0', tk.END)
         self.class_definition_text.insert('1.0', class_definition_text)
         self.class_definition_text.config(state='disabled')
         self.class_definition_cursor_position_indicator.update_position()
+
+    def fetch_accessible_vars(self, class_name):
+        # AI: Reads the class's accessible variables (own + inherited, both sides)
+        # fresh from the gem each time so the context menu never shows a stale list.
+        # AI: Returns None on no class or a gem error, which the menu treats as no vars.
+        if not class_name:
+            return None
+        try:
+            return self.gemstone_session_record.gemstone_browser_session.accessible_var_names(
+                class_name,
+            )
+        except (GemstoneDomainException, GemstoneError):
+            return None
 
     def run_all_tests(self):
         listbox = self.selection_list.selection_listbox

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -2464,6 +2464,17 @@ class MethodEditor(Pane):
         self.label_bar = tk.Label(self.navigation_bar, text='Method Editor', anchor='w')
         self.label_bar.grid(row=0, column=0, sticky='ew')
 
+        # AI: Auto-format is an application-wide save option; its single checkbox lives on
+        # this navigation bar rather than taking a whole line under each editor tab.
+        self.auto_format_var = tk.BooleanVar(value=self.application.auto_format)
+        self.auto_format_control = ttk.Checkbutton(
+            self.navigation_bar,
+            text='Auto format',
+            variable=self.auto_format_var,
+            command=lambda: self.application.set_auto_format(self.auto_format_var.get()),
+        )
+        self.auto_format_control.grid(row=0, column=1, padx=(6, 0))
+
         # AI: Compact icon buttons (glyph, not word) for history navigation, each
         # with a hover tooltip naming it. Back/Forward are thin arrows. BMP only.
         self.back_button = ttk.Button(
@@ -2472,7 +2483,7 @@ class MethodEditor(Pane):
             width=3,
             command=self.go_to_previous_method,
         )
-        self.back_button.grid(row=0, column=1, padx=(6, 0))
+        self.back_button.grid(row=0, column=2, padx=(6, 0))
         Tooltip(self.back_button, 'Back')
 
         self.forward_button = ttk.Button(
@@ -2481,7 +2492,7 @@ class MethodEditor(Pane):
             width=3,
             command=self.go_to_next_method,
         )
-        self.forward_button.grid(row=0, column=2, padx=(4, 0))
+        self.forward_button.grid(row=0, column=3, padx=(4, 0))
         Tooltip(self.forward_button, 'Forward')
 
         self.history_combobox = ttk.Combobox(
@@ -2489,7 +2500,7 @@ class MethodEditor(Pane):
             state='readonly',
             width=44,
         )
-        self.history_combobox.grid(row=0, column=3, padx=(6, 0), sticky='e')
+        self.history_combobox.grid(row=0, column=4, padx=(6, 0), sticky='e')
         self.history_combobox.bind(
             '<<ComboboxSelected>>',
             self.jump_to_selected_history_entry,

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -2527,8 +2527,8 @@ class MethodEditor(Pane):
         self.event_queue.subscribe('Committed', self.repopulate)
         self.event_queue.subscribe('Aborted', self.repopulate)
         self.event_queue.subscribe(
-            'InstVarHighlightRequested',
-            self.apply_instvar_highlight_to_active_tab,
+            'OccurrenceHighlightRequested',
+            self.apply_occurrence_highlight_to_active_tab,
         )
         self.event_queue.subscribe(
             'McpBusyStateChanged',
@@ -2799,12 +2799,12 @@ class MethodEditor(Pane):
         if method_context in self.open_tabs:
             self.pin_tab(self.open_tabs[method_context])
 
-    def apply_instvar_highlight_to_active_tab(self, instvar_name, origin=None):
+    def apply_occurrence_highlight_to_active_tab(self, search_term, origin=None):
         selected_tab_path = self.editor_notebook.select()
         if not selected_tab_path:
             return
         tab = self.editor_notebook.nametowidget(selected_tab_path)
-        tab.code_panel.apply_instvar_highlight(instvar_name)
+        tab.code_panel.apply_occurrence_highlight(search_term)
 
     def set_read_only(self, read_only):
         for open_tab in self.open_tabs.values():

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -7069,9 +7069,10 @@ class GemstoneBrowserSession:
         return self.unique_sorted_method_summaries(method_summaries)
 
     def find_instvar_references(self, class_name, instvar_name):
-        # AI: Uses GsNMethod>>instVarsAccessed (returns IdentitySet of accessed inst var
-        # AI: name Symbols) to find all instance-side methods on class_name that read or
-        # AI: write the named inst var. One GCI round-trip for the whole class.
+        # AI: Searches both instance and class sides of the entire subclass hierarchy
+        # AI: using GsNMethod>>instVarsAccessed. One GCI round-trip covers all subclasses.
+        # AI: Returns class TAB side TAB selector per line so callers know which class and
+        # AI: which side each reference lives on.
         class_name = (class_name or '').strip()
         instvar_name = (instvar_name or '').strip()
         if not class_name or not instvar_name:
@@ -7079,16 +7080,31 @@ class GemstoneBrowserSession:
         class_literal = self.smalltalk_string_literal(class_name)
         instvar_literal = self.smalltalk_string_literal(instvar_name)
         smalltalk_source = """
-            | cls varSym results |
-            cls := System myUserProfile symbolList objectNamed: %s asSymbol.
+            | startCls varSym toSearch results |
+            startCls := System myUserProfile symbolList objectNamed: %s asSymbol.
             varSym := %s asSymbol.
+            toSearch := OrderedCollection with: startCls.
+            toSearch addAll: startCls allSubclasses.
             results := OrderedCollection new.
-            cls selectors do: [ :sel |
-                | method |
-                method := cls compiledMethodAt: sel environmentId: 0 otherwise: nil.
-                method ifNotNil: [
-                    (method instVarsAccessed includes: varSym) ifTrue: [
-                        results add: sel asString
+            toSearch do: [ :cls |
+                cls selectors do: [ :sel |
+                    | method |
+                    method := cls compiledMethodAt: sel environmentId: 0 otherwise: nil.
+                    method ifNotNil: [
+                        (method instVarsAccessed includes: varSym) ifTrue: [
+                            results add: cls name asString, Character tab asString,
+                                'instance', Character tab asString, sel asString
+                        ]
+                    ]
+                ].
+                cls class selectors do: [ :sel |
+                    | method |
+                    method := cls class compiledMethodAt: sel environmentId: 0 otherwise: nil.
+                    method ifNotNil: [
+                        (method instVarsAccessed includes: varSym) ifTrue: [
+                            results add: cls name asString, Character tab asString,
+                                'class', Character tab asString, sel asString
+                        ]
                     ]
                 ]
             ].
@@ -7097,20 +7113,158 @@ class GemstoneBrowserSession:
         result_string = self.run_code(smalltalk_source).to_py
         references = []
         if result_string:
-            for selector in result_string.split('\n'):
-                selector = selector.strip()
-                if selector:
+            for line in result_string.split('\n'):
+                parts = line.strip().split('\t')
+                if len(parts) == 3:
+                    ref_class, side, selector = parts
                     references.append({
-                        'class_name': class_name,
-                        'show_instance_side': True,
+                        'class_name': ref_class,
+                        'show_instance_side': side == 'instance',
                         'method_selector': selector,
                     })
-        references.sort(key=lambda r: r['method_selector'])
+        references.sort(key=lambda r: (r['class_name'], r['method_selector']))
         return {
             'references': references,
             'total_count': len(references),
             'returned_count': len(references),
         }
+
+    def find_classvar_references(self, class_name, classvar_name):
+        # AI: Class variables are invisible to instVarsAccessed; a reference to one
+        # AI: compiles to a SymbolAssociation literal whose key is the variable name.
+        # AI: We find the variable's owner (the highest ancestor that declares it) and
+        # AI: scan its whole subclass hierarchy — the variable's real lexical scope —
+        # AI: for methods holding such a literal. Identity on the association does NOT
+        # AI: work (the compiler binds a different association object), so we match by
+        # AI: key symbol. detect:ifNone: and isKindOf: Association are used in place of
+        # AI: anySatisfy: / SymbolAssociation so the query also runs on GemStone 3.6.5.
+        class_name = (class_name or '').strip()
+        classvar_name = (classvar_name or '').strip()
+        if not class_name or not classvar_name:
+            return {'references': [], 'total_count': 0, 'returned_count': 0}
+        class_literal = self.smalltalk_string_literal(class_name)
+        classvar_literal = self.smalltalk_string_literal(classvar_name)
+        smalltalk_source = """
+            | startCls varSym owner toSearch results |
+            startCls := System myUserProfile symbolList objectNamed: %s asSymbol.
+            varSym := %s asSymbol.
+            owner := startCls.
+            [ owner superclass notNil
+                and: [ owner superclass classVarNames includes: varSym ] ] whileTrue: [
+                owner := owner superclass ].
+            toSearch := OrderedCollection with: owner.
+            toSearch addAll: owner allSubclasses.
+            results := OrderedCollection new.
+            toSearch do: [ :cls |
+                cls selectors do: [ :sel |
+                    | method |
+                    method := cls compiledMethodAt: sel environmentId: 0 otherwise: nil.
+                    method ifNotNil: [
+                        (method literals detect: [ :lit |
+                            (lit isKindOf: Association) and: [ lit key == varSym ] ]
+                            ifNone: [ nil ]) ifNotNil: [
+                            results add: cls name asString, Character tab asString,
+                                'instance', Character tab asString, sel asString
+                        ]
+                    ]
+                ].
+                cls class selectors do: [ :sel |
+                    | method |
+                    method := cls class compiledMethodAt: sel environmentId: 0 otherwise: nil.
+                    method ifNotNil: [
+                        (method literals detect: [ :lit |
+                            (lit isKindOf: Association) and: [ lit key == varSym ] ]
+                            ifNone: [ nil ]) ifNotNil: [
+                            results add: cls name asString, Character tab asString,
+                                'class', Character tab asString, sel asString
+                        ]
+                    ]
+                ]
+            ].
+            (String with: Character lf) join: results
+        """ % (class_literal, classvar_literal)
+        result_string = self.run_code(smalltalk_source).to_py
+        references = []
+        if result_string:
+            for line in result_string.split('\n'):
+                parts = line.strip().split('\t')
+                if len(parts) == 3:
+                    ref_class, side, selector = parts
+                    references.append({
+                        'class_name': ref_class,
+                        'show_instance_side': side == 'instance',
+                        'method_selector': selector,
+                    })
+        references.sort(key=lambda r: (r['class_name'], r['method_selector']))
+        return {
+            'references': references,
+            'total_count': len(references),
+            'returned_count': len(references),
+        }
+
+    def accessible_var_names(self, class_name):
+        # AI: Returns every variable accessible to this class, split into three kinds:
+        # AI: instance variables, class-instance variables, and class variables. Each
+        # AI: kind is a list of {'name', 'inherited'} dicts; 'inherited' is True when the
+        # AI: variable is defined on a superclass rather than this class. Own variables
+        # AI: come first, then inherited ones, so callers can present them in that order.
+        class_name = (class_name or '').strip()
+        empty_groups = {
+            'inst_var_names': [],
+            'class_inst_var_names': [],
+            'class_var_names': [],
+        }
+        if not class_name:
+            return empty_groups
+        class_literal = self.smalltalk_string_literal(class_name)
+        smalltalk_source = """
+            | cls tab lf results ownInst c |
+            cls := System myUserProfile symbolList objectNamed: %s asSymbol.
+            tab := Character tab asString.
+            lf := String with: Character lf.
+            results := OrderedCollection new.
+            ownInst := cls instVarNames.
+            ownInst do: [ :n | results add: 'inst', tab, n asString, tab, 'own' ].
+            cls allInstVarNames do: [ :n |
+                (ownInst includes: n) ifFalse: [
+                    results add: 'inst', tab, n asString, tab, 'inherited' ] ].
+            cls class instVarNames do: [ :n |
+                results add: 'classInst', tab, n asString, tab, 'own' ].
+            c := cls superclass.
+            [ c notNil ] whileTrue: [
+                c class instVarNames do: [ :n |
+                    results add: 'classInst', tab, n asString, tab, 'inherited' ].
+                c := c superclass ].
+            cls classVarNames do: [ :n |
+                results add: 'classVar', tab, n asString, tab, 'own' ].
+            c := cls superclass.
+            [ c notNil ] whileTrue: [
+                c classVarNames do: [ :n |
+                    results add: 'classVar', tab, n asString, tab, 'inherited' ].
+                c := c superclass ].
+            lf join: results
+        """ % class_literal
+        result_string = self.run_code(smalltalk_source).to_py
+        kind_to_key = {
+            'inst': 'inst_var_names',
+            'classInst': 'class_inst_var_names',
+            'classVar': 'class_var_names',
+        }
+        groups = {
+            'inst_var_names': [],
+            'class_inst_var_names': [],
+            'class_var_names': [],
+        }
+        if result_string:
+            for line in result_string.split('\n'):
+                parts = line.split('\t')
+                if len(parts) == 3:
+                    kind, name, flag = parts
+                    if kind in kind_to_key:
+                        groups[kind_to_key[kind]].append(
+                            {'name': name, 'inherited': flag == 'inherited'}
+                        )
+        return groups
 
 
     def selector_occurrence_summaries(

--- a/src/reahl/swordfish/gemstone/browser.py
+++ b/src/reahl/swordfish/gemstone/browser.py
@@ -7068,11 +7068,50 @@ class GemstoneBrowserSession:
                 )
         return self.unique_sorted_method_summaries(method_summaries)
 
-    
+    def find_instvar_references(self, class_name, instvar_name):
+        # AI: Uses GsNMethod>>instVarsAccessed (returns IdentitySet of accessed inst var
+        # AI: name Symbols) to find all instance-side methods on class_name that read or
+        # AI: write the named inst var. One GCI round-trip for the whole class.
+        class_name = (class_name or '').strip()
+        instvar_name = (instvar_name or '').strip()
+        if not class_name or not instvar_name:
+            return {'references': [], 'total_count': 0, 'returned_count': 0}
+        class_literal = self.smalltalk_string_literal(class_name)
+        instvar_literal = self.smalltalk_string_literal(instvar_name)
+        smalltalk_source = """
+            | cls varSym results |
+            cls := System myUserProfile symbolList objectNamed: %s asSymbol.
+            varSym := %s asSymbol.
+            results := OrderedCollection new.
+            cls selectors do: [ :sel |
+                | method |
+                method := cls compiledMethodAt: sel environmentId: 0 otherwise: nil.
+                method ifNotNil: [
+                    (method instVarsAccessed includes: varSym) ifTrue: [
+                        results add: sel asString
+                    ]
+                ]
+            ].
+            (String with: Character lf) join: results
+        """ % (class_literal, instvar_literal)
+        result_string = self.run_code(smalltalk_source).to_py
+        references = []
+        if result_string:
+            for selector in result_string.split('\n'):
+                selector = selector.strip()
+                if selector:
+                    references.append({
+                        'class_name': class_name,
+                        'show_instance_side': True,
+                        'method_selector': selector,
+                    })
+        references.sort(key=lambda r: r['method_selector'])
+        return {
+            'references': references,
+            'total_count': len(references),
+            'returned_count': len(references),
+        }
 
-    
-
-    
 
     def selector_occurrence_summaries(
         self,

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -3122,6 +3122,7 @@ class FindPane(Pane):
         match_mode=None,
         reference_target=None,
         sender_source_class_name=None,
+        instvar_class_name=None,
     ):
         super().__init__(parent, application, application.event_queue)
         self.sender_source_class_name = sender_source_class_name
@@ -3247,7 +3248,14 @@ class FindPane(Pane):
             variable=self.reference_target,
             value="method",
         )
-        self.reference_target_method_radio.pack(side="left")
+        self.reference_target_method_radio.pack(side="left", padx=(0, 8))
+        self.reference_target_instvar_radio = ttk.Radiobutton(
+            self.reference_target_frame,
+            text="Inst Var",
+            variable=self.reference_target,
+            value="instvar",
+        )
+        self.reference_target_instvar_radio.pack(side="left")
 
         ttk.Label(self, text="Find what:").grid(
             row=2,
@@ -3308,6 +3316,28 @@ class FindPane(Pane):
             '<KeyRelease>',
             lambda *_: self.on_receiver_class_changed(),
         )
+
+        self.instvar_class_label = ttk.Label(self, text="Class:")
+        self.instvar_class_label.grid(
+            row=3,
+            column=0,
+            padx=10,
+            pady=5,
+            sticky="w",
+        )
+        self.instvar_class_entry = ttk.Entry(self)
+        self.instvar_class_entry.grid(
+            row=3,
+            column=1,
+            columnspan=5,
+            padx=10,
+            pady=5,
+            sticky="ew",
+        )
+        if instvar_class_name:
+            self.instvar_class_entry.insert(0, instvar_class_name)
+        self.instvar_class_label.grid_remove()
+        self.instvar_class_entry.grid_remove()
 
         ttk.Label(self, text="Search intent:").grid(
             row=4,
@@ -3479,7 +3509,7 @@ class FindPane(Pane):
             configuration["match_mode"] = "exact"
         if match_mode in ["exact", "contains"]:
             configuration["match_mode"] = match_mode
-        if reference_target in ["class", "method"]:
+        if reference_target in ["class", "method", "instvar"]:
             configuration["reference_target"] = reference_target
         if configuration["search_type"] == "reference":
             configuration["match_mode"] = "exact"
@@ -3492,9 +3522,11 @@ class FindPane(Pane):
             self.match_mode.set("exact")
             return
         reference_target_is_method = self.reference_target.get() == "method"
+        reference_target_is_instvar = self.reference_target.get() == "instvar"
         tracing_controls_visible = (
             reference_mode_is_selected and reference_target_is_method
         )
+        instvar_controls_visible = reference_mode_is_selected and reference_target_is_instvar
         contains_match_state = tk.NORMAL
         exact_match_state = tk.NORMAL
         if reference_mode_is_selected:
@@ -3526,6 +3558,12 @@ class FindPane(Pane):
             self.receiver_class_entry.grid_remove()
             self.status_label.grid_remove()
             self.status_var.set("")
+        if instvar_controls_visible:
+            self.instvar_class_label.grid()
+            self.instvar_class_entry.grid()
+        else:
+            self.instvar_class_label.grid_remove()
+            self.instvar_class_entry.grid_remove()
         self.update_trace_narrow_state()
         self.update_search_context_fields()
 
@@ -3556,6 +3594,8 @@ class FindPane(Pane):
         self.match_exact_radio.config(state=mode_control_state)
         self.reference_target_class_radio.config(state=mode_control_state)
         self.reference_target_method_radio.config(state=mode_control_state)
+        self.reference_target_instvar_radio.config(state=mode_control_state)
+        self.instvar_class_entry.config(state=mode_control_state)
         self.update_trace_narrow_state()
         self.update_search_context_fields()
 
@@ -3624,6 +3664,17 @@ class FindPane(Pane):
             )
         return self.unique_sorted_navigation_results(reference_results)
 
+    def references_for_instvar_query(self, class_name, instvar_name, should_stop=None):
+        if should_stop is not None and should_stop():
+            return []
+        result = self.gemstone_session_record.gemstone_browser_session.find_instvar_references(
+            class_name, instvar_name
+        )
+        return self.unique_sorted_navigation_results([
+            (ref['class_name'], ref['show_instance_side'], ref['method_selector'])
+            for ref in result['references']
+        ])
+
     def references_for_method_query(
         self,
         query_text,
@@ -3686,6 +3737,8 @@ class FindPane(Pane):
             return "Finding methods matching %s..." % search_query
         if reference_target == "class":
             return "Finding references to class %s..." % search_query
+        if reference_target == "instvar":
+            return "Finding references to inst var %s..." % search_query
         return "Finding references to method %s..." % search_query
 
     def search_intent_text(
@@ -3707,6 +3760,11 @@ class FindPane(Pane):
             return 'Methods containing selector "%s".' % normalized_search_query
         if reference_target == 'class':
             return 'References to class "%s" (exact).' % normalized_search_query
+        if reference_target == 'instvar':
+            instvar_class = self.instvar_class_entry.get().strip()
+            if instvar_class:
+                return 'References to inst var %s in %s.' % (normalized_search_query, instvar_class)
+            return 'References to inst var "%s".' % normalized_search_query
         if self.sender_source_class_name is not None:
             return 'Senders of %s>>%s.' % (
                 self.sender_source_class_name,
@@ -3723,6 +3781,8 @@ class FindPane(Pane):
             if match_mode == "exact":
                 return "Double-click an implementor to open the method."
             return "Double-click a selector to find implementors (exact)."
+        if reference_target == "instvar":
+            return "Double-click a reference to open the method (inst var highlighted)."
         if reference_target == "method":
             return "Double-click a reference to open the caller method."
         return "Double-click a reference to open the method."
@@ -4092,6 +4152,23 @@ class FindPane(Pane):
         ]
         self.set_result_rows(rows, 'method', class_definition_by_name)
 
+    def populate_instvar_navigation_results(self, method_results, instvar_name):
+        self.navigation_method_results = list(method_results)
+        sender_entries = [
+            self.sender_entry_for_result(result)
+            for result in self.navigation_method_results
+        ]
+        class_names = [sender_entry['class_name'] for sender_entry in sender_entries]
+        class_definition_by_name = self.gemstone_session_record.class_definition_map(
+            class_names
+        )
+        rows = []
+        for sender_entry in sender_entries:
+            row = self.enriched_navigation_row(sender_entry, class_definition_by_name)
+            row['highlight_term'] = instvar_name
+            rows.append(row)
+        self.set_result_rows(rows, 'method', class_definition_by_name)
+
     def record_sender_entries_for_navigation(self, sender_entries):
         sender_results = [
             (
@@ -4363,6 +4440,7 @@ class FindPane(Pane):
             'search_type': search_type,
             'match_mode': match_mode,
             'reference_target': reference_target,
+            'instvar_class_name': self.instvar_class_entry.get().strip(),
         }
         message = self.activity_message_for_search(
             search_type,
@@ -4429,6 +4507,20 @@ class FindPane(Pane):
                 )
             )
             return {'kind': 'class_references', 'results': class_reference_results}
+        if reference_target == 'instvar':
+            instvar_class_name = configuration.get('instvar_class_name', '')
+            instvar_results = list(
+                self.references_for_instvar_query(
+                    instvar_class_name,
+                    normalized_search_query,
+                    should_stop=should_stop,
+                )
+            )
+            return {
+                'kind': 'instvar_references',
+                'results': instvar_results,
+                'instvar_name': normalized_search_query,
+            }
         (
             method_reference_results,
             selector_names,
@@ -4475,6 +4567,14 @@ class FindPane(Pane):
         elif kind == 'class_references':
             self.method_reference_results = list(payload['results'])
             self.populate_navigation_results(payload['results'])
+            self.static_sender_results = []
+            self.sender_entries_by_navigation_result = {}
+            self.last_reference_method_query = None
+            self.last_reference_method_match_mode = None
+            self.status_var.set('')
+        elif kind == 'instvar_references':
+            self.method_reference_results = list(payload['results'])
+            self.populate_instvar_navigation_results(payload['results'], payload['instvar_name'])
             self.static_sender_results = []
             self.sender_entries_by_navigation_result = {}
             self.last_reference_method_query = None
@@ -4839,7 +4939,11 @@ class FindPane(Pane):
             application.event_queue.publish(
                 'MethodTabPinRequested', method_context, origin=self
             )
-
+            highlight_term = selected_row.get('highlight_term')
+            if highlight_term:
+                application.event_queue.publish(
+                    'InstVarHighlightRequested', highlight_term, origin=self
+                )
 
     def peek_selected_result(self, event):
         # AI: Single-click previews a method result in the editor via the
@@ -8030,6 +8134,7 @@ class Swordfish(tk.Tk):
         match_mode=None,
         reference_target=None,
         sender_source_class_name=None,
+        instvar_class_name=None,
     ):
         # AI: Find is a single reusable pane beside the browser. If one is open,
         # replace its contents in place; otherwise split off a group for it.
@@ -8048,10 +8153,25 @@ class Swordfish(tk.Tk):
             match_mode=match_mode,
             reference_target=reference_target,
             sender_source_class_name=sender_source_class_name,
+            instvar_class_name=instvar_class_name,
         )
         target_group.add(find_pane, text='Find')
         target_group.select(find_pane)
         return find_pane
+
+    def open_find_dialog_for_instvar(self, class_name, instvar_name):
+        class_name = (class_name or '').strip()
+        instvar_name = (instvar_name or '').strip()
+        if not class_name or not instvar_name:
+            return None
+        return self.open_find_dialog(
+            search_type='reference',
+            search_query=instvar_name,
+            run_search=True,
+            match_mode='exact',
+            reference_target='instvar',
+            instvar_class_name=class_name,
+        )
 
     def open_find_dialog_for_class(self, class_name):
         selected_class_name = (class_name or "").strip()

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -4810,9 +4810,12 @@ class FindPane(Pane):
         search_type = self.search_type.get()
         match_mode = self.match_mode.get()
         if search_type == 'method' and match_mode == 'contains':
+            # AI: Pivot the whole intent to Implementors (not just the hidden match_mode),
+            # so the visible Method-tab variant moves to Implementors to match the search.
             self.find_entry.delete(0, tk.END)
             self.find_entry.insert(0, selected_row['method_selector'])
-            self.match_mode.set('exact')
+            self.search_intent.set('implementors')
+            self.apply_search_intent()
             self.find_text()
             return
         application = self.application

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -4838,7 +4838,7 @@ class FindPane(Pane):
             highlight_term = selected_row.get('highlight_term')
             if highlight_term:
                 application.event_queue.publish(
-                    'InstVarHighlightRequested', highlight_term, origin=self
+                    'OccurrenceHighlightRequested', highlight_term, origin=self
                 )
 
     def peek_selected_result(self, event):
@@ -4866,7 +4866,7 @@ class FindPane(Pane):
         highlight_term = selected_row.get('highlight_term')
         if highlight_term:
             self.application.event_queue.publish(
-                'InstVarHighlightRequested', highlight_term, origin=self
+                'OccurrenceHighlightRequested', highlight_term, origin=self
             )
 
 

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -3112,6 +3112,50 @@ class MainMenu(tk.Menu):
 
 
 class FindPane(Pane):
+    # AI: The user picks one named search intent; the three legacy controls
+    # (search_type / match_mode / reference_target) are derived from it behind the
+    # scenes and remain the engine's model. Intents are grouped into category tabs.
+    SEARCH_INTENT_TO_CONFIG = {
+        'class_contains': ('class', 'contains', 'class'),
+        'class_exact': ('class', 'exact', 'class'),
+        'class_references': ('reference', 'exact', 'class'),
+        'implementors': ('method', 'exact', 'class'),
+        'selector_contains': ('method', 'contains', 'class'),
+        'method_references': ('reference', 'exact', 'method'),
+        'instvar_references': ('reference', 'exact', 'instvar'),
+        'classvar_references': ('reference', 'exact', 'classvar'),
+    }
+    SEARCH_TABS = [
+        ('Class', [
+            ('Containing', 'class_contains'),
+            ('Exact', 'class_exact'),
+            ('References', 'class_references'),
+        ]),
+        ('Method', [
+            ('Implementors', 'implementors'),
+            ('Containing', 'selector_contains'),
+            ('Senders', 'method_references'),
+        ]),
+        ('Variable', [
+            ('Inst var', 'instvar_references'),
+            ('Class var', 'classvar_references'),
+        ]),
+    ]
+    def intent_for_config(self, search_type, match_mode, reference_target):
+        # AI: Reverse of SEARCH_INTENT_TO_CONFIG, used to select the right tab/variant
+        # when the dialog is opened programmatically with legacy parameters.
+        if search_type == 'class':
+            return 'class_exact' if match_mode == 'exact' else 'class_contains'
+        if search_type == 'method':
+            return 'implementors' if match_mode == 'exact' else 'selector_contains'
+        target_to_intent = {
+            'class': 'class_references',
+            'method': 'method_references',
+            'instvar': 'instvar_references',
+            'classvar': 'classvar_references',
+        }
+        return target_to_intent.get(reference_target, 'class_references')
+
     def __init__(
         self,
         parent,
@@ -3136,8 +3180,6 @@ class FindPane(Pane):
         self.last_reference_method_match_mode = None
         self.max_test_discovery_elapsed_ms = 120000
         self.status_var = tk.StringVar(value="")
-        self.search_intent_var = tk.StringVar(value="")
-        self.result_action_var = tk.StringVar(value="")
         self.find_operation_running = False
 
         self.grid_columnconfigure(1, weight=1)
@@ -3146,247 +3188,108 @@ class FindPane(Pane):
         self.search_type = tk.StringVar(value="class")
         self.match_mode = tk.StringVar(value="contains")
         self.reference_target = tk.StringVar(value="class")
-        ttk.Label(self, text="Search Type:").grid(
+        # AI: One notebook of category tabs (Class / Method / Variable). The variant
+        # radios within the selected tab drive self.search_intent, which apply_search_intent
+        # translates into the legacy search_type/match_mode/reference_target the engine reads.
+        self.search_intent = tk.StringVar(value='class_contains')
+        # AI: Each category tab carries its own variant row AND the inputs that category
+        # needs, so the whole search specification lives inside the tab. The per-tab query
+        # entries share one StringVar, so the typed text is the same whichever tab shows.
+        self.query_var = tk.StringVar()
+        self.owning_class_var = tk.StringVar(value=instvar_class_name or "")
+        self.receiver_var = tk.StringVar(value=sender_source_class_name or "")
+        # AI: on_search_tab_changed is inert until activate_search_tabs runs (after the
+        # pane is mapped), so the notebook's realization to tab 0 cannot clobber a
+        # programmatically chosen intent.
+        self.tab_change_active = False
+        self.search_notebook = ttk.Notebook(self)
+        self.search_notebook.grid(
             row=0,
             column=0,
+            columnspan=6,
             padx=10,
-            pady=5,
-            sticky="w",
-        )
-        self.search_type_frame = ttk.Frame(self)
-        self.search_type_frame.grid(
-            row=0,
-            column=1,
-            columnspan=5,
-            padx=(0, 10),
-            pady=5,
-            sticky="w",
-        )
-        self.class_radio = ttk.Radiobutton(
-            self.search_type_frame,
-            text="Class",
-            variable=self.search_type,
-            value="class",
-        )
-        self.class_radio.pack(side="left", padx=(0, 8))
-        self.method_radio = ttk.Radiobutton(
-            self.search_type_frame,
-            text="Method",
-            variable=self.search_type,
-            value="method",
-        )
-        self.method_radio.pack(side="left", padx=(0, 8))
-        self.reference_radio = ttk.Radiobutton(
-            self.search_type_frame,
-            text="References",
-            variable=self.search_type,
-            value="reference",
-        )
-        self.reference_radio.pack(side="left", padx=(0, 8))
-
-        ttk.Label(self, text="Match:").grid(
-            row=1,
-            column=0,
-            padx=10,
-            pady=5,
-            sticky="w",
-        )
-        self.match_mode_frame = ttk.Frame(self)
-        self.match_mode_frame.grid(
-            row=1,
-            column=1,
-            columnspan=2,
-            padx=(0, 10),
-            pady=5,
-            sticky="w",
-        )
-        self.match_contains_radio = ttk.Radiobutton(
-            self.match_mode_frame,
-            text="Contains",
-            variable=self.match_mode,
-            value="contains",
-        )
-        self.match_contains_radio.pack(side="left", padx=(0, 8))
-        self.match_exact_radio = ttk.Radiobutton(
-            self.match_mode_frame,
-            text="Exact",
-            variable=self.match_mode,
-            value="exact",
-        )
-        self.match_exact_radio.pack(side="left")
-
-        self.reference_target_label = ttk.Label(
-            self,
-            text="Reference target:",
-        )
-        self.reference_target_label.grid(
-            row=1,
-            column=3,
-            padx=(10, 6),
-            pady=5,
-            sticky="e",
-        )
-        self.reference_target_frame = ttk.Frame(self)
-        self.reference_target_frame.grid(
-            row=1,
-            column=4,
-            columnspan=2,
-            padx=(0, 10),
-            pady=5,
-            sticky="w",
-        )
-        self.reference_target_class_radio = ttk.Radiobutton(
-            self.reference_target_frame,
-            text="Class",
-            variable=self.reference_target,
-            value="class",
-        )
-        self.reference_target_class_radio.pack(side="left", padx=(0, 8))
-        self.reference_target_method_radio = ttk.Radiobutton(
-            self.reference_target_frame,
-            text="Method",
-            variable=self.reference_target,
-            value="method",
-        )
-        self.reference_target_method_radio.pack(side="left", padx=(0, 8))
-        self.reference_target_instvar_radio = ttk.Radiobutton(
-            self.reference_target_frame,
-            text="Inst Var",
-            variable=self.reference_target,
-            value="instvar",
-        )
-        self.reference_target_instvar_radio.pack(side="left", padx=(0, 8))
-        self.reference_target_classvar_radio = ttk.Radiobutton(
-            self.reference_target_frame,
-            text="Class Var",
-            variable=self.reference_target,
-            value="classvar",
-        )
-        self.reference_target_classvar_radio.pack(side="left")
-
-        ttk.Label(self, text="Find what:").grid(
-            row=2,
-            column=0,
-            padx=10,
-            pady=10,
-            sticky="w",
-        )
-        self.find_entry = ttk.Entry(self)
-        self.find_entry.grid(
-            row=2,
-            column=1,
-            columnspan=3,
-            padx=(10, 4),
-            pady=10,
+            pady=(8, 6),
             sticky="ew",
         )
-        self.find_entry.bind(
-            "<KeyRelease>",
-            lambda *_: self.update_search_context_fields(),
-        )
-        # AI: Enter in the search box runs the search, same as the find button.
-        self.find_entry.bind("<Return>", lambda *_: self.find_text())
+        query_label_for_tab = {
+            'Class': 'Class:',
+            'Method': 'Selector:',
+            'Variable': 'Variable:',
+        }
+        self.search_tab_frames = []
+        self.variant_radios = []
+        self.query_entries = []
+        self.find_buttons = []
+        self.intent_to_tab_index = {}
+        for tab_index, (tab_label, variants) in enumerate(self.SEARCH_TABS):
+            tab_frame = ttk.Frame(self.search_notebook)
+            tab_frame.grid_columnconfigure(1, weight=1)
+            self.search_notebook.add(tab_frame, text=tab_label)
+            self.search_tab_frames.append(tab_frame)
 
-        # AI: A small magnifying-glass icon button immediately right of the search box
-        # runs the search (a BMP glyph -- Tk 8.6 cannot render non-BMP emoji). There is
-        # no per-dialog Stop: a single Stop control in the menu bar interrupts whatever
-        # GemStone activity holds the shared session, this search included.
-        self.find_button = ttk.Button(
-            self,
-            text="⌕",
-            width=3,
-            command=self.find_text,
-        )
-        self.find_button.grid(row=2, column=4, padx=(0, 10), pady=10)
-        Tooltip(self.find_button, "Search")
+            variant_row = ttk.Frame(tab_frame)
+            variant_row.grid(
+                row=0, column=0, columnspan=3, padx=8, pady=(8, 4), sticky="w"
+            )
+            for variant_label, intent_key in variants:
+                self.intent_to_tab_index[intent_key] = tab_index
+                variant_radio = ttk.Radiobutton(
+                    variant_row,
+                    text=variant_label,
+                    variable=self.search_intent,
+                    value=intent_key,
+                    command=self.apply_search_intent,
+                )
+                variant_radio.pack(side="left", padx=(0, 10))
+                self.variant_radios.append(variant_radio)
 
-        self.receiver_class_label = ttk.Label(self, text="Receiver class:")
-        self.receiver_class_label.grid(
-            row=3,
-            column=0,
-            padx=10,
-            pady=5,
-            sticky="w",
-        )
-        self.receiver_class_entry = ttk.Entry(self)
-        self.receiver_class_entry.grid(
-            row=3,
-            column=1,
-            columnspan=5,
-            padx=10,
-            pady=5,
-            sticky="ew",
-        )
-        if sender_source_class_name:
-            self.receiver_class_entry.insert(0, sender_source_class_name)
-        self.receiver_class_entry.bind(
-            '<KeyRelease>',
-            lambda *_: self.on_receiver_class_changed(),
-        )
+            ttk.Label(tab_frame, text=query_label_for_tab[tab_label]).grid(
+                row=1, column=0, padx=(8, 6), pady=6, sticky="w"
+            )
+            query_entry = ttk.Entry(tab_frame, textvariable=self.query_var)
+            query_entry.grid(row=1, column=1, padx=(0, 4), pady=6, sticky="ew")
+            # AI: Enter in any query box runs the search, same as the find button. A BMP
+            # glyph is used (Tk 8.6 cannot render non-BMP emoji); there is no per-dialog
+            # Stop -- the single menu-bar Stop interrupts whatever holds the session.
+            query_entry.bind("<Return>", lambda *_: self.find_text())
+            self.query_entries.append(query_entry)
+            find_button = ttk.Button(
+                tab_frame, text="⌕", width=3, command=self.find_text
+            )
+            find_button.grid(row=1, column=2, padx=(0, 8), pady=6)
+            Tooltip(find_button, "Search")
+            self.find_buttons.append(find_button)
 
-        self.instvar_class_label = ttk.Label(self, text="Class:")
-        self.instvar_class_label.grid(
-            row=3,
-            column=0,
-            padx=10,
-            pady=5,
-            sticky="w",
-        )
-        self.instvar_class_entry = ttk.Entry(self)
-        self.instvar_class_entry.grid(
-            row=3,
-            column=1,
-            columnspan=5,
-            padx=10,
-            pady=5,
-            sticky="ew",
-        )
-        if instvar_class_name:
-            self.instvar_class_entry.insert(0, instvar_class_name)
-        self.instvar_class_label.grid_remove()
-        self.instvar_class_entry.grid_remove()
-
-        ttk.Label(self, text="Search intent:").grid(
-            row=4,
-            column=0,
-            padx=10,
-            pady=(0, 2),
-            sticky="w",
-        )
-        self.search_intent_label = ttk.Label(
-            self,
-            textvariable=self.search_intent_var,
-            anchor="w",
-        )
-        self.search_intent_label.grid(
-            row=4,
-            column=1,
-            columnspan=5,
-            padx=10,
-            pady=(0, 2),
-            sticky="ew",
-        )
-
-        ttk.Label(self, text="Result action:").grid(
-            row=5,
-            column=0,
-            padx=10,
-            pady=(0, 2),
-            sticky="w",
-        )
-        self.result_action_label = ttk.Label(
-            self,
-            textvariable=self.result_action_var,
-            anchor="w",
-        )
-        self.result_action_label.grid(
-            row=5,
-            column=1,
-            columnspan=5,
-            padx=10,
-            pady=(0, 2),
-            sticky="ew",
-        )
+            if tab_label == 'Variable':
+                ttk.Label(tab_frame, text="In class:").grid(
+                    row=2, column=0, padx=(8, 6), pady=(0, 8), sticky="w"
+                )
+                self.instvar_class_entry = ttk.Entry(
+                    tab_frame, textvariable=self.owning_class_var
+                )
+                self.instvar_class_entry.grid(
+                    row=2, column=1, columnspan=2, padx=(0, 8), pady=(0, 8), sticky="ew"
+                )
+            if tab_label == 'Method':
+                self.receiver_class_label = ttk.Label(
+                    tab_frame, text="Receiver class:"
+                )
+                self.receiver_class_label.grid(
+                    row=2, column=0, padx=(8, 6), pady=(0, 8), sticky="w"
+                )
+                self.receiver_class_entry = ttk.Entry(
+                    tab_frame, textvariable=self.receiver_var
+                )
+                self.receiver_class_entry.grid(
+                    row=2, column=1, columnspan=2, padx=(0, 8), pady=(0, 8), sticky="ew"
+                )
+                self.receiver_class_entry.bind(
+                    '<KeyRelease>',
+                    lambda *_: self.on_receiver_class_changed(),
+                )
+        # AI: All query entries share query_var, so .get()/.delete()/.insert() via any one
+        # of them (this reference) read and write the same text shown in every tab.
+        self.find_entry = self.query_entries[0]
 
         # AI: Find/Stop are now icon buttons beside the search box (above). This
         # frame survives only for the experimental Narrow button, and is gridded
@@ -3481,14 +3384,78 @@ class FindPane(Pane):
         self.search_type.set(configuration["search_type"])
         self.match_mode.set(configuration["match_mode"])
         self.reference_target.set(configuration["reference_target"])
+        # AI: Select the tab/variant matching the resolved legacy configuration, then
+        # start listening for tab changes (binding after the initial select avoids the
+        # handler firing while the notebook is still being built).
+        self.sync_intent_from_config()
+        self.search_notebook.bind(
+            "<<NotebookTabChanged>>",
+            self.on_search_tab_changed,
+        )
         if search_query:
             self.find_entry.delete(0, tk.END)
             self.find_entry.insert(0, search_query)
         self.update_mode_controls()
         self.set_find_operation_state(False)
-        self.update_search_context_fields()
         if run_search:
             self.find_text()
+
+    def apply_search_intent(self):
+        # AI: Translate the chosen intent into the legacy controls the engine reads.
+        # Setting the vars fires their write-traces, which refresh the visible inputs.
+        search_type, match_mode, reference_target = self.SEARCH_INTENT_TO_CONFIG[
+            self.search_intent.get()
+        ]
+        self.search_type.set(search_type)
+        self.match_mode.set(match_mode)
+        self.reference_target.set(reference_target)
+    def sync_intent_from_config(self):
+        # AI: Select the tab/variant that matches the current legacy controls (used when
+        # the dialog is opened programmatically with search_type/match_mode/target set).
+        intent = self.intent_for_config(
+            self.search_type.get(),
+            self.match_mode.get(),
+            self.reference_target.get(),
+        )
+        self.search_intent.set(intent)
+        self.search_notebook.select(self.intent_to_tab_index[intent])
+
+    def activate_search_tabs(self):
+        # AI: Called once the pane is mapped: re-select the intent's tab (select() only
+        # sticks after mapping) and enable on_search_tab_changed, so the notebook's
+        # realization to tab 0 can no longer overwrite a programmatically chosen intent.
+        self.update_idletasks()
+        self.search_notebook.select(
+            self.intent_to_tab_index[self.search_intent.get()]
+        )
+        self.tab_change_active = True
+
+    def selected_search_tab_index(self):
+        # AI: notebook.index('current') raises under headless Tk when no tab is mapped;
+        # resolve via the selected tab's widget path instead, returning None if unset.
+        selected_tab = self.search_notebook.select()
+        if not selected_tab:
+            return None
+        return self.search_notebook.index(selected_tab)
+
+    def default_intent_for_tab(self, tab_index):
+        # AI: Keep the current intent if it belongs to this tab; otherwise fall back to
+        # the tab's first variant. Pure so the fallback rule is testable without Tk.
+        current_intent = self.search_intent.get()
+        if self.intent_to_tab_index.get(current_intent) == tab_index:
+            return current_intent
+        return self.SEARCH_TABS[tab_index][1][0][1]
+
+    def on_search_tab_changed(self, event=None):
+        # AI: When the user switches category tabs, move the intent into that tab. Inert
+        # until activate_search_tabs runs, so realization events cannot clobber the intent.
+        if not self.tab_change_active:
+            return
+        tab_index = self.selected_search_tab_index()
+        if tab_index is None:
+            return
+        self.search_intent.set(self.default_intent_for_tab(tab_index))
+        self.apply_search_intent()
 
     def resolved_search_configuration(
         self,
@@ -3529,32 +3496,13 @@ class FindPane(Pane):
             self.match_mode.set("exact")
             return
         reference_target_is_method = self.reference_target.get() == "method"
-        # AI: Instance-, class-instance- and class-variable searches all need the
-        # owning-class context entry, so it is shown for both the instvar and classvar
-        # targets (class-instance variables use the instvar target).
-        reference_target_is_variable = self.reference_target.get() in ("instvar", "classvar")
+        # AI: The owning-class entry lives permanently in the Variable tab (both variable
+        # variants need it) and the receiver entry in the Method tab; the receiver row is
+        # shown only for the Senders intent. The per-column filter row is shown for ALL
+        # find types, so filter_frame is gridded once at construction and not toggled here.
         tracing_controls_visible = (
             reference_mode_is_selected and reference_target_is_method
         )
-        instvar_controls_visible = reference_mode_is_selected and reference_target_is_variable
-        contains_match_state = tk.NORMAL
-        exact_match_state = tk.NORMAL
-        if reference_mode_is_selected:
-            contains_match_state = tk.DISABLED
-        if self.find_operation_running:
-            contains_match_state = tk.DISABLED
-            exact_match_state = tk.DISABLED
-        self.match_contains_radio.config(state=contains_match_state)
-        self.match_exact_radio.config(state=exact_match_state)
-        if reference_mode_is_selected:
-            self.reference_target_label.grid()
-            self.reference_target_frame.grid()
-        else:
-            self.reference_target_label.grid_remove()
-            self.reference_target_frame.grid_remove()
-        # AI: The per-column filter row is shown for ALL find types (not just the
-        # tracing/sender mode), so filter_frame is gridded once at construction and
-        # is not toggled here.
         if tracing_controls_visible:
             if self.narrow_button is not None:
                 self.narrow_button.grid()
@@ -3568,15 +3516,7 @@ class FindPane(Pane):
             self.receiver_class_entry.grid_remove()
             self.status_label.grid_remove()
             self.status_var.set("")
-        if instvar_controls_visible:
-            self.instvar_class_label.grid()
-            self.instvar_class_entry.grid()
-        else:
-            self.instvar_class_label.grid_remove()
-            self.instvar_class_entry.grid_remove()
         self.update_trace_narrow_state()
-        self.update_search_context_fields()
-
     def update_trace_narrow_state(self):
         source_class_known = self.sender_source_class_name is not None
         can_trace = bool(self.sender_tracing_selector) and source_class_known
@@ -3591,25 +3531,20 @@ class FindPane(Pane):
 
     def set_find_operation_state(self, is_running):
         self.find_operation_running = is_running
-        self.find_button.config(state=tk.DISABLED if is_running else tk.NORMAL)
         mode_control_state = tk.DISABLED if is_running else tk.NORMAL
-        self.find_entry.config(state=mode_control_state)
-        self.class_radio.config(state=mode_control_state)
-        self.method_radio.config(state=mode_control_state)
-        self.reference_radio.config(state=mode_control_state)
-        contains_match_state = mode_control_state
-        if not is_running and self.search_type.get() == "reference":
-            contains_match_state = tk.DISABLED
-        self.match_contains_radio.config(state=contains_match_state)
-        self.match_exact_radio.config(state=mode_control_state)
-        self.reference_target_class_radio.config(state=mode_control_state)
-        self.reference_target_method_radio.config(state=mode_control_state)
-        self.reference_target_instvar_radio.config(state=mode_control_state)
-        self.reference_target_classvar_radio.config(state=mode_control_state)
+        for find_button in self.find_buttons:
+            find_button.config(state=mode_control_state)
+        for query_entry in self.query_entries:
+            query_entry.config(state=mode_control_state)
+        for variant_radio in self.variant_radios:
+            variant_radio.config(state=mode_control_state)
+        # AI: The notebook TABS are intentionally NOT disabled while a search runs:
+        # disabling the selected ttk tab blanks the notebook body, and a search opened
+        # from a shortcut auto-runs at construction. The find captures its config upfront,
+        # so switching tabs mid-run is harmless (the variant radios and find buttons above
+        # are disabled, so no new search can be launched until this one finishes).
         self.instvar_class_entry.config(state=mode_control_state)
         self.update_trace_narrow_state()
-        self.update_search_context_fields()
-
     def finish_stopped_find(self):
         self.status_var.set("Find stopped. Showing partial results.")
         self.sender_tracing_selector = None
@@ -3765,87 +3700,10 @@ class FindPane(Pane):
             return "Finding references to class var %s..." % search_query
         return "Finding references to method %s..." % search_query
 
-    def search_intent_text(
-        self,
-        search_type,
-        match_mode,
-        reference_target,
-        normalized_search_query,
-    ):
-        if not normalized_search_query:
-            return 'Enter text to search.'
-        if search_type == 'class':
-            if match_mode == 'exact':
-                return 'Class exactly "%s".' % normalized_search_query
-            return 'Classes containing "%s".' % normalized_search_query
-        if search_type == 'method':
-            if match_mode == 'exact':
-                return 'Implementors of method "%s".' % normalized_search_query
-            return 'Methods containing selector "%s".' % normalized_search_query
-        if reference_target == 'class':
-            return 'References to class "%s" (exact).' % normalized_search_query
-        if reference_target == 'instvar':
-            instvar_class = self.instvar_class_entry.get().strip()
-            if instvar_class:
-                return 'References to inst var %s in %s.' % (normalized_search_query, instvar_class)
-            return 'References to inst var "%s".' % normalized_search_query
-        if reference_target == 'classvar':
-            classvar_class = self.instvar_class_entry.get().strip()
-            if classvar_class:
-                return 'References to class var %s in %s.' % (normalized_search_query, classvar_class)
-            return 'References to class var "%s".' % normalized_search_query
-        if self.sender_source_class_name is not None:
-            return 'Senders of %s>>%s.' % (
-                self.sender_source_class_name,
-                normalized_search_query,
-            )
-        return 'Senders of "%s" (all implementors).' % normalized_search_query
-
-    def result_action_text(self, search_type, match_mode, reference_target):
-        if self.find_operation_running:
-            return "Search in progress. Click Stop to cancel."
-        if search_type == "class":
-            return "Double-click a class to navigate."
-        if search_type == "method":
-            if match_mode == "exact":
-                return "Double-click an implementor to open the method."
-            return "Double-click a selector to find implementors (exact)."
-        if reference_target == "instvar":
-            return "Double-click a reference to open the method (inst var highlighted)."
-        if reference_target == "classvar":
-            return "Double-click a reference to open the method (class var highlighted)."
-        if reference_target == "method":
-            return "Double-click a reference to open the caller method."
-        return "Double-click a reference to open the method."
-
     def on_receiver_class_changed(self):
         typed = self.receiver_class_entry.get().strip()
         self.sender_source_class_name = typed if typed else None
-        self.update_search_context_fields()
         self.update_trace_narrow_state()
-
-    def update_search_context_fields(self):
-        search_type = self.search_type.get()
-        match_mode = self.match_mode.get()
-        if search_type == "reference":
-            match_mode = "exact"
-        reference_target = self.reference_target.get()
-        normalized_search_query = self.find_entry.get().strip()
-        self.search_intent_var.set(
-            self.search_intent_text(
-                search_type,
-                match_mode,
-                reference_target,
-                normalized_search_query,
-            )
-        )
-        self.result_action_var.set(
-            self.result_action_text(
-                search_type,
-                match_mode,
-                reference_target,
-            )
-        )
 
     def result_column_specs(self, column_kind):
         # AI: Single source of truth for the adaptive result columns: each spec is
@@ -4167,23 +4025,11 @@ class FindPane(Pane):
             'method_category': method_category,
         }
 
-    def populate_navigation_results(self, method_results):
-        self.navigation_method_results = list(method_results)
-        sender_entries = [
-            self.sender_entry_for_result(result)
-            for result in self.navigation_method_results
-        ]
-        class_names = [sender_entry['class_name'] for sender_entry in sender_entries]
-        class_definition_by_name = self.gemstone_session_record.class_definition_map(
-            class_names
-        )
-        rows = [
-            self.enriched_navigation_row(sender_entry, class_definition_by_name)
-            for sender_entry in sender_entries
-        ]
-        self.set_result_rows(rows, 'method', class_definition_by_name)
-
-    def populate_instvar_navigation_results(self, method_results, instvar_name):
+    def populate_navigation_results(self, method_results, highlight_term=None):
+        # AI: highlight_term, when given, is the text each result method references (a
+        # variable name, a class name, or a sent selector). It is carried on every row so
+        # that peeking or opening the method highlights where it occurs -- the same visual
+        # cue for inst/class variables, class references, and senders.
         self.navigation_method_results = list(method_results)
         sender_entries = [
             self.sender_entry_for_result(result)
@@ -4196,9 +4042,13 @@ class FindPane(Pane):
         rows = []
         for sender_entry in sender_entries:
             row = self.enriched_navigation_row(sender_entry, class_definition_by_name)
-            row['highlight_term'] = instvar_name
+            if highlight_term:
+                row['highlight_term'] = highlight_term
             rows.append(row)
         self.set_result_rows(rows, 'method', class_definition_by_name)
+
+    def populate_instvar_navigation_results(self, method_results, instvar_name):
+        self.populate_navigation_results(method_results, highlight_term=instvar_name)
 
     def record_sender_entries_for_navigation(self, sender_entries):
         sender_results = [
@@ -4452,7 +4302,6 @@ class FindPane(Pane):
             if self.match_mode.get() != 'exact':
                 self.match_mode.set('exact')
         reference_target = self.reference_target.get()
-        self.update_search_context_fields()
         self.navigation_method_results = []
         self.method_reference_results = []
         self.reference_method_selectors = []
@@ -4465,7 +4314,6 @@ class FindPane(Pane):
             self.last_reference_method_match_mode = None
             self.clear_results()
             self.status_var.set('')
-            self.update_search_context_fields()
             return
         configuration = {
             'search_type': search_type,
@@ -4611,7 +4459,10 @@ class FindPane(Pane):
             self.status_var.set('')
         elif kind == 'class_references':
             self.method_reference_results = list(payload['results'])
-            self.populate_navigation_results(payload['results'])
+            self.populate_navigation_results(
+                payload['results'],
+                highlight_term=self.find_entry.get().strip(),
+            )
             self.static_sender_results = []
             self.sender_entries_by_navigation_result = {}
             self.last_reference_method_query = None
@@ -4640,7 +4491,10 @@ class FindPane(Pane):
                     payload['match_mode'],
                 )
             )
-            self.populate_navigation_results(payload['method_reference_results'])
+            self.populate_navigation_results(
+                payload['method_reference_results'],
+                highlight_term=payload.get('query'),
+            )
             self.update_sender_status_for_method_references(
                 payload['selector_names'],
                 len(self.static_sender_results),
@@ -4670,8 +4524,6 @@ class FindPane(Pane):
 
     def complete_find_operation(self):
         self.set_find_operation_state(False)
-        self.update_search_context_fields()
-
     def choose_tests_for_tracing(self, method_name):
         test_selection_dialog = CoveringTestsSearchDialog(
             self,
@@ -4962,7 +4814,6 @@ class FindPane(Pane):
             self.find_entry.insert(0, selected_row['method_selector'])
             self.match_mode.set('exact')
             self.find_text()
-            self.update_search_context_fields()
             return
         application = self.application
         if search_type == 'class':
@@ -5009,6 +4860,14 @@ class FindPane(Pane):
             (class_name, selected_row['show_instance_side'], method_selector),
             origin=self,
         )
+        # AI: Peeking also marks where the searched term occurs in the method, so a
+        # single click gives the same visual cue as opening it (variables, class
+        # references and senders alike).
+        highlight_term = selected_row.get('highlight_term')
+        if highlight_term:
+            self.application.event_queue.publish(
+                'InstVarHighlightRequested', highlight_term, origin=self
+            )
 
 
 class CoveringTestsSearchDialog(tk.Toplevel):
@@ -8202,6 +8061,9 @@ class Swordfish(tk.Tk):
         )
         target_group.add(find_pane, text='Find')
         target_group.select(find_pane)
+        # AI: Now that the pane is mapped, lock in the intent's tab (select() only sticks
+        # after mapping) and enable user-driven tab switching.
+        find_pane.activate_search_tabs()
         return find_pane
 
     def open_find_dialog_for_instvar(self, class_name, instvar_name):

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -3255,7 +3255,14 @@ class FindPane(Pane):
             variable=self.reference_target,
             value="instvar",
         )
-        self.reference_target_instvar_radio.pack(side="left")
+        self.reference_target_instvar_radio.pack(side="left", padx=(0, 8))
+        self.reference_target_classvar_radio = ttk.Radiobutton(
+            self.reference_target_frame,
+            text="Class Var",
+            variable=self.reference_target,
+            value="classvar",
+        )
+        self.reference_target_classvar_radio.pack(side="left")
 
         ttk.Label(self, text="Find what:").grid(
             row=2,
@@ -3509,7 +3516,7 @@ class FindPane(Pane):
             configuration["match_mode"] = "exact"
         if match_mode in ["exact", "contains"]:
             configuration["match_mode"] = match_mode
-        if reference_target in ["class", "method", "instvar"]:
+        if reference_target in ["class", "method", "instvar", "classvar"]:
             configuration["reference_target"] = reference_target
         if configuration["search_type"] == "reference":
             configuration["match_mode"] = "exact"
@@ -3522,11 +3529,14 @@ class FindPane(Pane):
             self.match_mode.set("exact")
             return
         reference_target_is_method = self.reference_target.get() == "method"
-        reference_target_is_instvar = self.reference_target.get() == "instvar"
+        # AI: Instance-, class-instance- and class-variable searches all need the
+        # owning-class context entry, so it is shown for both the instvar and classvar
+        # targets (class-instance variables use the instvar target).
+        reference_target_is_variable = self.reference_target.get() in ("instvar", "classvar")
         tracing_controls_visible = (
             reference_mode_is_selected and reference_target_is_method
         )
-        instvar_controls_visible = reference_mode_is_selected and reference_target_is_instvar
+        instvar_controls_visible = reference_mode_is_selected and reference_target_is_variable
         contains_match_state = tk.NORMAL
         exact_match_state = tk.NORMAL
         if reference_mode_is_selected:
@@ -3595,6 +3605,7 @@ class FindPane(Pane):
         self.reference_target_class_radio.config(state=mode_control_state)
         self.reference_target_method_radio.config(state=mode_control_state)
         self.reference_target_instvar_radio.config(state=mode_control_state)
+        self.reference_target_classvar_radio.config(state=mode_control_state)
         self.instvar_class_entry.config(state=mode_control_state)
         self.update_trace_narrow_state()
         self.update_search_context_fields()
@@ -3675,6 +3686,17 @@ class FindPane(Pane):
             for ref in result['references']
         ])
 
+    def references_for_classvar_query(self, class_name, classvar_name, should_stop=None):
+        if should_stop is not None and should_stop():
+            return []
+        result = self.gemstone_session_record.gemstone_browser_session.find_classvar_references(
+            class_name, classvar_name
+        )
+        return self.unique_sorted_navigation_results([
+            (ref['class_name'], ref['show_instance_side'], ref['method_selector'])
+            for ref in result['references']
+        ])
+
     def references_for_method_query(
         self,
         query_text,
@@ -3739,6 +3761,8 @@ class FindPane(Pane):
             return "Finding references to class %s..." % search_query
         if reference_target == "instvar":
             return "Finding references to inst var %s..." % search_query
+        if reference_target == "classvar":
+            return "Finding references to class var %s..." % search_query
         return "Finding references to method %s..." % search_query
 
     def search_intent_text(
@@ -3765,6 +3789,11 @@ class FindPane(Pane):
             if instvar_class:
                 return 'References to inst var %s in %s.' % (normalized_search_query, instvar_class)
             return 'References to inst var "%s".' % normalized_search_query
+        if reference_target == 'classvar':
+            classvar_class = self.instvar_class_entry.get().strip()
+            if classvar_class:
+                return 'References to class var %s in %s.' % (normalized_search_query, classvar_class)
+            return 'References to class var "%s".' % normalized_search_query
         if self.sender_source_class_name is not None:
             return 'Senders of %s>>%s.' % (
                 self.sender_source_class_name,
@@ -3783,6 +3812,8 @@ class FindPane(Pane):
             return "Double-click a selector to find implementors (exact)."
         if reference_target == "instvar":
             return "Double-click a reference to open the method (inst var highlighted)."
+        if reference_target == "classvar":
+            return "Double-click a reference to open the method (class var highlighted)."
         if reference_target == "method":
             return "Double-click a reference to open the caller method."
         return "Double-click a reference to open the method."
@@ -4519,6 +4550,20 @@ class FindPane(Pane):
             return {
                 'kind': 'instvar_references',
                 'results': instvar_results,
+                'instvar_name': normalized_search_query,
+            }
+        if reference_target == 'classvar':
+            classvar_class_name = configuration.get('instvar_class_name', '')
+            classvar_results = list(
+                self.references_for_classvar_query(
+                    classvar_class_name,
+                    normalized_search_query,
+                    should_stop=should_stop,
+                )
+            )
+            return {
+                'kind': 'instvar_references',
+                'results': classvar_results,
                 'instvar_name': normalized_search_query,
             }
         (
@@ -8170,6 +8215,20 @@ class Swordfish(tk.Tk):
             run_search=True,
             match_mode='exact',
             reference_target='instvar',
+            instvar_class_name=class_name,
+        )
+
+    def open_find_dialog_for_classvar(self, class_name, classvar_name):
+        class_name = (class_name or '').strip()
+        classvar_name = (classvar_name or '').strip()
+        if not class_name or not classvar_name:
+            return None
+        return self.open_find_dialog(
+            search_type='reference',
+            search_query=classvar_name,
+            run_search=True,
+            match_mode='exact',
+            reference_target='classvar',
             instvar_class_name=class_name,
         )
 

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -708,8 +708,8 @@ class CodePanel(tk.Frame):
             foreground=theme.color_for('breakpoint_foreground'),
         )
         self.text_editor.tag_configure(
-            'instvar_highlight',
-            background=theme.color_for('instvar_reference_background'),
+            'occurrence_highlight',
+            background=theme.color_for('reference_highlight_background'),
         )
 
         self.text_editor.bind('<Control-a>', self.select_all_text_editor)
@@ -2234,7 +2234,7 @@ class CodePanel(tk.Frame):
                     f'1.0 + {token.end_offset} chars',
                 )
 
-    def apply_instvar_highlight(self, search_term):
+    def apply_occurrence_highlight(self, search_term):
         # AI: Highlights every occurrence of search_term in the source. It serves all
         # reference searches, not only instance variables: a variable/class name or a
         # unary selector is a unary_or_identifier token, a keyword selector (e.g.
@@ -2242,7 +2242,7 @@ class CodePanel(tk.Frame):
         # binary_selector token, so we match search_term against the text of any of
         # those kinds. (Multi-keyword selectors such as at:put: are several tokens and
         # are not highlighted as a unit -- matching whole-token avoids false positives.)
-        self.text_editor.tag_remove('instvar_highlight', '1.0', tk.END)
+        self.text_editor.tag_remove('occurrence_highlight', '1.0', tk.END)
         if not search_term:
             return
         highlightable_kinds = (
@@ -2254,13 +2254,13 @@ class CodePanel(tk.Frame):
         for token in self.source_scanner.scan_tokens(text):
             if token.kind in highlightable_kinds and token.text == search_term:
                 self.text_editor.tag_add(
-                    'instvar_highlight',
+                    'occurrence_highlight',
                     f'1.0 + {token.start_offset} chars',
                     f'1.0 + {token.end_offset} chars',
                 )
 
-    def clear_instvar_highlight(self):
-        self.text_editor.tag_remove('instvar_highlight', '1.0', tk.END)
+    def clear_occurrence_highlight(self):
+        self.text_editor.tag_remove('occurrence_highlight', '1.0', tk.END)
 
     def token_tag_for_kind(self, kind):
         return SYNTAX_TOKEN_TAGS.get(kind)

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -707,6 +707,10 @@ class CodePanel(tk.Frame):
             background=theme.color_for('breakpoint_background'),
             foreground=theme.color_for('breakpoint_foreground'),
         )
+        self.text_editor.tag_configure(
+            'instvar_highlight',
+            background=theme.color_for('instvar_reference_background'),
+        )
 
         self.text_editor.bind('<Control-a>', self.select_all_text_editor)
         self.text_editor.bind('<Control-A>', self.select_all_text_editor)
@@ -2229,6 +2233,23 @@ class CodePanel(tk.Frame):
                     f'1.0 + {token.start_offset} chars',
                     f'1.0 + {token.end_offset} chars',
                 )
+
+    def apply_instvar_highlight(self, instvar_name):
+        self.text_editor.tag_remove('instvar_highlight', '1.0', tk.END)
+        if not instvar_name:
+            return
+        text = self.text_editor.get('1.0', tk.END)
+        for token in self.source_scanner.scan_tokens(text):
+            if (token.kind == SmalltalkTokenKind.unary_or_identifier
+                    and token.text == instvar_name):
+                self.text_editor.tag_add(
+                    'instvar_highlight',
+                    f'1.0 + {token.start_offset} chars',
+                    f'1.0 + {token.end_offset} chars',
+                )
+
+    def clear_instvar_highlight(self):
+        self.text_editor.tag_remove('instvar_highlight', '1.0', tk.END)
 
     def token_tag_for_kind(self, kind):
         return SYNTAX_TOKEN_TAGS.get(kind)

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -2382,13 +2382,9 @@ class EditorTab(tk.Frame):
         )
         self.code_panel.grid(row=0, column=0, sticky='nsew')
 
-        self.auto_format_var = tk.BooleanVar(value=application.auto_format)
-        auto_format_control = ttk.Checkbutton(
-            self, text='Auto format', variable=self.auto_format_var,
-            command=lambda: application.set_auto_format(self.auto_format_var.get())
-        )
-        auto_format_control.grid(row=1, column=0, sticky='w', padx=4, pady=(0, 2))
-
+        # AI: Auto-format is an application-wide setting; its single checkbox lives on the
+        # MethodEditor's navigation bar (with Back/Forward), not per tab. save() reads the
+        # live application value.
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
@@ -2487,7 +2483,7 @@ class EditorTab(tk.Frame):
     def save(self):
         selected_class, show_instance_side, method_symbol = self.tab_key
         source = self.code_panel.text_editor.get('1.0', 'end-1c')
-        if self.auto_format_var.get():
+        if self.application.auto_format:
             source = SmalltalkMethodFormat().format_method(source)
         self.application.gemstone_session_record.update_method_source(
             selected_class,

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -2234,14 +2234,25 @@ class CodePanel(tk.Frame):
                     f'1.0 + {token.end_offset} chars',
                 )
 
-    def apply_instvar_highlight(self, instvar_name):
+    def apply_instvar_highlight(self, search_term):
+        # AI: Highlights every occurrence of search_term in the source. It serves all
+        # reference searches, not only instance variables: a variable/class name or a
+        # unary selector is a unary_or_identifier token, a keyword selector (e.g.
+        # printOn:) is a keyword_message_part token, and a binary selector is a
+        # binary_selector token, so we match search_term against the text of any of
+        # those kinds. (Multi-keyword selectors such as at:put: are several tokens and
+        # are not highlighted as a unit -- matching whole-token avoids false positives.)
         self.text_editor.tag_remove('instvar_highlight', '1.0', tk.END)
-        if not instvar_name:
+        if not search_term:
             return
+        highlightable_kinds = (
+            SmalltalkTokenKind.unary_or_identifier,
+            SmalltalkTokenKind.keyword_message_part,
+            SmalltalkTokenKind.binary_selector,
+        )
         text = self.text_editor.get('1.0', tk.END)
         for token in self.source_scanner.scan_tokens(text):
-            if (token.kind == SmalltalkTokenKind.unary_or_identifier
-                    and token.text == instvar_name):
+            if token.kind in highlightable_kinds and token.text == search_term:
                 self.text_editor.tag_add(
                     'instvar_highlight',
                     f'1.0 + {token.start_offset} chars',

--- a/src/reahl/swordfish/theme.py
+++ b/src/reahl/swordfish/theme.py
@@ -101,7 +101,7 @@ LIGHT_THEME = Theme(
         'object_node_outline': '#3366cc',
         'object_oop_text': '#3366cc',
         'object_class_text': '#222222',
-        'instvar_reference_background': '#d4ecd4',
+        'reference_highlight_background': '#d4ecd4',
     },
 )
 
@@ -155,7 +155,7 @@ DARK_THEME = Theme(
         'object_node_outline': '#6fa8dc',
         'object_oop_text': '#9ec9f0',
         'object_class_text': '#d0d0d0',
-        'instvar_reference_background': '#1a3a2a',
+        'reference_highlight_background': '#1a3a2a',
     },
     restyles_widgets=True,
 )

--- a/src/reahl/swordfish/theme.py
+++ b/src/reahl/swordfish/theme.py
@@ -101,6 +101,7 @@ LIGHT_THEME = Theme(
         'object_node_outline': '#3366cc',
         'object_oop_text': '#3366cc',
         'object_class_text': '#222222',
+        'instvar_reference_background': '#d4ecd4',
     },
 )
 
@@ -154,6 +155,7 @@ DARK_THEME = Theme(
         'object_node_outline': '#6fa8dc',
         'object_oop_text': '#9ec9f0',
         'object_class_text': '#d0d0d0',
+        'instvar_reference_background': '#1a3a2a',
     },
     restyles_widgets=True,
 )

--- a/tests/test_code_panel_highlighting.py
+++ b/tests/test_code_panel_highlighting.py
@@ -31,8 +31,8 @@ class HighlightingCodePanel:
     token_tag_for_kind = CodePanel.token_tag_for_kind
     syntax_tag_names = CodePanel.syntax_tag_names
     apply_syntax_highlighting = CodePanel.apply_syntax_highlighting
-    apply_instvar_highlight = CodePanel.apply_instvar_highlight
-    clear_instvar_highlight = CodePanel.clear_instvar_highlight
+    apply_occurrence_highlight = CodePanel.apply_occurrence_highlight
+    clear_occurrence_highlight = CodePanel.clear_occurrence_highlight
 
     def __init__(self):
         self.source_scanner = SmalltalkSourceScanner()
@@ -83,20 +83,20 @@ def test_rehighlighting_clears_a_now_obsolete_string_tag(highlighting_fixture):
 
 
 @with_fixtures(HighlightingFixture)
-def test_apply_instvar_highlight_tags_all_occurrences_of_the_variable(highlighting_fixture):
-    """AI: apply_instvar_highlight must add the instvar_highlight tag at every token
+def test_apply_occurrence_highlight_tags_all_occurrences_of_the_variable(highlighting_fixture):
+    """AI: apply_occurrence_highlight must add the occurrence_highlight tag at every token
     position where the variable name appears, ignoring string literals and comments
     that happen to contain the same text."""
     code_panel = highlighting_fixture.code_panel
     source = 'printOn: aStream\n    currency printString\n    ^ currency'
     code_panel.text_editor.source_text = source
 
-    code_panel.apply_instvar_highlight('currency')
+    code_panel.apply_occurrence_highlight('currency')
 
     tagged_ranges = [
         (start, end)
         for tag, start, end in code_panel.text_editor.added
-        if tag == 'instvar_highlight'
+        if tag == 'occurrence_highlight'
     ]
     # AI: Two occurrences of 'currency' as identifiers in the source.
     assert len(tagged_ranges) == 2
@@ -106,19 +106,19 @@ def test_apply_instvar_highlight_tags_all_occurrences_of_the_variable(highlighti
 
 
 @with_fixtures(HighlightingFixture)
-def test_apply_instvar_highlight_marks_keyword_selector_sends(highlighting_fixture):
+def test_apply_occurrence_highlight_marks_keyword_selector_sends(highlighting_fixture):
     """AI: The same highlight serves senders, so a keyword selector (a
     keyword_message_part token, not an identifier) must be marked where it is sent."""
     code_panel = highlighting_fixture.code_panel
     source = 'store: anItem\n    collection printOn: aStream'
     code_panel.text_editor.source_text = source
 
-    code_panel.apply_instvar_highlight('printOn:')
+    code_panel.apply_occurrence_highlight('printOn:')
 
     tagged_ranges = [
         (start, end)
         for tag, start, end in code_panel.text_editor.added
-        if tag == 'instvar_highlight'
+        if tag == 'occurrence_highlight'
     ]
     assert len(tagged_ranges) == 1
     start, end = tagged_ranges[0]
@@ -127,33 +127,33 @@ def test_apply_instvar_highlight_marks_keyword_selector_sends(highlighting_fixtu
 
 
 @with_fixtures(HighlightingFixture)
-def test_apply_instvar_highlight_marks_class_name_references(highlighting_fixture):
+def test_apply_occurrence_highlight_marks_class_name_references(highlighting_fixture):
     """AI: The same highlight serves class-reference searches, so a class name is marked
     where it is referenced (and not where a same-named keyword/comment text appears)."""
     code_panel = highlighting_fixture.code_panel
     source = 'build\n    ^ OrderLine new register: OrderLine'
     code_panel.text_editor.source_text = source
 
-    code_panel.apply_instvar_highlight('OrderLine')
+    code_panel.apply_occurrence_highlight('OrderLine')
 
     tagged_ranges = [
         (start, end)
         for tag, start, end in code_panel.text_editor.added
-        if tag == 'instvar_highlight'
+        if tag == 'occurrence_highlight'
     ]
     assert len(tagged_ranges) == 2
 
 
 @with_fixtures(HighlightingFixture)
-def test_apply_instvar_highlight_clears_previous_before_reapplying(highlighting_fixture):
-    """AI: Calling apply_instvar_highlight twice must remove the previous tag before
+def test_apply_occurrence_highlight_clears_previous_before_reapplying(highlighting_fixture):
+    """AI: Calling apply_occurrence_highlight twice must remove the previous tag before
     adding new ranges, so stale highlights from an earlier method do not accumulate."""
     code_panel = highlighting_fixture.code_panel
     code_panel.text_editor.source_text = 'currency\n    ^ currency'
 
-    code_panel.apply_instvar_highlight('currency')
+    code_panel.apply_occurrence_highlight('currency')
     code_panel.text_editor.removed.clear()
     code_panel.text_editor.added.clear()
-    code_panel.apply_instvar_highlight('currency')
+    code_panel.apply_occurrence_highlight('currency')
 
-    assert any(tag == 'instvar_highlight' for tag, _, _ in code_panel.text_editor.removed)
+    assert any(tag == 'occurrence_highlight' for tag, _, _ in code_panel.text_editor.removed)

--- a/tests/test_code_panel_highlighting.py
+++ b/tests/test_code_panel_highlighting.py
@@ -106,6 +106,45 @@ def test_apply_instvar_highlight_tags_all_occurrences_of_the_variable(highlighti
 
 
 @with_fixtures(HighlightingFixture)
+def test_apply_instvar_highlight_marks_keyword_selector_sends(highlighting_fixture):
+    """AI: The same highlight serves senders, so a keyword selector (a
+    keyword_message_part token, not an identifier) must be marked where it is sent."""
+    code_panel = highlighting_fixture.code_panel
+    source = 'store: anItem\n    collection printOn: aStream'
+    code_panel.text_editor.source_text = source
+
+    code_panel.apply_instvar_highlight('printOn:')
+
+    tagged_ranges = [
+        (start, end)
+        for tag, start, end in code_panel.text_editor.added
+        if tag == 'instvar_highlight'
+    ]
+    assert len(tagged_ranges) == 1
+    start, end = tagged_ranges[0]
+    offset = int(start.split('+ ')[1].split(' chars')[0])
+    assert source[offset:offset + len('printOn:')] == 'printOn:'
+
+
+@with_fixtures(HighlightingFixture)
+def test_apply_instvar_highlight_marks_class_name_references(highlighting_fixture):
+    """AI: The same highlight serves class-reference searches, so a class name is marked
+    where it is referenced (and not where a same-named keyword/comment text appears)."""
+    code_panel = highlighting_fixture.code_panel
+    source = 'build\n    ^ OrderLine new register: OrderLine'
+    code_panel.text_editor.source_text = source
+
+    code_panel.apply_instvar_highlight('OrderLine')
+
+    tagged_ranges = [
+        (start, end)
+        for tag, start, end in code_panel.text_editor.added
+        if tag == 'instvar_highlight'
+    ]
+    assert len(tagged_ranges) == 2
+
+
+@with_fixtures(HighlightingFixture)
 def test_apply_instvar_highlight_clears_previous_before_reapplying(highlighting_fixture):
     """AI: Calling apply_instvar_highlight twice must remove the previous tag before
     adding new ranges, so stale highlights from an earlier method do not accumulate."""

--- a/tests/test_code_panel_highlighting.py
+++ b/tests/test_code_panel_highlighting.py
@@ -13,12 +13,16 @@ class RecordingTextEditor:
     def __init__(self):
         self.added = []
         self.removed = []
+        self.source_text = ''
 
     def tag_add(self, tag_name, start, end):
         self.added.append((tag_name, start, end))
 
     def tag_remove(self, tag_name, start, end):
         self.removed.append((tag_name, start, end))
+
+    def get(self, start, end):
+        return self.source_text
 
 
 class HighlightingCodePanel:
@@ -27,6 +31,8 @@ class HighlightingCodePanel:
     token_tag_for_kind = CodePanel.token_tag_for_kind
     syntax_tag_names = CodePanel.syntax_tag_names
     apply_syntax_highlighting = CodePanel.apply_syntax_highlighting
+    apply_instvar_highlight = CodePanel.apply_instvar_highlight
+    clear_instvar_highlight = CodePanel.clear_instvar_highlight
 
     def __init__(self):
         self.source_scanner = SmalltalkSourceScanner()
@@ -74,3 +80,41 @@ def test_rehighlighting_clears_a_now_obsolete_string_tag(highlighting_fixture):
 
     assert 'smalltalk_string' in highlighting_fixture.removed_tags()
     assert 'smalltalk_string' not in highlighting_fixture.added_tags()
+
+
+@with_fixtures(HighlightingFixture)
+def test_apply_instvar_highlight_tags_all_occurrences_of_the_variable(highlighting_fixture):
+    """AI: apply_instvar_highlight must add the instvar_highlight tag at every token
+    position where the variable name appears, ignoring string literals and comments
+    that happen to contain the same text."""
+    code_panel = highlighting_fixture.code_panel
+    source = 'printOn: aStream\n    currency printString\n    ^ currency'
+    code_panel.text_editor.source_text = source
+
+    code_panel.apply_instvar_highlight('currency')
+
+    tagged_ranges = [
+        (start, end)
+        for tag, start, end in code_panel.text_editor.added
+        if tag == 'instvar_highlight'
+    ]
+    # AI: Two occurrences of 'currency' as identifiers in the source.
+    assert len(tagged_ranges) == 2
+    for start, end in tagged_ranges:
+        offset = int(start.split('+ ')[1].split(' chars')[0])
+        assert source[offset:offset + len('currency')] == 'currency'
+
+
+@with_fixtures(HighlightingFixture)
+def test_apply_instvar_highlight_clears_previous_before_reapplying(highlighting_fixture):
+    """AI: Calling apply_instvar_highlight twice must remove the previous tag before
+    adding new ranges, so stale highlights from an earlier method do not accumulate."""
+    code_panel = highlighting_fixture.code_panel
+    code_panel.text_editor.source_text = 'currency\n    ^ currency'
+
+    code_panel.apply_instvar_highlight('currency')
+    code_panel.text_editor.removed.clear()
+    code_panel.text_editor.added.clear()
+    code_panel.apply_instvar_highlight('currency')
+
+    assert any(tag == 'instvar_highlight' for tag, _, _ in code_panel.text_editor.removed)

--- a/tests/test_gemstone_browser_instvar_references.py
+++ b/tests/test_gemstone_browser_instvar_references.py
@@ -16,7 +16,7 @@ class RecordingBrowserSession(GemstoneBrowserSession):
         return self.canned_run_code_result
 
 
-class TabDelimitedResult:
+class PlainResult:
     """AI: Satisfies the .to_py contract that parseltongue's run_code returns."""
 
     def __init__(self, to_py):
@@ -31,9 +31,9 @@ class InstVarReferenceFixture(Fixture):
 @with_fixtures(InstVarReferenceFixture)
 def test_instvar_reference_query_uses_instVarsAccessed(fixture):
     """AI: The query must ask GemStone for each method's instVarsAccessed and filter
-    on the named inst var. This tests that the correct Smalltalk API is used and
-    that the class name and inst var name appear in the emitted source."""
-    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+    on the named inst var, searching the full subclass hierarchy. This tests that
+    the correct Smalltalk API is used and that class name and inst var name appear."""
+    fixture.browser_session.canned_run_code_result = PlainResult('')
 
     fixture.browser_session.find_instvar_references('Amount', 'currency')
 
@@ -42,33 +42,96 @@ def test_instvar_reference_query_uses_instVarsAccessed(fixture):
     assert 'instVarsAccessed' in source
     assert "'Amount' asSymbol" in source
     assert "'currency' asSymbol" in source
+    assert 'allSubclasses' in source
 
 
 @with_fixtures(InstVarReferenceFixture)
-def test_instvar_reference_search_parses_newline_delimited_selectors(fixture):
-    """AI: GemStone returns one selector per line. The returned dicts must expose
-    class_name, show_instance_side, and method_selector for each method that
-    accesses the named inst var."""
-    fixture.browser_session.canned_run_code_result = TabDelimitedResult(
-        'printOn:\ncurrency'
+def test_instvar_reference_search_parses_class_side_and_instance_side_results(fixture):
+    """AI: GemStone returns class TAB side TAB selector per line. The returned dicts
+    must expose class_name, show_instance_side, and method_selector, distinguishing
+    instance-side from class-side results."""
+    fixture.browser_session.canned_run_code_result = PlainResult(
+        'Amount\tinstance\tprintOn:\nAmount\tclass\tnew'
     )
 
     result = fixture.browser_session.find_instvar_references('Amount', 'currency')
 
     assert result['total_count'] == 2
     assert result['returned_count'] == 2
-    selectors = [r['method_selector'] for r in result['references']]
-    assert sorted(selectors) == ['currency', 'printOn:']
-    for ref in result['references']:
-        assert ref['class_name'] == 'Amount'
-        assert ref['show_instance_side'] is True
+    by_selector = {r['method_selector']: r for r in result['references']}
+    assert by_selector['printOn:']['class_name'] == 'Amount'
+    assert by_selector['printOn:']['show_instance_side'] is True
+    assert by_selector['new']['class_name'] == 'Amount'
+    assert by_selector['new']['show_instance_side'] is False
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_search_includes_subclass_results(fixture):
+    """AI: Because the query traverses allSubclasses, results can come from a subclass
+    of the named class. The class_name field must reflect the actual defining class."""
+    fixture.browser_session.canned_run_code_result = PlainResult(
+        'Amount\tinstance\tprintOn:\nMoney\tinstance\tprintOn:'
+    )
+
+    result = fixture.browser_session.find_instvar_references('Amount', 'currency')
+
+    class_names = {r['class_name'] for r in result['references']}
+    assert class_names == {'Amount', 'Money'}
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_classvar_reference_query_matches_association_literal_in_owner_hierarchy(fixture):
+    """AI: Class variables are invisible to instVarsAccessed, so the class-var query
+    must instead scan method literals for an Association whose key is the variable,
+    after walking up to the variable's owner so the whole scope is covered. It must
+    use the portable selectors that also exist on the older GemStone (detect:ifNone:
+    and Association rather than anySatisfy:/SymbolAssociation)."""
+    fixture.browser_session.canned_run_code_result = PlainResult('')
+
+    fixture.browser_session.find_classvar_references('Date', 'MonthNames')
+
+    source = fixture.browser_session.recorded_run_code_source
+    assert source is not None
+    assert 'instVarsAccessed' not in source
+    assert 'literals' in source
+    assert 'key == varSym' in source
+    assert 'superclass classVarNames includes: varSym' in source
+    assert 'allSubclasses' in source
+    assert 'detect:' in source
+    assert 'isKindOf: Association' in source
+    assert "'Date' asSymbol" in source
+    assert "'MonthNames' asSymbol" in source
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_classvar_reference_search_parses_both_sides(fixture):
+    """AI: The class-var search returns the same class TAB side TAB selector shape as
+    the inst-var search, so the dialog can reuse the same navigation handling."""
+    fixture.browser_session.canned_run_code_result = PlainResult(
+        'Date\tinstance\tmonthName\nDate\tclass\tnameOfMonth:'
+    )
+
+    result = fixture.browser_session.find_classvar_references('Date', 'MonthNames')
+
+    assert result['total_count'] == 2
+    by_selector = {r['method_selector']: r for r in result['references']}
+    assert by_selector['monthName']['show_instance_side'] is True
+    assert by_selector['nameOfMonth:']['show_instance_side'] is False
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_classvar_reference_returns_empty_when_names_blank(fixture):
+    """AI: A blank class or variable name must short-circuit without querying GemStone."""
+    assert fixture.browser_session.find_classvar_references('', 'MonthNames')['references'] == []
+    assert fixture.browser_session.find_classvar_references('Date', '')['references'] == []
+    assert fixture.browser_session.recorded_run_code_source is None
 
 
 @with_fixtures(InstVarReferenceFixture)
 def test_instvar_reference_empty_result_when_no_methods_access_the_var(fixture):
     """AI: When no methods access the named inst var GemStone returns an empty
     string. The result dict must report zero references, not an error."""
-    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+    fixture.browser_session.canned_run_code_result = PlainResult('')
 
     result = fixture.browser_session.find_instvar_references('Amount', 'value')
 
@@ -92,4 +155,66 @@ def test_instvar_reference_returns_empty_when_instvar_name_is_blank(fixture):
     result = fixture.browser_session.find_instvar_references('Amount', '')
 
     assert result['references'] == []
+    assert fixture.browser_session.recorded_run_code_source is None
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_accessible_var_names_returns_all_three_kinds(fixture):
+    """AI: accessible_var_names splits variables into instance, class-instance and
+    class kinds. GemStone emits one 'kind TAB name TAB own|inherited' line per
+    variable, which must be parsed into per-kind lists of name/inherited dicts."""
+    fixture.browser_session.canned_run_code_result = PlainResult(
+        'inst\tamount\town\n'
+        'inst\tcurrency\town\n'
+        'classInst\tmanager\town\n'
+        'classVar\tTotal\town'
+    )
+
+    result = fixture.browser_session.accessible_var_names('Amount')
+
+    assert result['inst_var_names'] == [
+        {'name': 'amount', 'inherited': False},
+        {'name': 'currency', 'inherited': False},
+    ]
+    assert result['class_inst_var_names'] == [
+        {'name': 'manager', 'inherited': False},
+    ]
+    assert result['class_var_names'] == [{'name': 'Total', 'inherited': False}]
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_accessible_var_names_marks_inherited_variables(fixture):
+    """AI: A variable defined on a superclass is flagged inherited so the UI can
+    distinguish it from variables the class itself introduces."""
+    fixture.browser_session.canned_run_code_result = PlainResult(
+        'inst\tamount\town\n'
+        'inst\tcurrency\tinherited'
+    )
+
+    result = fixture.browser_session.accessible_var_names('Amount')
+
+    assert result['inst_var_names'] == [
+        {'name': 'amount', 'inherited': False},
+        {'name': 'currency', 'inherited': True},
+    ]
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_accessible_var_names_returns_empty_groups_when_result_is_empty(fixture):
+    """AI: A class with no variables returns empty lists for all three kinds."""
+    fixture.browser_session.canned_run_code_result = PlainResult('')
+
+    result = fixture.browser_session.accessible_var_names('Amount')
+
+    assert result['inst_var_names'] == []
+    assert result['class_inst_var_names'] == []
+    assert result['class_var_names'] == []
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_accessible_var_names_returns_empty_when_class_name_is_blank(fixture):
+    """AI: A blank class name must short-circuit without querying GemStone."""
+    result = fixture.browser_session.accessible_var_names('')
+
+    assert result['inst_var_names'] == []
     assert fixture.browser_session.recorded_run_code_source is None

--- a/tests/test_gemstone_browser_instvar_references.py
+++ b/tests/test_gemstone_browser_instvar_references.py
@@ -1,0 +1,95 @@
+from reahl.stubble import stubclass
+from reahl.tofu import Fixture, with_fixtures
+
+from reahl.swordfish.gemstone.browser import GemstoneBrowserSession
+
+
+@stubclass(GemstoneBrowserSession)
+class RecordingBrowserSession(GemstoneBrowserSession):
+    """AI: Stubs run_code so tests verify the Smalltalk query without a live stone."""
+
+    recorded_run_code_source = None
+    canned_run_code_result = None
+
+    def run_code(self, source):
+        self.recorded_run_code_source = source
+        return self.canned_run_code_result
+
+
+class TabDelimitedResult:
+    """AI: Satisfies the .to_py contract that parseltongue's run_code returns."""
+
+    def __init__(self, to_py):
+        self.to_py = to_py
+
+
+class InstVarReferenceFixture(Fixture):
+    def new_browser_session(self):
+        return RecordingBrowserSession(None)
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_query_uses_instVarsAccessed(fixture):
+    """AI: The query must ask GemStone for each method's instVarsAccessed and filter
+    on the named inst var. This tests that the correct Smalltalk API is used and
+    that the class name and inst var name appear in the emitted source."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+
+    fixture.browser_session.find_instvar_references('Amount', 'currency')
+
+    source = fixture.browser_session.recorded_run_code_source
+    assert source is not None
+    assert 'instVarsAccessed' in source
+    assert "'Amount' asSymbol" in source
+    assert "'currency' asSymbol" in source
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_search_parses_newline_delimited_selectors(fixture):
+    """AI: GemStone returns one selector per line. The returned dicts must expose
+    class_name, show_instance_side, and method_selector for each method that
+    accesses the named inst var."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult(
+        'printOn:\ncurrency'
+    )
+
+    result = fixture.browser_session.find_instvar_references('Amount', 'currency')
+
+    assert result['total_count'] == 2
+    assert result['returned_count'] == 2
+    selectors = [r['method_selector'] for r in result['references']]
+    assert sorted(selectors) == ['currency', 'printOn:']
+    for ref in result['references']:
+        assert ref['class_name'] == 'Amount'
+        assert ref['show_instance_side'] is True
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_empty_result_when_no_methods_access_the_var(fixture):
+    """AI: When no methods access the named inst var GemStone returns an empty
+    string. The result dict must report zero references, not an error."""
+    fixture.browser_session.canned_run_code_result = TabDelimitedResult('')
+
+    result = fixture.browser_session.find_instvar_references('Amount', 'value')
+
+    assert result['references'] == []
+    assert result['total_count'] == 0
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_returns_empty_when_class_name_is_blank(fixture):
+    """AI: A blank class name means no class is selected. The method must
+    short-circuit without querying GemStone to avoid a Smalltalk error."""
+    result = fixture.browser_session.find_instvar_references('', 'currency')
+
+    assert result['references'] == []
+    assert fixture.browser_session.recorded_run_code_source is None
+
+
+@with_fixtures(InstVarReferenceFixture)
+def test_instvar_reference_returns_empty_when_instvar_name_is_blank(fixture):
+    """AI: A blank inst var name must not query GemStone — no variable to search for."""
+    result = fixture.browser_session.find_instvar_references('Amount', '')
+
+    assert result['references'] == []
+    assert fixture.browser_session.recorded_run_code_source is None

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -8397,7 +8397,7 @@ def test_open_find_dialog_for_classvar_runs_classvar_search(fixture):
 @with_fixtures(SwordfishAppFixture)
 def test_find_dialog_double_click_instvar_result_publishes_highlight_event(fixture):
     """AI: Double-clicking an inst-var reference result must publish both
-    MethodDisplayRequested (to open the tab) and InstVarHighlightRequested (to
+    MethodDisplayRequested (to open the tab) and OccurrenceHighlightRequested (to
     highlight all occurrences of the inst var in the opened method)."""
     fixture.simulate_login()
     fixture.mock_browser.get_method_category.return_value = 'accessing'
@@ -8413,7 +8413,7 @@ def test_find_dialog_double_click_instvar_result_publishes_highlight_event(fixtu
     dialog.populate_instvar_navigation_results([('Amount', True, 'printOn:')], 'currency')
 
     highlight_handler = Mock()
-    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+    fixture.app.event_queue.subscribe('OccurrenceHighlightRequested', highlight_handler)
 
     select_find_result(dialog, 'Amount>>printOn:')
     dialog.on_result_double_click(None)
@@ -8441,7 +8441,7 @@ def test_find_dialog_peek_publishes_highlight_for_reference_result(fixture):
     dialog.populate_instvar_navigation_results([('Amount', True, 'printOn:')], 'currency')
 
     highlight_handler = Mock()
-    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+    fixture.app.event_queue.subscribe('OccurrenceHighlightRequested', highlight_handler)
 
     select_find_result(dialog, 'Amount>>printOn:')
     dialog.peek_selected_result(None)
@@ -8472,7 +8472,7 @@ def test_senders_result_highlights_the_sent_selector(fixture):
     )
 
     highlight_handler = Mock()
-    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+    fixture.app.event_queue.subscribe('OccurrenceHighlightRequested', highlight_handler)
 
     select_find_result(dialog, 'OrderLine>>recalculate')
     dialog.on_result_double_click(None)
@@ -8500,7 +8500,7 @@ def test_find_dialog_result_without_highlight_term_does_not_publish_highlight_ev
     dialog.populate_navigation_results([('Amount', True, 'printOn:')])
 
     highlight_handler = Mock()
-    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+    fixture.app.event_queue.subscribe('OccurrenceHighlightRequested', highlight_handler)
 
     select_find_result(dialog, 'Amount>>printOn:')
     dialog.on_result_double_click(None)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1025,6 +1025,20 @@ def test_method_editor_is_a_standalone_tool_built_from_the_application(fixture):
 
 
 @with_fixtures(SwordfishGuiFixture)
+def test_auto_format_checkbox_lives_on_editor_navigation_bar(fixture):
+    """AI: Auto-format is a single application-wide checkbox on the editor's navigation
+    bar (alongside Back/Forward), not a per-tab control taking a whole line under every
+    editor tab. Toggling it routes through the application setting."""
+    editor = MethodEditor(fixture.root, fixture.application, fixture.event_queue)
+
+    assert editor.auto_format_control.winfo_parent() == str(editor.navigation_bar)
+
+    fixture.application.set_auto_format = Mock()
+    editor.auto_format_control.invoke()
+    fixture.application.set_auto_format.assert_called_once_with(True)
+
+
+@with_fixtures(SwordfishGuiFixture)
 def test_double_clicking_a_method_pins_its_tab(fixture):
     """AI: Double-clicking a method pins its tab, so it is no longer the
     recyclable preview tab and survives opening another method."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import time
 import tkinter as tk
+import tkinter.font as tkfont
 import tkinter.messagebox as messagebox
 import types
 from tkinter import ttk
@@ -55,6 +56,7 @@ from reahl.swordfish.mcp.integration_state import IntegratedSessionState
 from reahl.swordfish.object_diagram import UmlObjectDiagramNodeDetailDialog
 from reahl.swordfish.pane_area import PaneArea
 from reahl.swordfish.session_activity import ForegroundActivity, McpActivity
+from reahl.swordfish.theme import active_theme
 from reahl.swordfish.text_editing import PINNED_TAB_MARKER
 
 
@@ -283,6 +285,38 @@ class SwordfishGuiFixture(Fixture):
 
         self.mock_browser.get_class_definition.side_effect = get_class_definition
 
+        # AI: accessible_var_names mirrors the live gem: for each variable kind it
+        # lists the class's own variables first (inherited=False) then those from its
+        # superclasses (inherited=True), so the UI can group and grey them.
+        def accessible_var_names(class_name):
+            own_definition = class_definitions.get(class_name)
+            ancestor_definitions = []
+            ancestor_name = (
+                own_definition["superclass_name"] if own_definition else None
+            )
+            while ancestor_name in class_definitions:
+                ancestor_definition = class_definitions[ancestor_name]
+                ancestor_definitions.append(ancestor_definition)
+                ancestor_name = ancestor_definition["superclass_name"]
+
+            def entries_for(kind_key):
+                entries = []
+                if own_definition:
+                    for name in own_definition[kind_key]:
+                        entries.append({"name": name, "inherited": False})
+                for ancestor_definition in ancestor_definitions:
+                    for name in ancestor_definition[kind_key]:
+                        entries.append({"name": name, "inherited": True})
+                return entries
+
+            return {
+                "inst_var_names": entries_for("inst_var_names"),
+                "class_inst_var_names": entries_for("class_inst_var_names"),
+                "class_var_names": entries_for("class_var_names"),
+            }
+
+        self.mock_browser.accessible_var_names.side_effect = accessible_var_names
+
         # AI: get_compiled_method returns an object whose sourceString() method
         # returns an object with a .to_py attribute (the raw Smalltalk source string).
         mock_method = Mock()
@@ -414,6 +448,37 @@ def menu_command_labels(menu):
     for entry_index in range(entry_count):
         if menu.type(entry_index) == "command":
             labels.append(menu.entrycget(entry_index, "label"))
+    return labels
+
+
+def cascade_submenu(menu, cascade_label):
+    """AI: Resolve the submenu Menu widget hung off a cascade entry.
+
+    A cascade entry stores its submenu as a Tk path string under the 'menu'
+    option; nametowidget resolves that back to the child Menu widget.
+    """
+    entry_count = int(menu.index("end")) + 1
+    for entry_index in range(entry_count):
+        if menu.type(entry_index) == "cascade":
+            if menu.entrycget(entry_index, "label") == cascade_label:
+                submenu_path = menu.entrycget(entry_index, "menu")
+                return menu.nametowidget(submenu_path)
+    raise AssertionError(f"Could not find cascade {cascade_label}.")
+
+
+def cascade_submenu_labels(menu, cascade_label):
+    """AI: Return the selectable variable labels of a cascade's submenu.
+
+    Heading rows carry no command (they are inert labels), so filtering to entries
+    that have a command leaves exactly the variable names a user could click.
+    """
+    submenu = cascade_submenu(menu, cascade_label)
+    labels = []
+    entry_count = int(submenu.index("end")) + 1
+    for entry_index in range(entry_count):
+        if submenu.type(entry_index) == "command":
+            if str(submenu.entrycget(entry_index, "command")) != "":
+                labels.append(submenu.entrycget(entry_index, "label"))
     return labels
 
 
@@ -8225,6 +8290,41 @@ def test_open_find_dialog_for_instvar_prefills_controls_and_runs_search(fixture)
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_open_find_dialog_for_classvar_runs_classvar_search(fixture):
+    """AI: open_find_dialog_for_classvar must open the Find pane in reference mode with
+    the new 'classvar' target and run find_classvar_references (NOT the inst-var
+    search, which cannot see class variables), pre-filling class and variable name."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_classvar_references.return_value = {
+        'references': [
+            {
+                'class_name': 'Date',
+                'show_instance_side': True,
+                'method_selector': 'monthName',
+                'method_category': 'accessing',
+            }
+        ],
+        'total_count': 1,
+        'returned_count': 1,
+    }
+    fixture.mock_browser.get_method_category.return_value = 'accessing'
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = fixture.app.open_find_dialog_for_classvar('Date', 'MonthNames')
+
+    assert dialog is not None
+    assert dialog.search_type.get() == 'reference'
+    assert dialog.reference_target.get() == 'classvar'
+    assert dialog.match_mode.get() == 'exact'
+    assert dialog.find_entry.get() == 'MonthNames'
+    assert dialog.instvar_class_entry.get() == 'Date'
+    fixture.mock_browser.find_classvar_references.assert_called_once_with('Date', 'MonthNames')
+    fixture.mock_browser.find_instvar_references.assert_not_called()
+    assert find_result_labels(dialog) == ['Date>>monthName']
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_find_dialog_double_click_instvar_result_publishes_highlight_event(fixture):
     """AI: Double-clicking an inst-var reference result must publish both
     MethodDisplayRequested (to open the tab) and InstVarHighlightRequested (to
@@ -10039,6 +10139,154 @@ def test_class_list_context_menu_find_references_uses_selected_class_name(
 
 
 @with_fixtures(SwordfishGuiFixture)
+def test_class_list_instvar_references_submenu_reflects_the_right_clicked_class(
+    fixture,
+):
+    """AI: The Variable References submenu must list the variables of the class the
+    user right-clicked, even when a different class was right-clicked moments before.
+    Right-clicking does not select, so a class-scoped cache would leak the first
+    class's variables into the second menu; reading fresh per right-click prevents it."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    classes_widget = fixture.browser_window.classes_widget
+    class_listbox = classes_widget.selection_list.selection_listbox
+
+    def instvar_submenu_labels_after_right_click(class_name):
+        class_index = list(class_listbox.get(0, "end")).index(class_name)
+        class_listbox.see(class_index)
+        fixture.root.update()
+        class_item_box = class_listbox.bbox(class_index)
+        assert class_item_box is not None
+        classes_widget.show_context_menu(
+            types.SimpleNamespace(
+                widget=class_listbox,
+                y=class_item_box[1] + 1,
+                x_root=1,
+                y_root=1,
+            )
+        )
+        return cascade_submenu_labels(
+            classes_widget.current_context_menu,
+            "Variable References",
+        )
+
+    order_line_vars = instvar_submenu_labels_after_right_click("OrderLine")
+    assert order_line_vars == ["amount", "quantity", "lines"]
+
+    order_vars = instvar_submenu_labels_after_right_click("Order")
+    assert order_vars == ["lines"]
+    assert "amount" not in order_vars
+    assert "quantity" not in order_vars
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_variable_references_submenu_marks_kinds_and_inheritance(fixture):
+    """AI: The submenu must let the reader tell the variable kinds and inheritance
+    apart: each kind sits under a bold, non-selectable heading, and inherited
+    variables are shown in the muted colour (yet stay selectable) while the class's
+    own variables render normally."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    classes_widget = fixture.browser_window.classes_widget
+    class_listbox = classes_widget.selection_list.selection_listbox
+    class_index = list(class_listbox.get(0, "end")).index("OrderLine")
+    class_listbox.see(class_index)
+    fixture.root.update()
+    class_item_box = class_listbox.bbox(class_index)
+    assert class_item_box is not None
+    classes_widget.show_context_menu(
+        types.SimpleNamespace(
+            widget=class_listbox,
+            y=class_item_box[1] + 1,
+            x_root=1,
+            y_root=1,
+        )
+    )
+    submenu = cascade_submenu(
+        classes_widget.current_context_menu,
+        "Variable References",
+    )
+
+    def entry_at(label):
+        entry_count = int(submenu.index("end")) + 1
+        for entry_index in range(entry_count):
+            if submenu.type(entry_index) == "command":
+                if submenu.entrycget(entry_index, "label") == label:
+                    return entry_index
+        raise AssertionError(f"No submenu entry labelled {label}.")
+
+    muted_colour = active_theme.current().color_for("disabled_list_item")
+    heading_index = entry_at("Instance")
+    # AI: The heading is an inert label (no command) but stays in the normal colour
+    # (not greyed) and is underlined rather than bold, so it reads as a section title.
+    assert str(submenu.entrycget(heading_index, "command")) == ""
+    assert str(submenu.entrycget(heading_index, "foreground")) != muted_colour
+    heading_font = tkfont.Font(submenu, font=submenu.entrycget(heading_index, "font"))
+    assert heading_font.actual("underline") == 1
+    assert heading_font.actual("weight") == "normal"
+
+    inherited_index = entry_at("lines")
+    assert str(submenu.entrycget(inherited_index, "foreground")) == muted_colour
+    assert str(submenu.entrycget(inherited_index, "command")) != ""
+
+    own_index = entry_at("amount")
+    assert str(submenu.entrycget(own_index, "foreground")) != muted_colour
+    assert str(submenu.entrycget(own_index, "command")) != ""
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_class_variable_pick_routes_to_classvar_reference_search(fixture):
+    """AI: Choosing a class variable must run the class-variable search, not the
+    instance-variable one (instVarsAccessed cannot see class vars). This is observable
+    as the class-var-specific find entry point being invoked with the class context."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    classes_widget = fixture.browser_window.classes_widget
+    classes_widget.application.open_find_dialog_for_classvar = Mock()
+    classes_widget.application.open_find_dialog_for_instvar = Mock()
+    # AI: Give OrderLine a class variable for this menu without disturbing the shared
+    # class-definition fixtures used elsewhere.
+    classes_widget.gemstone_session_record.gemstone_browser_session.accessible_var_names.side_effect = (
+        lambda class_name: {
+            "inst_var_names": [{"name": "amount", "inherited": False}],
+            "class_inst_var_names": [],
+            "class_var_names": [{"name": "DefaultRate", "inherited": False}],
+        }
+    )
+    class_listbox = classes_widget.selection_list.selection_listbox
+    class_index = list(class_listbox.get(0, "end")).index("OrderLine")
+    class_listbox.see(class_index)
+    fixture.root.update()
+    class_item_box = class_listbox.bbox(class_index)
+    assert class_item_box is not None
+    classes_widget.show_context_menu(
+        types.SimpleNamespace(
+            widget=class_listbox,
+            y=class_item_box[1] + 1,
+            x_root=1,
+            y_root=1,
+        )
+    )
+    submenu = cascade_submenu(
+        classes_widget.current_context_menu,
+        "Variable References",
+    )
+    invoke_menu_command_by_label(submenu, "DefaultRate")
+
+    classes_widget.application.open_find_dialog_for_classvar.assert_called_once_with(
+        "OrderLine",
+        "DefaultRate",
+    )
+    classes_widget.application.open_find_dialog_for_instvar.assert_not_called()
+
+
+@with_fixtures(SwordfishGuiFixture)
 def test_class_hierarchy_context_menu_find_references_uses_selected_class_name(
     fixture,
 ):
@@ -10092,6 +10340,60 @@ def test_class_hierarchy_context_menu_find_references_uses_selected_class_name(
     classes_widget.application.open_find_dialog_for_class.assert_called_once_with(
         "OrderLine",
     )
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_class_hierarchy_context_menu_instvar_references_submenu_reflects_clicked_class(
+    fixture,
+):
+    """AI: The hierarchy context menu must offer the same Inst Var References submenu
+    as the class list, listing the clicked class's accessible variables (own and
+    inherited). This keeps the two views of the class set consistent."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    fixture.select_in_listbox(
+        fixture.browser_window.classes_widget.selection_list.selection_listbox,
+        "OrderLine",
+    )
+    classes_widget = fixture.browser_window.classes_widget
+    classes_widget.classes_notebook.select(classes_widget.hierarchy_frame)
+    fixture.root.update()
+    tree = classes_widget.hierarchy_tree
+
+    def child_with_text(parent_item, expected_text):
+        child_item_ids = tree.get_children(parent_item)
+        for child_item_id in child_item_ids:
+            if tree.item(child_item_id, "text") == expected_text:
+                return child_item_id
+        raise AssertionError(
+            f"Could not find {expected_text} under {parent_item}.",
+        )
+
+    object_item = child_with_text("", "Object")
+    order_item = child_with_text(object_item, "Order")
+    order_line_item = child_with_text(order_item, "OrderLine")
+    tree.selection_set(order_line_item)
+    tree.focus(order_line_item)
+    tree.see(order_line_item)
+    fixture.root.update()
+    order_line_box = tree.bbox(order_line_item)
+    assert order_line_box not in [None, ""]
+
+    classes_widget.show_hierarchy_context_menu(
+        types.SimpleNamespace(
+            widget=tree,
+            y=order_line_box[1] + 1,
+            x_root=1,
+            y_root=1,
+        )
+    )
+    instvar_labels = cascade_submenu_labels(
+        classes_widget.current_context_menu,
+        "Variable References",
+    )
+    assert instvar_labels == ["amount", "quantity", "lines"]
 
 
 @with_fixtures(SwordfishGuiFixture)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -7661,12 +7661,15 @@ def test_find_is_an_icon_button_beside_the_search_box_with_no_per_dialog_stop(fi
     with patch.object(FindPane, "wait_visibility"):
         dialog = FindPane(fixture.app, fixture.app)
 
-    assert dialog.find_button.cget("text") not in ("Find", "")
-    assert int(dialog.find_button.grid_info()["row"]) == int(
-        dialog.find_entry.grid_info()["row"]
+    # AI: Each category tab carries its own icon find button beside its query entry.
+    find_button = dialog.find_buttons[0]
+    query_entry = dialog.query_entries[0]
+    assert find_button.cget("text") not in ("Find", "")
+    assert int(find_button.grid_info()["row"]) == int(
+        query_entry.grid_info()["row"]
     )
-    assert int(dialog.find_button.grid_info()["column"]) > int(
-        dialog.find_entry.grid_info()["column"]
+    assert int(find_button.grid_info()["column"]) > int(
+        query_entry.grid_info()["column"]
     )
     assert not hasattr(dialog, "stop_button")
     dialog.destroy()
@@ -7865,7 +7868,7 @@ def test_find_renders_partial_results_and_a_stopped_status_when_interrupted(fixt
 
     assert dialog.status_var.get() == "Find stopped. Showing partial results."
     assert find_result_labels(dialog) == ["Order0", "Order1", "Order2"]
-    assert str(dialog.find_button.cget("state")) == tk.NORMAL
+    assert str(dialog.find_buttons[0].cget("state")) == tk.NORMAL
     dialog.destroy()
 
 
@@ -8034,8 +8037,11 @@ def test_find_dialog_selector_contains_search_shows_only_a_method_column(fixture
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_find_dialog_shows_search_intent_and_result_action_text(fixture):
-    """AI: Find dialog should show current search intent and result action guidance."""
+def test_find_dialog_intent_selection_drives_legacy_config(fixture):
+    """AI: The single search intent (chosen via the category tabs/variants) drives the
+    hidden search_type/match_mode/reference_target. Opening with method/contains selects
+    the 'Selector containing' intent; choosing the 'Implementors' variant flips the
+    derived config to method/exact."""
     fixture.simulate_login()
     fixture.mock_browser.find_selectors.return_value = ["subtotal", "total"]
     fixture.mock_browser.find_implementors.return_value = [
@@ -8052,20 +8058,16 @@ def test_find_dialog_shows_search_intent_and_result_action_text(fixture):
             match_mode="contains",
         )
 
-    assert dialog.search_intent_var.get() == 'Methods containing selector "total".'
-    assert (
-        dialog.result_action_var.get()
-        == "Double-click a selector to find implementors (exact)."
-    )
+    assert dialog.search_intent.get() == "selector_contains"
+    assert dialog.search_type.get() == "method"
+    assert dialog.match_mode.get() == "contains"
 
-    dialog.match_mode.set("exact")
+    dialog.search_intent.set("implementors")
+    dialog.apply_search_intent()
     dialog.find_text()
 
-    assert dialog.search_intent_var.get() == 'Implementors of method "total".'
-    assert (
-        dialog.result_action_var.get()
-        == "Double-click an implementor to open the method."
-    )
+    assert dialog.search_type.get() == "method"
+    assert dialog.match_mode.get() == "exact"
     dialog.destroy()
 
 
@@ -8098,7 +8100,6 @@ def test_method_contains_double_click_pivots_to_exact_search_in_place(fixture):
     assert dialog.match_mode.get() == "exact"
     assert dialog.find_entry.get() == "total"
     assert find_result_labels(dialog) == ["OrderLine>>total"]
-    assert dialog.search_intent_var.get() == 'Implementors of method "total".'
     dialog.destroy()
 
 
@@ -8132,7 +8133,7 @@ def test_find_dialog_reference_method_search_is_always_exact(
         )
 
     assert dialog.match_mode.get() == "exact"
-    assert str(dialog.match_contains_radio.cget("state")) == tk.DISABLED
+    assert dialog.search_intent.get() == "method_references"
     fixture.mock_browser.find_selectors.assert_not_called()
     fixture.mock_browser.find_senders.assert_called_once_with(
         "total",
@@ -8172,10 +8173,79 @@ def test_find_dialog_reference_class_search_is_always_exact(
         )
 
     assert dialog.match_mode.get() == "exact"
-    assert str(dialog.match_contains_radio.cget("state")) == tk.DISABLED
+    assert dialog.search_intent.get() == "class_references"
     fixture.mock_browser.find_classes.assert_not_called()
     fixture.mock_browser.find_class_references.assert_called_once_with("Or")
     assert find_result_labels(dialog) == ["OrderBuilder>>fromOrder:"]
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_each_search_intent_derives_its_legacy_config(fixture):
+    """AI: Every named intent must translate to the correct hidden
+    search_type/match_mode/reference_target triple the engine reads — this is the
+    contract that lets one intent control replace the three former radio groups."""
+    fixture.simulate_login()
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    expected = {
+        "class_contains": ("class", "contains", "class"),
+        "class_exact": ("class", "exact", "class"),
+        "class_references": ("reference", "exact", "class"),
+        "implementors": ("method", "exact", "class"),
+        "selector_contains": ("method", "contains", "class"),
+        "method_references": ("reference", "exact", "method"),
+        "instvar_references": ("reference", "exact", "instvar"),
+        "classvar_references": ("reference", "exact", "classvar"),
+    }
+    for intent, (search_type, match_mode, reference_target) in expected.items():
+        dialog.search_intent.set(intent)
+        dialog.apply_search_intent()
+        assert dialog.search_type.get() == search_type
+        assert dialog.match_mode.get() == match_mode
+        assert dialog.reference_target.get() == reference_target
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_switching_category_tab_falls_back_to_first_variant(fixture):
+    """AI: Moving to a category whose variants do not include the current intent must
+    fall back to that category's first variant; staying within the category keeps the
+    current intent. (Tk's notebook selection is not observable headless, so the fallback
+    rule is verified directly and then applied through apply_search_intent.)"""
+    fixture.simulate_login()
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    variable_tab_index = dialog.intent_to_tab_index["instvar_references"]
+    # AI: Coming from a Class-tab intent, switching to Variable picks its first variant.
+    assert dialog.default_intent_for_tab(variable_tab_index) == "instvar_references"
+    # AI: Already on a Variable-tab intent, switching within the tab keeps it.
+    dialog.search_intent.set("classvar_references")
+    assert dialog.default_intent_for_tab(variable_tab_index) == "classvar_references"
+
+    # AI: Applying a variable intent derives the target and reveals the owning-class
+    # entry (checked via the grid manager, which is reliable headless unlike ismapped).
+    dialog.search_intent.set("instvar_references")
+    dialog.apply_search_intent()
+    assert dialog.reference_target.get() == "instvar"
+    assert dialog.instvar_class_entry.grid_info() != {}
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_open_find_dialog_for_classvar_selects_class_var_intent(fixture):
+    """AI: A programmatic class-var open must select the Class var intent (Variable
+    category) so the visible control reflects the search being run."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_classvar_references.return_value = {
+        "references": [], "total_count": 0, "returned_count": 0,
+    }
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = fixture.app.open_find_dialog_for_classvar("Date", "MonthNames")
+
+    assert dialog.search_intent.get() == "classvar_references"
     dialog.destroy()
 
 
@@ -8354,9 +8424,68 @@ def test_find_dialog_double_click_instvar_result_publishes_highlight_event(fixtu
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_find_dialog_double_click_non_instvar_result_does_not_publish_highlight_event(fixture):
-    """AI: Double-clicking a class-reference result (no highlight_term) must NOT
-    publish InstVarHighlightRequested — that event is instvar-search-specific."""
+def test_find_dialog_peek_publishes_highlight_for_reference_result(fixture):
+    """AI: Single-click peek must mark where the searched term occurs, the same cue as
+    opening the method, so a glance at a result shows the references in context."""
+    fixture.simulate_login()
+    fixture.mock_browser.get_method_category.return_value = 'accessing'
+    fixture.mock_gemstone_session.resolve_symbol.return_value.category.return_value.to_py = (
+        'Kernel'
+    )
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    dialog.search_type.set('reference')
+    dialog.reference_target.set('instvar')
+    dialog.populate_instvar_navigation_results([('Amount', True, 'printOn:')], 'currency')
+
+    highlight_handler = Mock()
+    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+
+    select_find_result(dialog, 'Amount>>printOn:')
+    dialog.peek_selected_result(None)
+    fixture.app.update()
+
+    highlight_handler.assert_called_once_with('currency', origin=ANY)
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_senders_result_highlights_the_sent_selector(fixture):
+    """AI: To be consistent with variable searches, a senders result highlights where the
+    selector is sent: the row carries the selector as its highlight term, so opening the
+    method marks the send."""
+    fixture.simulate_login()
+    fixture.mock_browser.get_method_category.return_value = 'calculating'
+    fixture.mock_gemstone_session.resolve_symbol.return_value.category.return_value.to_py = (
+        'Kernel'
+    )
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    dialog.search_type.set('reference')
+    dialog.reference_target.set('method')
+    dialog.populate_navigation_results(
+        [('OrderLine', True, 'recalculate')], highlight_term='total'
+    )
+
+    highlight_handler = Mock()
+    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+
+    select_find_result(dialog, 'OrderLine>>recalculate')
+    dialog.on_result_double_click(None)
+    fixture.app.update()
+
+    highlight_handler.assert_called_once_with('total', origin=ANY)
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_result_without_highlight_term_does_not_publish_highlight_event(fixture):
+    """AI: A result row carrying no highlight term (e.g. an implementors match) must NOT
+    publish a highlight event — the highlight is only for reference-style searches."""
     fixture.simulate_login()
     fixture.mock_browser.get_method_category.return_value = 'accessing'
     fixture.mock_gemstone_session.resolve_symbol.return_value.category.return_value.to_py = (

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -8098,6 +8098,9 @@ def test_method_contains_double_click_pivots_to_exact_search_in_place(fixture):
     fixture.mock_browser.find_implementors.assert_called_once_with("total")
     assert dialog.winfo_exists() == 1
     assert dialog.match_mode.get() == "exact"
+    # AI: The pivot must also move the visible intent to Implementors, not leave the
+    # 'Selector containing' variant selected while an implementors search is shown.
+    assert dialog.search_intent.get() == "implementors"
     assert dialog.find_entry.get() == "total"
     assert find_result_labels(dialog) == ["OrderLine>>total"]
     dialog.destroy()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -8191,6 +8191,97 @@ def test_find_dialog_double_click_pins_class_reference_method(fixture):
 
 
 @with_fixtures(SwordfishAppFixture)
+def test_open_find_dialog_for_instvar_prefills_controls_and_runs_search(fixture):
+    """AI: open_find_dialog_for_instvar should open the Find pane in reference/instvar
+    mode with class and inst var name pre-filled, and immediately run the search so
+    results appear without the user clicking Find."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_instvar_references.return_value = {
+        'references': [
+            {
+                'class_name': 'Amount',
+                'show_instance_side': True,
+                'method_selector': 'printOn:',
+                'method_category': 'printing',
+            }
+        ],
+        'total_count': 1,
+        'returned_count': 1,
+    }
+    fixture.mock_browser.get_method_category.return_value = 'printing'
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = fixture.app.open_find_dialog_for_instvar('Amount', 'currency')
+
+    assert dialog is not None
+    assert dialog.search_type.get() == 'reference'
+    assert dialog.reference_target.get() == 'instvar'
+    assert dialog.match_mode.get() == 'exact'
+    assert dialog.find_entry.get() == 'currency'
+    assert dialog.instvar_class_entry.get() == 'Amount'
+    fixture.mock_browser.find_instvar_references.assert_called_once_with('Amount', 'currency')
+    assert find_result_labels(dialog) == ['Amount>>printOn:']
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_double_click_instvar_result_publishes_highlight_event(fixture):
+    """AI: Double-clicking an inst-var reference result must publish both
+    MethodDisplayRequested (to open the tab) and InstVarHighlightRequested (to
+    highlight all occurrences of the inst var in the opened method)."""
+    fixture.simulate_login()
+    fixture.mock_browser.get_method_category.return_value = 'accessing'
+    fixture.mock_gemstone_session.resolve_symbol.return_value.category.return_value.to_py = (
+        'Kernel'
+    )
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    dialog.search_type.set('reference')
+    dialog.reference_target.set('instvar')
+    dialog.populate_instvar_navigation_results([('Amount', True, 'printOn:')], 'currency')
+
+    highlight_handler = Mock()
+    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+
+    select_find_result(dialog, 'Amount>>printOn:')
+    dialog.on_result_double_click(None)
+    fixture.app.update()
+
+    highlight_handler.assert_called_once_with('currency', origin=ANY)
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_dialog_double_click_non_instvar_result_does_not_publish_highlight_event(fixture):
+    """AI: Double-clicking a class-reference result (no highlight_term) must NOT
+    publish InstVarHighlightRequested — that event is instvar-search-specific."""
+    fixture.simulate_login()
+    fixture.mock_browser.get_method_category.return_value = 'accessing'
+    fixture.mock_gemstone_session.resolve_symbol.return_value.category.return_value.to_py = (
+        'Kernel'
+    )
+
+    with patch.object(FindPane, 'wait_visibility'):
+        dialog = FindPane(fixture.app, fixture.app)
+
+    dialog.search_type.set('reference')
+    dialog.reference_target.set('class')
+    dialog.populate_navigation_results([('Amount', True, 'printOn:')])
+
+    highlight_handler = Mock()
+    fixture.app.event_queue.subscribe('InstVarHighlightRequested', highlight_handler)
+
+    select_find_result(dialog, 'Amount>>printOn:')
+    dialog.on_result_double_click(None)
+    fixture.app.update()
+
+    highlight_handler.assert_not_called()
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
 def test_find_dialog_double_click_navigates_browser_to_selected_class(fixture):
     """Double-clicking a class name in the FindPane results navigates the
     browser to that class by selecting its package and class in the columns."""


### PR DESCRIPTION
Variable References + Find dialog overhaul (#43)

  Implements issue #43 ("References to an inst var") and, as a corollary, simplifies and tightens the whole Find dialog.

  Variable References (#43)

  - New entry point: right-click a class in the class list or the hierarchy tree → Variable References cascade listing that class's accessible variables, grouped Instance / 
  Class-instance / Class under underlined heading rows. Own variables show normally; inherited ones are greyed (the same convention as inherited methods) but stay selectable. The
  submenu is read fresh from the gem each time it's posted.
  - Search scope: the whole subclass hierarchy, both instance and class sides.
    - Instance & class-instance vars use GsNMethod>>instVarsAccessed.
    - Class variables can't use that selector, so a new find_classvar_references walks to the variable's owner and scans method literals for a SymbolAssociation whose key is the
  variable name (identity fails; key-match works). Portable selectors keep it working on GemStone 3.6.5 (verified live on 3.7.4.3 and 3.6.5).
  - Find dialog gained a Class Var target; the submenu routes each kind to the right search.

  Find dialog redesign

  - Replaced the three radio groups (search type × match mode × reference target) and the search-intent sentence with a single intent presented as three category tabs (Class / Method /
  Variable), each carrying its own variant row and the inputs that category needs (query; owning-class for Variable; receiver for Senders). The intent derives the engine's existing
  config behind the scenes — search engine, persistence and programmatic openers unchanged.
  - Fixed the shortcut-open wrong/empty tab (ttk realization race + tabs being disabled during the auto-run search) and class-var results not populating.
  - Double-clicking a Method → Containing result now pivots the visible intent to Implementors, not just the hidden match mode.
  - Removed the redundant Result action line.

  Consistent reference highlighting

  - Every reference search now highlights its term in the result method on both peek and open: variable name, class name, or sent selector. Matcher covers identifier, keyword-selector
  (printOn:) and binary-selector tokens.
  - Renamed the now-general mechanism: OccurrenceHighlightRequested / apply_occurrence_highlight / reference_highlight_background (was instvar-specific).

  Editor tidy-up

  The autoformat checkbox takes u a whole line below the editor. Cant't it be put in the editor's top line with the back/forward buttons?