### PR TITLE
Run/Debug tests from Find results; gate gem actions on session busy; ttk controls (#42)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,6 +164,39 @@ a unit (whole-token matching avoids false positives). The highlight uses the
 syntax tags so it wins background priority while syntax foreground colours remain active).
 Clearing the highlight is implicit the next time a different method opens or it is re-applied.
 
+### Find results: run or debug a test method in place
+A Find result that is a **test method** can be run or debugged straight from the results list —
+right-click → **Run Test** / **Debug Test** — without first navigating to its class. The menu also
+carries **Senders** / **Implementors** (any method result), mirroring the method-list and
+source-window menus so the same selector navigation is reachable wherever a method appears.
+Navigating *to* a method result is the job of click (peek) / double-click (pin), so there is
+deliberately **no Jump to Class** here. Every action in this menu drives the gem, so **all are
+greyed while the session is busy with any other activity** (`Swordfish.session_is_busy()` — a find,
+a test run, an MCP tool): the single-threaded session runs one call at a time, so a second gem
+operation must never be launched on top of one still running.
+
+A **class-bound** result (Implementors / Senders / References, which carry a class) is runnable when
+it is a test method by the **same rule the sender scan uses**: an **instance-side** method whose
+selector starts with `test` on a **`TestCase` subclass**. A **bare-selector** result — the **Methods
+containing** search returns selector names with **no owning class** — is offered when the selector
+merely *names* a test (`test…`); its owning test class is **resolved from the selector's implementors
+only when actually run**, so drawing the menu stays a cheap, local check (no gem round-trip per
+right-click). On run, a bare selector resolves to its instance-side `TestCase` implementors and:
+**one** → runs it directly; **several** → **pivots the search to Implementors** (the same pivot
+double-click uses) so the user picks which to run; **none** → says so.
+
+Run Test / Debug Test are **always shown but greyed when the result is not a runnable test** (an
+ordinary method, a class-side method, a method on a non-`TestCase` class, a non-`test…` bare
+selector, or a bare class result) — the **greyed-means-not-applicable, never hidden** convention used
+elsewhere, so the affordance stays consistently placed and discoverable. The class-lineage answer is
+cached per class (`FindPane.test_case_class_by_name`, reset when results are replaced) so the at-most
+one gem round-trip per distinct class is not repeated.
+
+Running and debugging a test go through the **one shared path** every test-bearing pane uses —
+`Pane.run_test_for` / `Pane.debug_test_for` (a passing run reports via `show_test_result`, a genuine
+trap opens the debugger) — the same wiring behind the browser's method-list **Run Test / Debug
+Test** and the class-list **Run All Tests**. See `FindPane.show_result_context_menu` in `main.py`.
+
 ### Anything that can run long is interruptible from the IDE
 If an operation can take a noticeable time (a search, a run/inspect/debug of user code, a test
 run, a debugger resume/step, an MCP tool's work), it must run as a **foreground activity** and
@@ -222,6 +255,13 @@ departing theme (dark) restyles, via `ThemeApplication` — the Tk **option data
 widgets plus a `clam`-based `ttk.Style` for ttk widgets (the two families don't share a styling
 mechanism). New colour sites read a role; new screens get themed for free.
 
+**Prefer `ttk` widgets over classic `tk` ones** (checkbuttons, radiobuttons, buttons, …) so they
+pick up the `clam`-based dark styling — in particular the selected-indicator colour
+(`TCheckbutton`/`TRadiobutton` `indicatorcolor` map). A classic `tk.Checkbutton`/`tk.Radiobutton`
+is only reachable through the option DB and its selected indicator goes invisible on a dark
+background; the browser's controls are `ttk` for exactly this reason. (Note: ttk's `cget('state')`
+returns a Tcl object, not a bare `str` — compare `str(widget.cget('state'))` in tests.)
+
 **User editor preferences** live under the top-level `appearance` key in the JSON config file,
 alongside `appearance.theme`. Current keys:
 
