### PR TITLE
Disable breakpoint commands while a method is dirty; sync markers acr…

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -290,10 +290,16 @@ cross-references. See `EventQueue` in `main.py` and `reference_mcp_ide_refresh_b
 Breakpoints follow this rule concretely. A breakpoint binds to a `CompiledMethod`, which a
 recompile replaces — so a recompile **re-applies** the method's breakpoints onto the new method
 (remapping each to the step point nearest its stored source offset): an edit never silently
-disarms a breakpoint the user can still see. Every view that shows them re-reads on the typed
-events — the editor gutter and the **debugger frame pane** (the same `CodePanel`, so it marks the
-displayed frame's method) on method display, and the **Breakpoints pane** on
-`MethodsChanged`/`BreakpointsChanged`.
+disarms a breakpoint the user can still see. Setting or clearing a breakpoint — whether from the
+IDE context menu or via the MCP — publishes the one generic **`BreakpointsChanged`** event; every
+view that shows breakpoints re-marks itself from it, so an open editor tab and the debugger never
+disagree about where breakpoints are. (`BreakpointSet`/`BreakpointCleared` are still published, but
+only as activity-log records, not as refresh triggers — subscribe to `BreakpointsChanged`.) Views
+also re-read on the other typed events: the editor gutter and the **debugger frame pane** (the same
+`CodePanel`, so it marks the displayed frame's method) on method display, and the **Breakpoints
+pane** on `MethodsChanged`/`BreakpointsChanged`. A pane with **unsaved edits is skipped** when
+re-marking: its stored offsets no longer match the edited text, and Tk is already tracking the live
+marker tags as the user types.
 
 **Step-point and breakpoint markers are visually independent.** The current step point (where
 execution is paused) is shown as a character **background highlight** (`step_point_background`
@@ -305,7 +311,11 @@ step-point tag; without it, landing on a breakpoint makes the step position invi
 Breakpoint markers are applied once when source loads and tracked by Tk as the user edits; they
 are **not** re-applied on every key event (`on_key_release` only re-runs syntax highlighting).
 Set/Clear Breakpoint is available in **both** the regular editor context menu and the debugger
-source-pane context menu.
+source-pane context menu — and in both, the commands are **greyed out while the editor is
+read-only or has unsaved edits**. A breakpoint's source offset is captured from the live editor
+text but resolved against the *compiled* method; while the buffer is dirty those two coordinate
+systems have diverged, so a breakpoint set now would land at the wrong step point. The user must
+save (recompile) or cancel first.
 
 ### One shared GemStone session; gem work off the UI thread
 There is one `ide-session` and it runs **one GCI call at a time**. Long gem work runs on a

--- a/src/reahl/swordfish/main.py
+++ b/src/reahl/swordfish/main.py
@@ -5454,13 +5454,11 @@ class BreakpointsPane(Pane):
         self.columnconfigure(2, weight=0)
         self.rowconfigure(0, weight=1)
 
-        # AI: Keep the list live -- setting or clearing a breakpoint elsewhere
-        # (e.g. from the editor) refreshes the pane while it is open.
-        self.event_queue.subscribe('BreakpointSet', self.refresh_breakpoints)
-        self.event_queue.subscribe('BreakpointCleared', self.refresh_breakpoints)
-        # AI: MCP-driven breakpoint changes reach the pane through the model-
-        # refresh bridge's 'breakpoints' kind -> BreakpointsChanged (the MCP
-        # doesn't publish the per-action BreakpointSet/BreakpointCleared events).
+        # AI: Keep the list live -- setting or clearing a breakpoint anywhere refreshes the
+        # pane while it is open. Both the IDE set/clear path and the MCP model-refresh bridge
+        # publish BreakpointsChanged, so subscribing to that one event covers both (the per-
+        # action BreakpointSet/BreakpointCleared events remain, but only as activity-log
+        # records, to avoid refreshing this list twice for a single change).
         self.event_queue.subscribe('BreakpointsChanged', self.refresh_breakpoints)
         # AI: A recompile re-applies a method's breakpoints onto the new CompiledMethod,
         # remapping their offset/step point. MethodsChanged is published by every edit path

--- a/src/reahl/swordfish/text_editing.py
+++ b/src/reahl/swordfish/text_editing.py
@@ -639,6 +639,16 @@ class CodePanel(tk.Frame):
         self.on_text_changed = on_text_changed
         self.is_refreshing = False
         self.chord_pending = False
+        # AI: Persistent dirtiness flag (the Tk 'modified' flag is unreliable - the line-number
+        # gutter resets it after every edit). Set in notify_text_changed, cleared in refresh().
+        self.is_dirty = False
+
+        # AI: Re-mark this view whenever breakpoints change anywhere (IDE set/clear or MCP),
+        # so open editors and the debugger stay in sync. Weakly referenced by the EventQueue,
+        # so no explicit unsubscribe is needed when the widget is destroyed.
+        event_queue = getattr(application, 'event_queue', None)
+        if event_queue is not None:
+            event_queue.subscribe('BreakpointsChanged', self.refresh_breakpoint_markers)
 
         self.text_editor = tk.Text(self, wrap='none', undo=True)
         _tab_font = tkfont.Font(font=self.text_editor.cget('font'))
@@ -801,8 +811,24 @@ class CodePanel(tk.Frame):
             modified = bool(self.text_editor.edit_modified())
         except tk.TclError:
             modified = False
-        if modified and self.on_text_changed is not None:
-            self.on_text_changed()
+        if modified:
+            # AI: Record dirtiness on our own flag here, while the Tk 'modified' flag is still
+            # True. We cannot read edit_modified() later: the line-number gutter also handles
+            # <<Modified>> and resets the flag to False after every edit (so it keeps getting
+            # the event), which would make edit_modified() a useless dirtiness signal.
+            self.is_dirty = True
+            if self.on_text_changed is not None:
+                self.on_text_changed()
+
+    def has_unsaved_edits(self):
+        # AI: One dirtiness signal that serves both the method-editor tab and the debugger source
+        # pane (both are this same CodePanel): our own is_dirty flag, set in notify_text_changed
+        # on any edit and cleared by refresh() (which runs on every source load and after a save).
+        # While it is set the editor text no longer matches the compiled method, so a breakpoint's
+        # source offset would resolve against the wrong step point - which is why breakpoint
+        # commands are disabled in this state. (We deliberately do NOT read the Tk 'modified' flag:
+        # the line-number gutter resets it after every edit - see notify_text_changed.)
+        return self.is_dirty
 
     def replace_selected_text_editor_before_typing(self, event):
         self.editable_text.delete_selection_before_typing(event)
@@ -882,6 +908,12 @@ class CodePanel(tk.Frame):
         if read_only:
             write_command_state = tk.DISABLED
             run_command_state = tk.DISABLED
+        # AI: Breakpoint commands also require a clean buffer. The cursor offset they capture is
+        # meaningless against the compiled method while there are unsaved edits, so disable them
+        # whenever the editor is read-only OR dirty - in both the editor tab and debugger pane.
+        breakpoint_command_state = write_command_state
+        if breakpoint_command_state == tk.NORMAL and self.has_unsaved_edits():
+            breakpoint_command_state = tk.DISABLED
         self.current_context_menu.add_command(
             label='Select All',
             command=self.select_all_text_editor,
@@ -919,12 +951,12 @@ class CodePanel(tk.Frame):
             self.current_context_menu.add_command(
                 label='Set Breakpoint Here',
                 command=self.set_breakpoint_at_cursor,
-                state=write_command_state,
+                state=breakpoint_command_state,
             )
             self.current_context_menu.add_command(
                 label='Clear Breakpoint Here',
                 command=self.clear_breakpoint_at_cursor,
-                state=write_command_state,
+                state=breakpoint_command_state,
             )
             self.current_context_menu.add_separator()
         elif self.is_debugger_source_panel():
@@ -945,10 +977,12 @@ class CodePanel(tk.Frame):
             self.current_context_menu.add_command(
                 label='Set Breakpoint Here',
                 command=self.set_breakpoint_at_cursor,
+                state=breakpoint_command_state,
             )
             self.current_context_menu.add_command(
                 label='Clear Breakpoint Here',
                 command=self.clear_breakpoint_at_cursor,
+                state=breakpoint_command_state,
             )
             self.current_context_menu.add_separator()
         selected_text = self.selected_text()
@@ -1125,8 +1159,10 @@ class CodePanel(tk.Frame):
                     'source_offset': breakpoint_entry['source_offset'],
                 },
             )
-            current_source = self.text_editor.get('1.0', 'end-1c')
-            self.apply_breakpoint_markers(current_source)
+            # AI: Re-mark every open view of this method (this pane included) through the
+            # shared event, not just the pane the command ran in. Each CodePanel subscribes to
+            # BreakpointsChanged; a dirty pane skips re-marking (see refresh_breakpoint_markers).
+            self.application.event_queue.publish('BreakpointsChanged')
         except (DomainException, GemstoneDomainException) as domain_exception:
             messagebox.showerror('Set Breakpoint', str(domain_exception))
         except GemstoneError as error:
@@ -1157,8 +1193,10 @@ class CodePanel(tk.Frame):
                     'source_offset': source_offset,
                 },
             )
-            current_source = self.text_editor.get('1.0', 'end-1c')
-            self.apply_breakpoint_markers(current_source)
+            # AI: Re-mark every open view of this method (this pane included) through the
+            # shared event, not just the pane the command ran in. Each CodePanel subscribes to
+            # BreakpointsChanged; a dirty pane skips re-marking (see refresh_breakpoint_markers).
+            self.application.event_queue.publish('BreakpointsChanged')
         except (DomainException, GemstoneDomainException) as domain_exception:
             messagebox.showerror('Clear Breakpoint', str(domain_exception))
         except GemstoneError as error:
@@ -2332,6 +2370,20 @@ class CodePanel(tk.Frame):
                 )
             index += 1
 
+    def refresh_breakpoint_markers(self, origin=None):
+        # AI: A breakpoint set or cleared anywhere republishes BreakpointsChanged; every open
+        # source view re-reads the session's breakpoints and re-paints its gutter, so the editor
+        # and the debugger never disagree about where breakpoints are.
+        # AI: A pane with unsaved edits is skipped on purpose - its stored offsets no longer
+        # match the edited text, and Tk is already tracking the live marker tags as the user
+        # types, so re-applying from offsets would misplace them.
+        if self.has_unsaved_edits():
+            return
+        if self.method_context() is None:
+            return
+        current_source = self.text_editor.get('1.0', 'end-1c')
+        self.apply_breakpoint_markers(current_source)
+
     def refresh(self, source, mark=None):
         self.is_refreshing = True
         try:
@@ -2354,6 +2406,8 @@ class CodePanel(tk.Frame):
                 self.text_editor.edit_modified(False)
             except tk.TclError:
                 pass
+            # AI: A fresh source load (or a save, which repopulates) is a clean baseline.
+            self.is_dirty = False
         finally:
             self.is_refreshing = False
 

--- a/tests/test_breakpoint_editor_sync.py
+++ b/tests/test_breakpoint_editor_sync.py
@@ -1,0 +1,241 @@
+import tkinter as tk
+import types
+from unittest.mock import patch
+
+from reahl.swordfish.main import EventQueue
+from reahl.swordfish.text_editing import CodePanel
+
+
+def make_fake_app(root=None, **overrides):
+    fake_app = types.SimpleNamespace(
+        tab_spacing=4,
+        integrated_session_state=types.SimpleNamespace(is_mcp_busy=lambda: False),
+        debugger_tab=None,
+        experimental_features_enabled=False,
+        gemstone_session_record=None,
+        event_queue=None,
+    )
+    for name, value in overrides.items():
+        setattr(fake_app, name, value)
+    return fake_app
+
+
+def simulate_user_edit(code_panel, text):
+    # AI: Reproduce a real edit, NOT a synthetic edit_modified(True). A real keystroke fires
+    # <<Modified>>, which BOTH CodePanel.notify_text_changed (records dirtiness) and the line-
+    # number gutter's on_text_modified (resets the Tk 'modified' flag so it keeps getting events)
+    # handle. The gutter's reset is exactly what makes the raw Tk flag useless as a dirtiness
+    # signal, so a faithful test must include it - otherwise it cannot catch that regression.
+    code_panel.text_editor.insert(tk.INSERT, text)
+    code_panel.notify_text_changed()
+    code_panel.line_number_column.on_text_modified()
+
+
+def breakpoint_command_states(code_panel):
+    # AI: Pop the right-click menu (suppressing the real popup) and read back the
+    # tk state of the Set/Clear Breakpoint entries so a test can assert greying.
+    event = types.SimpleNamespace(x=0, y=0, x_root=0, y_root=0)
+    with patch.object(tk.Menu, 'tk_popup'):
+        code_panel.open_text_menu(event)
+    menu = code_panel.current_context_menu
+    end_index = menu.index(tk.END)
+    states = {}
+    index = 0
+    while index <= end_index:
+        if menu.type(index) not in ('separator', 'tearoff'):
+            label = menu.entrycget(index, 'label')
+            if label in ('Set Breakpoint Here', 'Clear Breakpoint Here'):
+                states[label] = str(menu.entrycget(index, 'state'))
+        index += 1
+    return states
+
+
+def attach_debugger_pane(fake_app, code_panel):
+    fake_app.debugger_tab = types.SimpleNamespace(
+        code_panel=code_panel,
+        save_current_frame_method=lambda: None,
+        cancel_current_frame_method=lambda: None,
+    )
+
+
+def test_debugger_breakpoint_commands_disabled_while_method_is_dirty():
+    """AI: A breakpoint's source offset is captured from the editor's live text but resolved
+    against the COMPILED method. While the debugger source pane carries unsaved edits the two
+    coordinate systems have diverged, so a breakpoint set now lands at the wrong step point.
+    Set/Clear Breakpoint must therefore be greyed out until the edits are saved or cancelled."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        fake_app = make_fake_app()
+        code_panel = CodePanel(root, application=fake_app)
+        attach_debugger_pane(fake_app, code_panel)
+        simulate_user_edit(code_panel, 'edited but unsaved')
+
+        states = breakpoint_command_states(code_panel)
+
+        assert states['Set Breakpoint Here'] == 'disabled'
+        assert states['Clear Breakpoint Here'] == 'disabled'
+    finally:
+        root.destroy()
+
+
+def test_debugger_breakpoint_commands_enabled_when_method_is_clean():
+    """AI: With no unsaved edits the pane's text matches the compiled method, so offsets line
+    up and breakpoints are meaningful. The commands must be available in that state."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        fake_app = make_fake_app()
+        code_panel = CodePanel(root, application=fake_app)
+        attach_debugger_pane(fake_app, code_panel)
+        code_panel.text_editor.edit_modified(False)
+
+        states = breakpoint_command_states(code_panel)
+
+        assert states['Set Breakpoint Here'] == 'normal'
+        assert states['Clear Breakpoint Here'] == 'normal'
+    finally:
+        root.destroy()
+
+
+def test_editor_tab_breakpoint_commands_disabled_while_method_is_dirty():
+    """AI: The same offset divergence applies to the regular method editor, not only the
+    debugger pane. A dirty editor tab must grey out Set/Clear Breakpoint for the same reason."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        editor_tab_parent = tk.Frame(root)
+        editor_tab_parent.save = lambda: None
+        editor_tab_parent.method_editor = object()
+        fake_app = make_fake_app()
+        code_panel = CodePanel(editor_tab_parent, application=fake_app)
+        simulate_user_edit(code_panel, 'edited but unsaved')
+
+        states = breakpoint_command_states(code_panel)
+
+        assert states['Set Breakpoint Here'] == 'disabled'
+        assert states['Clear Breakpoint Here'] == 'disabled'
+    finally:
+        root.destroy()
+
+
+def test_editor_tab_breakpoint_commands_enabled_when_method_is_clean():
+    """AI: A clean method editor tab keeps the breakpoint commands available."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        editor_tab_parent = tk.Frame(root)
+        editor_tab_parent.save = lambda: None
+        editor_tab_parent.method_editor = object()
+        fake_app = make_fake_app()
+        code_panel = CodePanel(editor_tab_parent, application=fake_app)
+        code_panel.text_editor.edit_modified(False)
+
+        states = breakpoint_command_states(code_panel)
+
+        assert states['Set Breakpoint Here'] == 'normal'
+        assert states['Clear Breakpoint Here'] == 'normal'
+    finally:
+        root.destroy()
+
+
+def breakpoint_for(class_name, method_selector):
+    return {
+        'class_name': class_name,
+        'show_instance_side': True,
+        'method_selector': method_selector,
+        'source_offset': 5,
+        'step_point': 1,
+        'breakpoint_id': 1,
+    }
+
+
+def test_breakpoints_changed_remarks_a_clean_pane_showing_that_method():
+    """AI: A breakpoint set in one view must appear in every other open view of the same method.
+    On BreakpointsChanged a clean pane re-reads the session's breakpoints and re-paints its
+    gutter, so the editor and debugger never disagree about where breakpoints are."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        tab_key = ('Account', True, 'deposit:')
+        session_record = types.SimpleNamespace(
+            list_breakpoints=lambda: [breakpoint_for('Account', 'deposit:')],
+        )
+        fake_app = make_fake_app(gemstone_session_record=session_record)
+        code_panel = CodePanel(root, application=fake_app, tab_key=tab_key)
+        code_panel.refresh('deposit: anAmount\n\t^anAmount')
+        code_panel.text_editor.tag_remove('breakpoint_marker', '1.0', tk.END)
+
+        code_panel.refresh_breakpoint_markers()
+
+        assert code_panel.text_editor.tag_ranges('breakpoint_marker')
+    finally:
+        root.destroy()
+
+
+def test_breakpoints_changed_skips_a_dirty_pane():
+    """AI: A pane with unsaved edits must NOT be re-painted from stored offsets: the offsets no
+    longer match the edited text, so re-applying would drop markers in the wrong place. Tk keeps
+    tracking the existing marker tags as the user types, so the skip is safe."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        tab_key = ('Account', True, 'deposit:')
+        session_record = types.SimpleNamespace(
+            list_breakpoints=lambda: [breakpoint_for('Account', 'deposit:')],
+        )
+        fake_app = make_fake_app(gemstone_session_record=session_record)
+        code_panel = CodePanel(root, application=fake_app, tab_key=tab_key)
+        code_panel.refresh('deposit: anAmount\n\t^anAmount')
+        code_panel.text_editor.tag_remove('breakpoint_marker', '1.0', tk.END)
+        simulate_user_edit(code_panel, ' edited')
+
+        code_panel.refresh_breakpoint_markers()
+
+        assert not code_panel.text_editor.tag_ranges('breakpoint_marker')
+    finally:
+        root.destroy()
+
+
+def test_setting_a_breakpoint_remarks_another_open_pane_for_the_same_method():
+    """AI: End-to-end of the sync bug: setting a breakpoint in one pane re-marks a second open
+    pane that shows the same method, via the BreakpointsChanged event each pane subscribes to."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        tab_key = ('Account', True, 'deposit:')
+        recorded_breakpoints = []
+
+        def set_breakpoint(class_name, show_instance_side, method_selector, source_offset):
+            entry = {
+                'class_name': class_name,
+                'show_instance_side': show_instance_side,
+                'method_selector': method_selector,
+                'source_offset': source_offset,
+                'step_point': 1,
+                'breakpoint_id': len(recorded_breakpoints) + 1,
+            }
+            recorded_breakpoints.append(entry)
+            return entry
+
+        session_record = types.SimpleNamespace(
+            set_breakpoint=set_breakpoint,
+            list_breakpoints=lambda: list(recorded_breakpoints),
+        )
+        event_queue = EventQueue(root)
+        fake_app = make_fake_app(
+            gemstone_session_record=session_record,
+            event_queue=event_queue,
+        )
+
+        setting_pane = CodePanel(root, application=fake_app, tab_key=tab_key)
+        setting_pane.refresh('deposit: anAmount\n\t^anAmount')
+        viewing_pane = CodePanel(root, application=fake_app, tab_key=tab_key)
+        viewing_pane.refresh('deposit: anAmount\n\t^anAmount')
+        viewing_pane.text_editor.tag_remove('breakpoint_marker', '1.0', tk.END)
+
+        setting_pane.set_breakpoint_at_cursor()
+
+        assert viewing_pane.text_editor.tag_ranges('breakpoint_marker')
+    finally:
+        root.destroy()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4085,35 +4085,6 @@ def test_breakpoints_single_click_peeks_the_method(fixture):
 
 
 @with_fixtures(SwordfishAppFixture)
-def test_breakpoints_pane_refreshes_when_a_breakpoint_is_set(fixture):
-    """AI: An open breakpoints pane listens for breakpoint changes -- placing a
-    breakpoint elsewhere (the BreakpointSet event) re-lists the active
-    breakpoints in place, without reopening the pane."""
-    fixture.simulate_login()
-    fixture.session_record.list_breakpoints = Mock(return_value=[])
-    breakpoints_pane = fixture.app.open_breakpoints_dialog()
-    fixture.app.update()
-    assert len(breakpoints_pane.breakpoint_list.get_children()) == 0
-
-    fixture.session_record.list_breakpoints = Mock(
-        return_value=[
-            {
-                "breakpoint_id": "bp-1",
-                "class_name": "OrderLine",
-                "show_instance_side": True,
-                "method_selector": "total",
-                "source_offset": 42,
-                "step_point": 3,
-            }
-        ]
-    )
-    fixture.app.event_queue.publish('BreakpointSet')
-    fixture.app.update()
-
-    assert len(breakpoints_pane.breakpoint_list.get_children()) == 1
-
-
-@with_fixtures(SwordfishAppFixture)
 def test_breakpoints_pane_refreshes_on_breakpoints_changed(fixture):
     """AI: The breakpoints pane refreshes on the generic BreakpointsChanged event
     -- the one the MCP model-refresh bridge publishes for its 'breakpoints' kind


### PR DESCRIPTION
…oss views

Set/Clear Breakpoint captured the cursor offset from the live editor text but resolved it against the compiled method, so editing without saving made the two coordinate systems diverge and breakpoints landed at the wrong step point. Grey out Set/Clear Breakpoint whenever the editor is read-only or has unsaved edits, in both the method editor and the debugger source pane.

Dirtiness is tracked by a CodePanel.is_dirty flag set in notify_text_changed and cleared in refresh(). We cannot use Tk's edit_modified() flag: the line-number gutter handles <<Modified>> and resets that flag after every edit (so it keeps receiving the event), which makes it useless as a persistent dirtiness signal.

Also route breakpoint set/clear through the generic BreakpointsChanged event so every open view re-marks itself (CodePanel.refresh_breakpoint_markers, which skips dirty panes); BreakpointsPane refreshes on that single event. MCP-set breakpoints now reflect in open editors too.