### PR TITLE
Theme the native directory chooser's file listing in dark mode

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -255,6 +255,16 @@ departing theme (dark) restyles, via `ThemeApplication` — the Tk **option data
 widgets plus a `clam`-based `ttk.Style` for ttk widgets (the two families don't share a styling
 mechanism). New colour sites read a role; new screens get themed for free.
 
+A departing theme also has a third, narrow reach: **`ThemeApplication.install_native_dialog_overrides`**
+for Tk's own dialogs that neither mechanism can reach. The native directory chooser
+(`filedialog.askdirectory`) draws its file listing with a Tk-shipped `::tk::IconList` whose canvas
+hardcodes a white background and black text *at construction time* — colours that beat the option
+database, and a canvas item's colour ignores it entirely. Dark mixes a themed `Create` into that
+class (deferring to the original via `next`, then rebinding only the canvas background and item
+text to the editor roles) so the listing matches every other list instead of a white rectangle in a
+dark dialog. Reach for our own themed widget before a native Tk dialog; when a native dialog is
+unavoidable and shows through unthemed, patch it here rather than re-implementing Tk's dialog.
+
 **Prefer `ttk` widgets over classic `tk` ones** (checkbuttons, radiobuttons, buttons, …) so they
 pick up the `clam`-based dark styling — in particular the selected-indicator colour
 (`TCheckbutton`/`TRadiobutton` `indicatorcolor` map). A classic `tk.Checkbutton`/`tk.Radiobutton`

--- a/src/reahl/swordfish/theme.py
+++ b/src/reahl/swordfish/theme.py
@@ -246,6 +246,7 @@ class ThemeApplication:
         if theme.restyles_widgets:
             self.install_option_defaults(theme)
             self.install_ttk_styles(theme)
+            self.install_native_dialog_overrides(theme)
 
     def install_option_defaults(self, theme):
         # AI: Classic-tk widgets (Frame/Label/Button/Menu/Text/Listbox/Entry) ignore ttk styling
@@ -454,6 +455,41 @@ class ThemeApplication:
             background=select_background,
             troughcolor=window_background,
             bordercolor=border,
+        )
+
+    def install_native_dialog_overrides(self, theme):
+        # AI: The native directory chooser (filedialog.askdirectory) draws its file listing with a
+        # ::tk::IconList - a Tk-shipped megawidget whose canvas is built with a hardcoded white
+        # background and whose entries are drawn in a hardcoded black. A colour passed at
+        # construction time beats the option database, and a canvas item's colour ignores the
+        # option database entirely, so that listing stays a jarring white rectangle in a dark
+        # dialog unless we intervene. We mix a themed Create into the IconList class: it defers to
+        # the original (via next) and then rebinds only the canvas background and the item text
+        # colour to the editor roles, matching every other list without re-implementing any of
+        # Tk's dialog. IconList autoloads lazily the first time a file dialog opens, so force it
+        # in before mixing; the guard on our mixin class keeps a repeated apply idempotent.
+        editor_background = theme.color_for('editor_background')
+        editor_foreground = theme.color_for('editor_foreground')
+        self.tk_root.tk.eval(
+            '''
+            if {![llength [info commands ::tk::IconList]]} {
+                catch {auto_load ::tk::IconList}
+            }
+            if {[llength [info commands ::tk::IconList]]
+                    && ![llength [info commands ::tk::SwordfishThemedIconList]]} {
+                oo::class create ::tk::SwordfishThemedIconList {
+                    method Create {} {
+                        next
+                        variable canvas
+                        variable fill
+                        set fill {%(foreground)s}
+                        $canvas configure -background {%(background)s}
+                    }
+                }
+                oo::define ::tk::IconList mixin ::tk::SwordfishThemedIconList
+            }
+            '''
+            % {'foreground': editor_foreground, 'background': editor_background}
         )
 
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -159,6 +159,32 @@ def test_a_restyling_theme_applies_its_colours_to_a_tk_root():
         root.destroy()
 
 
+def test_a_restyling_theme_darkens_the_native_directory_choosers_file_listing():
+    """AI: The native directory chooser (filedialog.askdirectory) builds its file listing from a
+    ::tk::IconList whose canvas hardcodes a white background and black text at construction time -
+    colours that beat the option database and canvas items ignore it entirely, so that listing can
+    never follow a departing theme on its own. A restyling theme (dark) therefore installs an
+    override so the listing renders in the editor colours like every other list, instead of a
+    jarring white rectangle inside an otherwise dark dialog."""
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        ThemeApplication(root).apply(DARK_THEME)
+        root.tk.eval('::tk::IconList .themed_directory_listing')
+        canvas = '.themed_directory_listing.cHull.canvas'
+        blank_icon = root.tk.eval('image create photo -width 1 -height 1')
+        root.tk.call('.themed_directory_listing', 'add', blank_icon, ['a_directory'])
+
+        canvas_background = root.tk.call(canvas, 'cget', '-background')
+        entry_item = root.tk.call(canvas, 'find', 'withtag', 'text')[0]
+        entry_text_colour = root.tk.call(canvas, 'itemcget', entry_item, '-fill')
+
+        assert canvas_background == DARK_THEME.color_for('editor_background')
+        assert entry_text_colour == DARK_THEME.color_for('editor_foreground')
+    finally:
+        root.destroy()
+
+
 def test_a_native_look_theme_leaves_the_widget_styling_untouched():
     """AI: Light matches the host's native widget look, so applying it must not switch the ttk base
     theme - the IDE's established appearance is preserved with no global restyling, only the


### PR DESCRIPTION
filedialog.askdirectory (chooseDir) draws its file listing with a Tk-shipped ::tk::IconList whose canvas hardcodes a white background and its entries black text, both set at construction time. A construction colour beats the option database and a canvas item colour ignores it entirely, so that listing stayed a white rectangle in an otherwise dark dialog.

ThemeApplication.install_native_dialog_overrides mixes a themed Create into ::tk::IconList: it defers to the original via next, then rebinds only the canvas background and item text colour to the editor roles, so the listing matches every other list without re-implementing Tk's dialog. Applied only for a restyling (dark) theme; autoloads IconList first and guards for idempotence.

DESIGN.md records this as the third, narrow reach of a departing theme (for native dialogs neither the option DB nor ttk styling can touch).