@@ -274,6 +314,16 @@ happen on the UI thread. Gem-free UI events (e.g. announcing that an activity st
 reach the UI **even while an MCP operation holds the session** — they bypass the
 session-admission gate via `SESSION_SAFE_EVENT_NAMES`; gem-touching events still defer to avoid
 a 2203 collision. Do not run IDE GCI from the event drain while the session is held.
+
+**Gem-touching UI actions gate on `Swordfish.session_is_busy()`, not on `is_mcp_busy()` alone.**
+The session runs one call at a time, so a menu command that launches gem work (a search like
+Senders / Implementors / References, a Run/Debug Test, Run All Tests, a write) must be **greyed
+while the session is busy with _any_ activity** — an in-flight MCP tool **or** an IDE foreground
+job (a find, a test run, a debugger step). `session_is_busy()` is the superset (`current_session_activity is not None or is_mcp_busy()`); gating only on `is_mcp_busy()` leaves the
+window where one IDE activity is running and a second would collide. This extends to gem work done
+to *build* a menu: the class menu's **Variable References** cascade reads the gem when posted, so
+`fetch_accessible_vars` returns nothing (a disabled cascade) while the session is busy rather than
+issuing that read.
 
 ### Interruptible work: the session-activity model
 A long operation is a **`ForegroundActivity`** (`session_activity.py`): `work(should_stop)` runs

--- a/src/reahl/swordfish/browser.py
+++ b/src/reahl/swordfish/browser.py
@@ -612,6 +612,48 @@ class Pane(ttk.Frame):
             lines.extend(result['errors'])
             messagebox.showerror('Test Result', '\n'.join(lines))
 
+    def run_test_for(self, class_name, method_selector):
+        # AI: Run one test method in the image as an interruptible foreground activity, then
+        # report its outcome. Shared by every pane that can name a test (the method list and
+        # the Find results), so the test-running behaviour lives in one place.
+        TestExecution(
+            self.application,
+            'Running test %s>>%s...' % (class_name, method_selector),
+            lambda should_stop: self.gemstone_session_record.run_test_method(
+                class_name,
+                method_selector,
+            ),
+            self.show_test_result,
+            'Run Test',
+        ).start()
+
+    def debug_test_for(self, class_name, method_selector):
+        # AI: Debug one test method: stop at its first statement and open the debugger. A domain
+        # error is reported; a genuine trap opens the debugger. Shared by the method list and
+        # the Find results so both reach the debugger by the same path.
+        self.application.event_queue.publish(
+            'DebugTestStarted',
+            log_context={
+                'class_name': class_name,
+                'method': method_selector,
+            },
+        )
+        self.application.begin_foreground_activity(
+            'Debugging test %s>>%s...' % (class_name, method_selector)
+        )
+        try:
+            try:
+                self.gemstone_session_record.debug_test_method(
+                    class_name,
+                    method_selector,
+                )
+            except (DomainException, GemstoneDomainException) as domain_exception:
+                messagebox.showerror('Debug Test', str(domain_exception))
+            except GemstoneError as error:
+                self.application.open_debugger(error)
+        finally:
+            self.application.end_foreground_activity()
+
 
 class PackageSelection(Pane):
     def __init__(self, parent, application, event_queue):
@@ -643,14 +685,14 @@ class PackageSelection(Pane):
         self.browse_mode_controls.columnconfigure(0, weight=1)
         self.browse_mode_controls.columnconfigure(1, weight=1)
         self.browse_mode_controls.columnconfigure(2, weight=1)
-        self.dictionaries_radiobutton = tk.Radiobutton(
+        self.dictionaries_radiobutton = ttk.Radiobutton(
             self.browse_mode_controls,
             text='Dictionaries',
             variable=self.browse_mode_var,
             value='dictionaries',
             command=self.change_browse_mode,
         )
-        self.categories_radiobutton = tk.Radiobutton(
+        self.categories_radiobutton = ttk.Radiobutton(
             self.browse_mode_controls,
             text='Categories',
             variable=self.browse_mode_var,
@@ -660,7 +702,7 @@ class PackageSelection(Pane):
         rowan_state = (
             tk.NORMAL if self.gemstone_session_record.rowan_installed else tk.DISABLED
         )
-        self.rowan_radiobutton = tk.Radiobutton(
+        self.rowan_radiobutton = ttk.Radiobutton(
             self.browse_mode_controls,
             text='Rowan',
             variable=self.browse_mode_var,
@@ -738,9 +780,11 @@ class PackageSelection(Pane):
         else:
             self.context_menu_class_category = None
         menu = tk.Menu(self, tearoff=0)
-        read_only = (
-            self.application.integrated_session_state.is_mcp_busy()
-        )
+        # AI: The single-threaded session runs one call at a time, so every gem-touching menu
+        # command is disabled while the session is busy with ANY activity -- an in-flight MCP
+        # tool OR an IDE foreground job (a find, a test run, a debugger step) -- not merely while
+        # MCP holds it. session_is_busy() is the superset; see Swordfish.session_is_busy.
+        read_only = self.application.session_is_busy()
         # AI: A selected group is only a class category in categories/rowan mode; in
         # dictionaries mode it names a symbol dictionary, which file in/out does not address.
         names_a_category = (
@@ -857,13 +901,13 @@ class ClassSelection(Pane):
         self.class_controls_frame.columnconfigure(0, weight=0)
         self.class_controls_frame.columnconfigure(1, weight=0)
         self.class_controls_frame.columnconfigure(2, weight=1)
-        self.class_radiobutton = tk.Radiobutton(
+        self.class_radiobutton = ttk.Radiobutton(
             self.class_controls_frame,
             text='Class',
             variable=self.selection_var,
             value='class',
         )
-        self.instance_radiobutton = tk.Radiobutton(
+        self.instance_radiobutton = ttk.Radiobutton(
             self.class_controls_frame,
             text='Instance',
             variable=self.selection_var,
@@ -872,7 +916,7 @@ class ClassSelection(Pane):
         self.instance_radiobutton.grid(column=0, row=0, sticky='w')
         self.class_radiobutton.grid(column=1, row=0, sticky='w')
         self.show_class_definition_var = tk.BooleanVar(value=False)
-        self.show_class_definition_checkbox = tk.Checkbutton(
+        self.show_class_definition_checkbox = ttk.Checkbutton(
             self.class_controls_frame,
             text='Definition',
             variable=self.show_class_definition_var,
@@ -1149,9 +1193,11 @@ class ClassSelection(Pane):
         if self.current_context_menu:
             self.current_context_menu.unpost()
         menu = self.current_context_menu = tk.Menu(self, tearoff=0)
-        read_only = (
-            self.application.integrated_session_state.is_mcp_busy()
-        )
+        # AI: The single-threaded session runs one call at a time, so every gem-touching menu
+        # command is disabled while the session is busy with ANY activity -- an in-flight MCP
+        # tool OR an IDE foreground job (a find, a test run, a debugger step) -- not merely while
+        # MCP holds it. session_is_busy() is the superset; see Swordfish.session_is_busy.
+        read_only = self.application.session_is_busy()
         write_command_state = tk.NORMAL
         run_command_state = tk.NORMAL
         if read_only:
@@ -1171,7 +1217,7 @@ class ClassSelection(Pane):
         menu.add_command(
             label='References',
             command=self.find_references_for_selected_class,
-            state=tk.NORMAL if has_selection else tk.DISABLED,
+            state=tk.NORMAL if (has_selection and not read_only) else tk.DISABLED,
         )
         self.add_instvar_references_cascade(menu, selected_class_name)
         menu.add_command(
@@ -1546,6 +1592,12 @@ class ClassSelection(Pane):
         # AI: Returns None on no class or a gem error, which the menu treats as no vars.
         if not class_name:
             return None
+        # AI: Building the cascade reads the gem; never read it while the single-threaded
+        # session is busy with another activity (a find, a test run, an MCP tool) -- that read
+        # would collide. The menu then shows a disabled 'Variable References' cascade, like every
+        # other gem-touching action here.
+        if self.application.session_is_busy():
+            return None
         try:
             return self.gemstone_session_record.gemstone_browser_session.accessible_var_names(
                 class_name,
@@ -1632,9 +1684,11 @@ class CategorySelection(Pane):
         else:
             self.context_menu_method_category = None
         menu = tk.Menu(self, tearoff=0)
-        read_only = (
-            self.application.integrated_session_state.is_mcp_busy()
-        )
+        # AI: The single-threaded session runs one call at a time, so every gem-touching menu
+        # command is disabled while the session is busy with ANY activity -- an in-flight MCP
+        # tool OR an IDE foreground job (a find, a test run, a debugger step) -- not merely while
+        # MCP holds it. session_is_busy() is the superset; see Swordfish.session_is_busy.
+        read_only = self.application.session_is_busy()
         write_command_state = tk.DISABLED if read_only else tk.NORMAL
         delete_command_state = write_command_state if has_selection else tk.DISABLED
         menu.add_command(
@@ -1786,14 +1840,14 @@ class MethodSelection(Pane):
         self.controls_frame.columnconfigure(0, weight=1)
         self.controls_frame.columnconfigure(1, weight=1)
         self.show_method_hierarchy_var = tk.BooleanVar(value=False)
-        self.show_method_hierarchy_checkbox = tk.Checkbutton(
+        self.show_method_hierarchy_checkbox = ttk.Checkbutton(
             self.controls_frame,
             text='Inheritance',
             variable=self.show_method_hierarchy_var,
             command=self.toggle_method_hierarchy,
         )
         self.show_method_hierarchy_checkbox.grid(row=0, column=0, sticky='w')
-        self.show_inherited_methods_checkbox = tk.Checkbutton(
+        self.show_inherited_methods_checkbox = ttk.Checkbutton(
             self.controls_frame,
             text='Inherited Methods',
             variable=self.show_inherited_methods_var,
@@ -2240,9 +2294,11 @@ class MethodSelection(Pane):
             listbox.get(idx) if has_selection else None
         )
         menu = self.current_context_menu = tk.Menu(self, tearoff=0)
-        read_only = (
-            self.application.integrated_session_state.is_mcp_busy()
-        )
+        # AI: The single-threaded session runs one call at a time, so every gem-touching menu
+        # command is disabled while the session is busy with ANY activity -- an in-flight MCP
+        # tool OR an IDE foreground job (a find, a test run, a debugger step) -- not merely while
+        # MCP holds it. session_is_busy() is the superset; see Swordfish.session_is_busy.
+        read_only = self.application.session_is_busy()
         write_command_state = tk.NORMAL
         run_command_state = tk.NORMAL
         if read_only:
@@ -2264,8 +2320,12 @@ class MethodSelection(Pane):
             command=self.show_method_in_class_diagram,
             state=tk.NORMAL if has_selection else tk.DISABLED,
         )
-        # AI: Senders/Implementors lookups are read-only; gate only on selection.
-        selector_navigation_state = tk.NORMAL if has_selection else tk.DISABLED
+        # AI: Senders/Implementors run a gem search, so gate on selection AND on the session
+        # being free -- a read still drives the single-threaded session and must not run on top
+        # of another in-flight activity.
+        selector_navigation_state = (
+            tk.NORMAL if (has_selection and not read_only) else tk.DISABLED
+        )
         menu.add_separator()
         menu.add_command(
             label='Senders',
@@ -2372,16 +2432,7 @@ class MethodSelection(Pane):
             return
         class_name = self.gemstone_session_record.selected_class
         method_selector = listbox.get(selection[0])
-        TestExecution(
-            self.application,
-            'Running test %s>>%s...' % (class_name, method_selector),
-            lambda should_stop: self.gemstone_session_record.run_test_method(
-                class_name,
-                method_selector,
-            ),
-            self.show_test_result,
-            'Run Test',
-        ).start()
+        self.run_test_for(class_name, method_selector)
 
     def debug_test(self):
         listbox = self.selection_list.selection_listbox
@@ -2390,28 +2441,7 @@ class MethodSelection(Pane):
             return
         class_name = self.gemstone_session_record.selected_class
         method_selector = listbox.get(selection[0])
-        self.application.event_queue.publish(
-            'DebugTestStarted',
-            log_context={
-                'class_name': class_name,
-                'method': method_selector,
-            },
-        )
-        self.application.begin_foreground_activity(
-            'Debugging test %s>>%s...' % (class_name, method_selector)
-        )
-        try:
-            try:
-                self.gemstone_session_record.debug_test_method(
-                    class_name,
-                    method_selector,
-                )
-            except (DomainException, GemstoneDomainException) as domain_exception:
-                messagebox.showerror('Debug Test', str(domain_exception))
-            except GemstoneError as error:
-                self.application.open_debugger(error)
-        finally:
-            self.application.end_foreground_activity()
+        self.debug_test_for(class_name, method_selector)
 
     def open_covering_tests(self):
         listbox = self.selection_list.selection_listbox

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -1034,6 +1034,12 @@ class GemstoneSessionRecord:
             class_name, method_selector
         )
 
+    def is_test_case_class(self, class_name):
+        # AI: A class can host runnable tests when it is a TestCase subclass. This is a
+        # read-only lineage query (no write access required), used to decide whether to offer
+        # Run/Debug Test on a method.
+        return self.gemstone_browser_session.class_inherits_from(class_name, "TestCase")
+
     def debug_source(self, source):
         self.require_write_access("debug_source")
         return self.gemstone_browser_session.debug_source(source)
@@ -3326,6 +3332,10 @@ class FindPane(Pane):
         # AI: Class / Class Category / Method / Method Category columns and so
         # AI: column #0 can indent overrides under the method/class they override.
         self.result_rows_by_iid = {}
+        # AI: Remember which result classes are TestCase subclasses, so deciding whether to
+        # offer Run/Debug Test on a right-click costs one gem round-trip per distinct class
+        # rather than one per click. Reset whenever results are replaced (clear_results).
+        self.test_case_class_by_name = {}
         self.baseline_result_rows = []
         self.result_column_kind = 'method'
         self.baseline_class_definition_by_name = {}
@@ -3340,6 +3350,8 @@ class FindPane(Pane):
         )
         self.results_tree.bind('<Double-Button-1>', self.on_result_double_click)
         self.results_tree.bind('<ButtonRelease-1>', self.peek_selected_result)
+        self.results_tree.bind('<Button-3>', self.show_result_context_menu)
+        self.current_result_context_menu = None
         # AI: Keep the overlaid filter boxes aligned to the columns: <Configure>
         # covers the widget being mapped/resized; B1-Motion/ButtonRelease cover a
         # column being drag-resized (ttk emits no event for that).
@@ -3875,6 +3887,7 @@ class FindPane(Pane):
         for iid in self.results_tree.get_children():
             self.results_tree.delete(iid)
         self.result_rows_by_iid = {}
+        self.test_case_class_by_name = {}
 
     def ancestor_class_names(self, class_name, class_definition_by_name):
         # AI: Superclass chain (nearest ancestor first) drawn from the cached
@@ -4871,6 +4884,165 @@ class FindPane(Pane):
             self.application.event_queue.publish(
                 'OccurrenceHighlightRequested', highlight_term, origin=self
             )
+
+    def selected_result_row(self):
+        # AI: The result-row dict currently selected in the results tree, or None.
+        selected_iids = self.results_tree.selection()
+        if not selected_iids:
+            return None
+        return self.result_rows_by_iid.get(selected_iids[0])
+
+    def result_offers_test_run(self, row):
+        # AI: Whether Run/Debug Test should be offered for this result. A class-bound result
+        # (implementors / senders / references) must be a genuine test method: instance-side,
+        # selector test*, on a TestCase subclass. A bare-selector result (the 'methods
+        # containing' search is not tied to a class) is offered when its selector names a test;
+        # the owning test class is resolved from the selector's implementors only when it is
+        # actually run, so drawing the menu stays a cheap, local check.
+        if row is None:
+            return False
+        method_selector = row.get('method_selector')
+        names_a_test = (
+            method_selector is not None
+            and row.get('show_instance_side')
+            and method_selector.startswith('test')
+        )
+        if not names_a_test:
+            return False
+        class_name = row.get('class_name')
+        if class_name is None:
+            return True
+        return self.class_is_test_case(class_name)
+
+    def class_is_test_case(self, class_name):
+        # AI: Cache the TestCase-lineage answer per class so repeated right-clicks (and the
+        # implementor resolution below) cost at most one gem round-trip per distinct class.
+        if class_name not in self.test_case_class_by_name:
+            self.test_case_class_by_name[class_name] = (
+                self.gemstone_session_record.is_test_case_class(class_name)
+            )
+        return self.test_case_class_by_name[class_name]
+
+    def show_result_context_menu(self, event):
+        # AI: Right-click a result to act on it without leaving the Find list. ttk does not
+        # select on right-click, so select the row under the cursor first to act on what was
+        # clicked. Senders / Implementors mirror the method-list and source-window menus (any
+        # method result). Run/Debug Test are always offered but enabled only when the result
+        # names a runnable test (greyed otherwise -- never hidden). Every action here drives the
+        # gem, so all are greyed while the single-threaded session is busy with any other
+        # activity (a find, a test run, an MCP tool) -- it can run only one call at a time.
+        # Navigating to a method result is the job of click/double-click, so there is no Jump to
+        # Class here.
+        row_under_cursor = self.results_tree.identify_row(event.y)
+        if row_under_cursor:
+            self.results_tree.selection_set(row_under_cursor)
+        row = self.selected_result_row()
+        session_busy = self.application.session_is_busy()
+        has_method_selector = row is not None and row.get('method_selector') is not None
+        selector_navigation_state = (
+            tk.NORMAL if (has_method_selector and not session_busy) else tk.DISABLED
+        )
+        test_run_is_offered = self.result_offers_test_run(row) and not session_busy
+        test_command_state = tk.NORMAL if test_run_is_offered else tk.DISABLED
+        menu = self.current_result_context_menu = tk.Menu(self, tearoff=0)
+        menu.add_command(
+            label='Senders',
+            command=self.open_senders_for_selected_result,
+            state=selector_navigation_state,
+        )
+        menu.add_command(
+            label='Implementors',
+            command=self.open_implementors_for_selected_result,
+            state=selector_navigation_state,
+        )
+        menu.add_separator()
+        menu.add_command(
+            label='Run Test',
+            command=self.run_selected_result_test,
+            state=test_command_state,
+        )
+        menu.add_command(
+            label='Debug Test',
+            command=self.debug_selected_result_test,
+            state=test_command_state,
+        )
+        popup_menu(menu, event)
+
+    def open_senders_for_selected_result(self):
+        # AI: Find result -> Senders, through the same Swordfish.open_senders_dialog entry point
+        # the method-list and source-window menus use.
+        row = self.selected_result_row()
+        if row is None or row.get('method_selector') is None:
+            return
+        selector = row['method_selector']
+        self.application.event_queue.publish(
+            'SendersOpened', log_context={'selector': selector}
+        )
+        self.application.open_senders_dialog(method_symbol=selector)
+
+    def open_implementors_for_selected_result(self):
+        # AI: Find result -> Implementors, through the same Swordfish.open_implementors_dialog
+        # entry point the method-list and source-window menus use.
+        row = self.selected_result_row()
+        if row is None or row.get('method_selector') is None:
+            return
+        self.application.open_implementors_dialog(
+            method_symbol=row['method_selector'],
+        )
+
+    def run_selected_result_test(self):
+        self.act_on_selected_result_test(self.run_test_for)
+
+    def debug_selected_result_test(self):
+        self.act_on_selected_result_test(self.debug_test_for)
+
+    def act_on_selected_result_test(self, run_test_action):
+        # AI: Run or debug the selected result as a test. A class-bound result runs directly. A
+        # bare-selector result (methods-containing search) carries no class, so resolve the
+        # selector's test implementors first: run the single one, or -- when several test cases
+        # implement it -- pivot to the Implementors view so the user picks which to run.
+        row = self.selected_result_row()
+        if not self.result_offers_test_run(row):
+            return
+        method_selector = row['method_selector']
+        class_name = row.get('class_name')
+        if class_name is not None:
+            run_test_action(class_name, method_selector)
+        else:
+            self.resolve_and_run_bare_selector_test(method_selector, run_test_action)
+
+    def resolve_and_run_bare_selector_test(self, method_selector, run_test_action):
+        test_class_names = self.test_class_names_implementing(method_selector)
+        if len(test_class_names) == 1:
+            run_test_action(test_class_names[0], method_selector)
+        elif len(test_class_names) > 1:
+            self.pivot_to_implementors(method_selector)
+        else:
+            messagebox.showinfo(
+                'Run Test',
+                "No test case implements '%s'." % method_selector,
+            )
+
+    def test_class_names_implementing(self, method_selector):
+        # AI: The TestCase subclasses whose instance side implements the selector -- the classes
+        # it could be run against as a test. find_implementors_of_method yields
+        # (class_name, is_meta); a test method lives on the instance side (is_meta False).
+        return [
+            class_name
+            for class_name, is_meta in (
+                self.gemstone_session_record.find_implementors_of_method(method_selector)
+            )
+            if not is_meta and self.class_is_test_case(class_name)
+        ]
+
+    def pivot_to_implementors(self, method_selector):
+        # AI: Reuse the same intent pivot double-click uses, so an ambiguous bare selector lands
+        # on the class-bound Implementors list where each test can be run individually.
+        self.find_entry.delete(0, tk.END)
+        self.find_entry.insert(0, method_selector)
+        self.search_intent.set('implementors')
+        self.apply_search_intent()
+        self.find_text()
 
 
 class CoveringTestsSearchDialog(tk.Toplevel):
@@ -6447,6 +6619,16 @@ class Swordfish(tk.Tk):
         self.event_queue.publish(
             "SessionActivityChanged",
             is_active=activity is not None,
+        )
+
+    def session_is_busy(self):
+        # AI: True when the shared GemStone session is occupied by ANY activity -- a foreground
+        # job (a find, a test run, a debugger step) or an in-flight MCP tool. The session runs
+        # one call at a time, so a second gem operation must not be launched on top of one that
+        # is still running; gem-touching UI actions gate on this, not merely on is_mcp_busy().
+        return (
+            self.current_session_activity is not None
+            or self.integrated_session_state.is_mcp_busy()
         )
 
     def stop_current_session_activity(self):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -70,6 +70,7 @@ class FakeApplication:
         self.experimental_features_enabled = True
         self.tab_spacing = 4
         self.auto_format = False
+        self.current_session_activity = None
 
     def handle_sender_selection(self, class_name, show_instance_side, method_symbol):
         if self.gemstone_session_record.gemstone_session is not None:
@@ -108,6 +109,14 @@ class FakeApplication:
         # mirroring Swordfish.run_activities_synchronously (the real app's test seam).
         activity.run_work()
         activity.deliver_outcome()
+
+    def session_is_busy(self):
+        # AI: Mirrors Swordfish.session_is_busy -- busy when any activity holds the single
+        # session slot or an MCP tool is in flight.
+        return (
+            self.current_session_activity is not None
+            or self.integrated_session_state.is_mcp_busy()
+        )
 
     def open_debugger(self, error):
         pass
@@ -493,6 +502,35 @@ def invoke_menu_command_by_label(menu, label):
     raise AssertionError(f"Menu command not found: {label}")
 
 
+def menu_command_state(menu, label):
+    # AI: Read the tk state ('normal'/'disabled') of a command entry by its label, so
+    # tests can assert a menu item is greyed-out (offered but not applicable) without
+    # invoking it.
+    entry_count = int(menu.index("end")) + 1
+    for entry_index in range(entry_count):
+        entry_is_matching_command = (
+            menu.type(entry_index) == "command"
+            and menu.entrycget(entry_index, "label") == label
+        )
+        if entry_is_matching_command:
+            return str(menu.entrycget(entry_index, "state"))
+    raise AssertionError(f"Menu command not found: {label}")
+
+
+def menu_cascade_state(menu, label):
+    # AI: Read the tk state of a cascade (submenu) entry by its label, so tests can assert a
+    # cascade is greyed without descending into it.
+    entry_count = int(menu.index("end")) + 1
+    for entry_index in range(entry_count):
+        entry_is_matching_cascade = (
+            menu.type(entry_index) == "cascade"
+            and menu.entrycget(entry_index, "label") == label
+        )
+        if entry_is_matching_cascade:
+            return str(menu.entrycget(entry_index, "state"))
+    raise AssertionError(f"Menu cascade not found: {label}")
+
+
 @with_fixtures(SwordfishGuiFixture)
 def test_selecting_group_fetches_and_shows_classes(fixture):
     """AI: Selecting a left-pane group should fetch classes for the active browse mode."""
@@ -584,8 +622,9 @@ def test_rowan_mode_button_is_disabled_when_rowan_is_not_installed(fixture):
     fixture.browser_window.packages_widget.handle_browse_mode_changed()
     fixture.root.update()
 
+    # AI: ttk's cget('state') returns a Tcl object, not a bare str, so compare its text.
     rowan_state = fixture.browser_window.packages_widget.rowan_radiobutton.cget("state")
-    assert rowan_state == tk.DISABLED
+    assert str(rowan_state) == tk.DISABLED
 
 
 @with_fixtures(SwordfishGuiFixture)
@@ -8120,6 +8159,449 @@ def test_method_contains_double_click_pivots_to_exact_search_in_place(fixture):
     dialog.destroy()
 
 
+def open_find_result_menu(dialog, label):
+    # AI: Select a result row by its reconstructed label and open the results-list
+    # right-click menu over it, returning the built menu so a test can inspect or
+    # invoke its commands. identify_row finds nothing in an unmapped tree, so the
+    # pre-selection (not the synthetic cursor position) determines the target row.
+    select_find_result(dialog, label)
+    dialog.show_result_context_menu(
+        types.SimpleNamespace(x=5, y=5, x_root=5, y_root=5)
+    )
+    return dialog.current_result_context_menu
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_offers_run_and_debug_for_a_test_method(fixture):
+    """AI: A test method found in the Find results can be run or debugged straight from the
+    results list -- without the detour of jumping to its class first. Right-clicking a genuine
+    test method (an instance-side test* method on a TestCase subclass) offers Run Test and
+    Debug Test, both enabled."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+
+    labels = menu_command_labels(menu)
+    assert "Run Test" in labels
+    assert "Debug Test" in labels
+    assert menu_command_state(menu, "Run Test") == tk.NORMAL
+    assert menu_command_state(menu, "Debug Test") == tk.NORMAL
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_run_test_runs_the_selected_test_method(fixture):
+    """AI: Run Test on a test-method result runs exactly that test (its class and selector) in
+    the image, reusing the same test-running path the browser's method list uses."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+    with patch.object(FindPane, "show_test_result"):
+        invoke_menu_command_by_label(menu, "Run Test")
+
+    fixture.mock_browser.run_test_method.assert_called_once_with(
+        "AccountTest", "testComputesTotal"
+    )
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_debug_test_debugs_the_selected_test_method(fixture):
+    """AI: Debug Test on a test-method result opens the test under the debugger for exactly that
+    class and selector, reusing the method list's debug-test path."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+    invoke_menu_command_by_label(menu, "Debug Test")
+
+    fixture.mock_browser.debug_test_method.assert_called_once_with(
+        "AccountTest", "testComputesTotal"
+    )
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_run_debug_greyed_for_non_test_selector(fixture):
+    """AI: An ordinary (non-test*) method on a TestCase subclass is not a test, so Run/Debug
+    Test are offered but greyed -- the affordance stays consistently placed and discoverable
+    while only a genuine test method is runnable."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="setUpHelper",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "AccountTest>>setUpHelper")
+
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_run_debug_greyed_for_non_test_case_class(fixture):
+    """AI: A test*-named method on a class that is NOT a TestCase subclass is not a runnable
+    test; Run/Debug Test are greyed. Test-ness is the class's lineage, not just the selector
+    name."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "OrderLine", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = False
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testFlag",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "OrderLine>>testFlag")
+
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_run_debug_greyed_for_a_class_result(fixture):
+    """AI: A class result carries no method, so it cannot be run as a test; Run/Debug Test are
+    greyed."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_classes.return_value = ["AccountTest"]
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(fixture.app, fixture.app)
+    dialog.find_entry.insert(0, "AccountTest")
+    dialog.find_text()
+
+    menu = open_find_result_menu(dialog, "AccountTest")
+
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_right_click_acts_on_the_row_under_the_cursor(fixture):
+    """AI: A real right-click does not pre-select (ttk selects only on left-click), so the menu
+    must resolve the row under the cursor itself. Right-clicking a test-method result with no
+    prior selection still offers an enabled Run Test for that row."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    row_iid = find_result_iid_for_label(dialog, "AccountTest>>testComputesTotal")
+    assert not dialog.results_tree.selection()
+    with patch.object(dialog.results_tree, "identify_row", return_value=row_iid):
+        dialog.show_result_context_menu(
+            types.SimpleNamespace(x=5, y=5, x_root=5, y_root=5)
+        )
+
+    assert menu_command_state(dialog.current_result_context_menu, "Run Test") == tk.NORMAL
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_containing_result_offers_run_for_a_bare_test_selector(fixture):
+    """AI: A 'methods containing' search returns bare selectors with no owning class. Run/Debug
+    Test are still offered for a test*-named selector -- the owning test class is resolved from
+    its implementors only when run -- so the search-then-run flow works from that list too."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["testTotal", "computeTotal"]
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="tot",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    menu = open_find_result_menu(dialog, "testTotal")
+
+    assert menu_command_state(menu, "Run Test") == tk.NORMAL
+    assert menu_command_state(menu, "Debug Test") == tk.NORMAL
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_containing_result_run_resolves_the_single_test_implementor(fixture):
+    """AI: Running a bare test selector resolves its implementors and, when exactly one TestCase
+    implements it, runs that test directly -- the search-then-run flow with no extra step."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["testTotal"]
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="tot",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    menu = open_find_result_menu(dialog, "testTotal")
+    with patch.object(FindPane, "show_test_result"):
+        invoke_menu_command_by_label(menu, "Run Test")
+
+    fixture.mock_browser.run_test_method.assert_called_once_with(
+        "AccountTest", "testTotal"
+    )
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_containing_result_run_pivots_when_several_test_classes_implement_it(fixture):
+    """AI: When several TestCase classes implement the bare selector, there is no single test to
+    run, so Run Test pivots the search to Implementors -- the class-bound list where each test
+    can be run individually -- rather than guessing."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["testTotal"]
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+        {"class_name": "OrderTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="tot",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    menu = open_find_result_menu(dialog, "testTotal")
+    invoke_menu_command_by_label(menu, "Run Test")
+
+    assert dialog.search_intent.get() == "implementors"
+    assert dialog.find_entry.get() == "testTotal"
+    fixture.mock_browser.run_test_method.assert_not_called()
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_containing_result_run_reports_when_no_test_implements_it(fixture):
+    """AI: A test*-named bare selector that no TestCase implements cannot be run; running it
+    says so plainly rather than failing silently or guessing a class."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["testTotal"]
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "OrderLine", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = False
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="tot",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    menu = open_find_result_menu(dialog, "testTotal")
+    with patch("reahl.swordfish.main.messagebox.showinfo") as showinfo:
+        invoke_menu_command_by_label(menu, "Run Test")
+
+    showinfo.assert_called_once()
+    fixture.mock_browser.run_test_method.assert_not_called()
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_containing_result_greyed_for_a_non_test_selector(fixture):
+    """AI: An ordinary (non-test*) bare selector is not a test; Run/Debug Test are greyed even
+    though the selector has no class, because the selector name alone settles it."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_selectors.return_value = ["computeTotal"]
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="tot",
+            run_search=True,
+            match_mode="contains",
+        )
+
+    menu = open_find_result_menu(dialog, "computeTotal")
+
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_menu_offers_senders_and_implementors(fixture):
+    """AI: For consistency with the method-list and source-window menus, a method result also
+    offers Senders and Implementors -- each opening the Find dialog for that result's selector,
+    so the same navigation is reachable wherever a method appears."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+    labels = menu_command_labels(menu)
+    assert "Senders" in labels
+    assert "Implementors" in labels
+    assert menu_command_state(menu, "Senders") == tk.NORMAL
+    assert menu_command_state(menu, "Implementors") == tk.NORMAL
+
+    with patch.object(fixture.app, "open_implementors_dialog") as open_implementors:
+        invoke_menu_command_by_label(menu, "Implementors")
+    open_implementors.assert_called_once_with(method_symbol="testComputesTotal")
+
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+    with patch.object(fixture.app, "open_senders_dialog") as open_senders:
+        invoke_menu_command_by_label(menu, "Senders")
+    open_senders.assert_called_once_with(method_symbol="testComputesTotal")
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_class_result_greys_senders_and_implementors(fixture):
+    """AI: A class result carries no selector, so Senders / Implementors -- which act on a
+    selector -- are greyed, while they are available for any method result."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_classes.return_value = ["AccountTest"]
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(fixture.app, fixture.app)
+    dialog.find_entry.insert(0, "AccountTest")
+    dialog.find_text()
+
+    menu = open_find_result_menu(dialog, "AccountTest")
+
+    assert menu_command_state(menu, "Senders") == tk.DISABLED
+    assert menu_command_state(menu, "Implementors") == tk.DISABLED
+    dialog.destroy()
+
+
+@with_fixtures(SwordfishAppFixture)
+def test_find_result_menu_greyed_while_session_is_busy(fixture):
+    """AI: The linked GemStone session runs one call at a time, so no result action may launch
+    gem work while another activity (a find, a test run, an MCP tool) still holds the session.
+    While the session is busy every gem-touching result action -- Senders, Implementors, Run and
+    Debug Test -- is greyed, so the user cannot start a second call on top of the first."""
+    fixture.simulate_login()
+    fixture.mock_browser.find_implementors.return_value = [
+        {"class_name": "AccountTest", "show_instance_side": True},
+    ]
+    fixture.mock_browser.class_inherits_from.return_value = True
+
+    with patch.object(FindPane, "wait_visibility"):
+        dialog = FindPane(
+            fixture.app,
+            fixture.app,
+            search_type="method",
+            search_query="testComputesTotal",
+            run_search=True,
+            match_mode="exact",
+        )
+
+    # AI: Some other activity now holds the single session slot.
+    fixture.app.current_session_activity = Mock()
+    menu = open_find_result_menu(dialog, "AccountTest>>testComputesTotal")
+
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+    assert menu_command_state(menu, "Senders") == tk.DISABLED
+    assert menu_command_state(menu, "Implementors") == tk.DISABLED
+    dialog.destroy()
+
+
 @with_fixtures(SwordfishAppFixture)
 def test_find_dialog_reference_method_search_is_always_exact(
     fixture,
@@ -10282,6 +10764,60 @@ def test_class_list_context_menu_find_references_uses_selected_class_name(
     classes_widget.application.open_find_dialog_for_class.assert_called_once_with(
         "OrderLine",
     )
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_method_context_menu_greyed_while_session_is_busy(fixture):
+    """AI: The single-threaded session runs one call at a time, so while ANOTHER activity (a
+    find, a test run, an MCP tool) holds it, the method menu's gem actions -- Senders,
+    Implementors, Run and Debug Test -- are greyed, not merely while MCP is busy."""
+    fixture.select_down_to_method("Kernel", "OrderLine", "accessing", "total")
+    methods_widget = fixture.browser_window.methods_widget
+    fixture.application.current_session_activity = Mock()
+
+    methods_widget.show_context_menu(
+        types.SimpleNamespace(x=1, y=1, x_root=1, y_root=1),
+    )
+    menu = methods_widget.current_context_menu
+
+    assert menu_command_state(menu, "Senders") == tk.DISABLED
+    assert menu_command_state(menu, "Implementors") == tk.DISABLED
+    assert menu_command_state(menu, "Run Test") == tk.DISABLED
+    assert menu_command_state(menu, "Debug Test") == tk.DISABLED
+
+
+@with_fixtures(SwordfishGuiFixture)
+def test_class_context_menu_greyed_while_session_is_busy(fixture):
+    """AI: While the single session slot is held by another activity, the class menu's gem
+    actions -- References and Run All Tests -- are greyed: a second gem call must not start on
+    top of the first."""
+    fixture.select_in_listbox(
+        fixture.browser_window.packages_widget.selection_list.selection_listbox,
+        "Kernel",
+    )
+    classes_widget = fixture.browser_window.classes_widget
+    class_listbox = classes_widget.selection_list.selection_listbox
+    class_index = list(class_listbox.get(0, "end")).index("OrderLine")
+    class_item_box = class_listbox.bbox(class_index)
+    assert class_item_box is not None
+    fixture.application.current_session_activity = Mock()
+
+    classes_widget.show_context_menu(
+        types.SimpleNamespace(
+            widget=class_listbox,
+            y=class_item_box[1] + 1,
+            x_root=1,
+            y_root=1,
+        )
+    )
+    menu = classes_widget.current_context_menu
+
+    assert menu_command_state(menu, "References") == tk.DISABLED
+    assert menu_command_state(menu, "Run All Tests") == tk.DISABLED
+    # AI: Building the Variable References cascade reads the gem; while busy that read must be
+    # skipped entirely (the cascade shows disabled), not merely deferred.
+    assert str(menu_cascade_state(menu, "Variable References")) == tk.DISABLED
+    fixture.mock_browser.accessible_var_names.assert_not_called()
 
 
 @with_fixtures(SwordfishGuiFixture)


### PR DESCRIPTION
  Closes #42. Three related changes, all on top of the post-#49 main:

  1. Run/Debug a test method from the Find results (the issue)

  Right-clicking a result in the Find dialog now offers Run Test / Debug Test — no more "find it → jump to class → run from there" detour. The menu also carries Senders / Implementors,
  mirroring the method-list and source-window menus so the same navigation is reachable wherever a method appears. (There's deliberately no Jump to Class: single/double-click already
  navigate a method result.)

  - Class-bound results (Implementors / Senders / References) are runnable when the row is a genuine test method — instance-side, selector test*, on a TestCase subclass — the same rule
  the sender scan already uses.
  - Bare-selector results ("Methods containing" returns selector names with no owning class) resolve the owning test class from the selector's implementors on click: exactly one → run
  it; several → pivot the search to Implementors so you pick; none → a clear message. Menu-draw stays cheap (a local test* check; no gem round-trip).
  - Run/Debug go through one shared path — Pane.run_test_for / debug_test_for — lifted out of MethodSelection (which now delegates) and reused by FindPane.

  2. Gate gem-touching UI on the session being free

  The linked GemStone session is single-threaded; launching a second gem call on top of one already running collides (error 2203). run_foreground_activity doesn't enforce the "one
  slot" rule, and several menu actions were gated only on is_mcp_busy() (or not at all), leaving a window where a find/test in flight could be stepped on.

  - New Swordfish.session_is_busy() = a foreground activity or an MCP tool holds the slot. Every gem-touching menu command now gates on it — the new Find menu and all four
  selection-pane menus (Senders/Implementors/References included).
  - Building the class menu's Variable References cascade itself reads the gem, so that read is skipped while busy (disabled cascade) — closing the same hazard at menu-build time.

  3. Dark-theme checkbox/radio visibility

  The browser's classic tk.Checkbutton/tk.Radiobutton were styleable only via the option DB and showed no visible selection on a dark background. Converted them to ttk, so they inherit
  the existing dark indicatorcolor styling (matching the already-ttk auto_format control).
